### PR TITLE
Remove "experimental" namespace

### DIFF
--- a/include/flux/source/generator.hpp
+++ b/include/flux/source/generator.hpp
@@ -13,8 +13,6 @@
 
 namespace flux {
 
-namespace experimental {
-
 template <typename ElemT>
 struct generator : inline_sequence_base<generator<ElemT>> {
 
@@ -73,10 +71,8 @@ public:
     }
 };
 
-} // namespace experimental
-
 template <typename T>
-struct sequence_traits<experimental::generator<T>>
+struct sequence_traits<generator<T>>
 {
 private:
     struct cursor_type {
@@ -87,7 +83,7 @@ private:
         friend struct sequence_traits;
     };
 
-    using self_t = experimental::generator<T>;
+    using self_t = generator<T>;
 
 public:
     static auto first(self_t& self) {

--- a/single_include/flux.hpp
+++ b/single_include/flux.hpp
@@ -6632,8 +6632,6 @@ inline constexpr auto zip = detail::zip_fn{};
 
 namespace flux {
 
-namespace experimental {
-
 template <typename ElemT>
 struct generator : inline_sequence_base<generator<ElemT>> {
 
@@ -6692,10 +6690,8 @@ public:
     }
 };
 
-} // namespace experimental
-
 template <typename T>
-struct sequence_traits<experimental::generator<T>>
+struct sequence_traits<generator<T>>
 {
 private:
     struct cursor_type {
@@ -6706,7 +6702,7 @@ private:
         friend struct sequence_traits;
     };
 
-    using self_t = experimental::generator<T>;
+    using self_t = generator<T>;
 
 public:
     static auto first(self_t& self) {

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -11,9 +11,9 @@
 
 #include "test_utils.hpp"
 
-using flux::experimental::generator;
-
 namespace {
+
+using flux::generator;
 
 auto ints(int from = 0) -> generator<int>
 {


### PR DESCRIPTION
Generators are no more experimental than anything else in Flux.