### PR TITLE
Add unchecked adaptor

### DIFF
--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -40,6 +40,7 @@
 #include <flux/op/take.hpp>
 #include <flux/op/take_while.hpp>
 #include <flux/op/to.hpp>
+#include <flux/op/unchecked.hpp>
 #include <flux/op/write_to.hpp>
 #include <flux/op/zip.hpp>
 

--- a/include/flux/core/optional.hpp
+++ b/include/flux/core/optional.hpp
@@ -9,6 +9,7 @@
 #include <flux/core/assert.hpp>
 #include <flux/core/utils.hpp>
 
+#include <functional>
 #include <optional>
 
 namespace flux {

--- a/include/flux/core/sequence_access.hpp
+++ b/include/flux/core/sequence_access.hpp
@@ -185,14 +185,14 @@ template <typename Seq>
 concept has_custom_move_at_unchecked =
     sequence<Seq> &&
     requires (Seq& seq, cursor_t<Seq> const& cur) {
-        { traits_t<Seq>::read_at_unchecked(seq, cur) } -> std::same_as<rvalue_element_t<Seq>>;
+        { traits_t<Seq>::move_at_unchecked(seq, cur) } -> std::same_as<rvalue_element_t<Seq>>;
 };
 
 struct move_at_unchecked_fn {
     template <sequence Seq>
     [[nodiscard]]
     constexpr auto operator()(Seq& seq, cursor_t<Seq> const& cur) const
-        -> rvalue_element_type<Seq>
+        -> rvalue_element_t<Seq>
     {
         if constexpr (has_custom_move_at_unchecked<Seq>) {
             return traits_t<Seq>::move_at_unchecked(seq, cur);

--- a/include/flux/op/sort.hpp
+++ b/include/flux/op/sort.hpp
@@ -4,6 +4,7 @@
 
 #include <flux/core.hpp>
 #include <flux/op/detail/pdqsort.hpp>
+#include <flux/op/unchecked.hpp>
 
 namespace flux {
 
@@ -17,7 +18,8 @@ struct sort_fn {
                  std::predicate<Cmp&, projected_t<Proj, Seq>, projected_t<Proj, Seq>>
     constexpr auto operator()(Seq&& seq, Cmp cmp = {}, Proj proj = {}) const
     {
-        detail::pdqsort(seq, cmp, proj);
+        auto wrapper = flux::unchecked(flux::ref(seq));
+        detail::pdqsort(wrapper, cmp, proj);
     }
 };
 

--- a/include/flux/op/unchecked.hpp
+++ b/include/flux/op/unchecked.hpp
@@ -18,7 +18,7 @@ private:
     Base base_;
 
 public:
-    constexpr unchecked_adaptor(decays_to<Base> auto&& base)
+    constexpr explicit unchecked_adaptor(decays_to<Base> auto&& base)
         : base_(FLUX_FWD(base))
     {}
 
@@ -45,12 +45,19 @@ public:
     };
 };
 
+struct unchecked_fn {
+    template <adaptable_sequence Seq>
+    [[nodiscard]]
+    constexpr auto operator()(Seq&& seq) const
+        -> unchecked_adaptor<std::decay_t<Seq>>
+    {
+        return unchecked_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
+    }
+};
+
 } // namespace detail
 
-inline constexpr auto unchecked =
-[]<adaptable_sequence Seq> [[nodiscard]] (Seq&& seq) -> sequence auto {
-    return detail::unchecked_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
-};
+inline constexpr auto unchecked = detail::unchecked_fn{};
 
 } // namespace flux
 

--- a/include/flux/op/unchecked.hpp
+++ b/include/flux/op/unchecked.hpp
@@ -1,0 +1,57 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_UNCHECKED_HPP_INCLUDED
+#define FLUX_OP_UNCHECKED_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+namespace flux {
+
+namespace detail {
+
+template <sequence Base>
+struct unchecked_adaptor : inline_sequence_base<unchecked_adaptor<Base>> {
+private:
+    Base base_;
+
+public:
+    constexpr unchecked_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
+    {}
+
+    constexpr auto base() & -> Base& { return base_; }
+    constexpr auto base() const& -> Base const& { return base_; }
+
+    struct flux_sequence_traits : passthrough_traits_base<Base> {
+
+        using value_type = value_t<Base>;
+        static constexpr bool disable_multipass = !multipass_sequence<Base>;
+        static constexpr bool is_infinite = infinite_sequence<Base>;
+
+        static constexpr auto read_at(auto& self, auto const& cur)
+            -> element_t<Base>
+        {
+            return flux::read_at_unchecked(self.base(), cur);
+        }
+
+        static constexpr auto move_at(auto& self, auto const& cur)
+            -> rvalue_element_t<Base>
+        {
+            return flux::move_at_unchecked(self.base(), cur);
+        }
+    };
+};
+
+} // namespace detail
+
+inline constexpr auto unchecked =
+[]<adaptable_sequence Seq> [[nodiscard]] (Seq&& seq) -> sequence auto {
+    return detail::unchecked_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
+};
+
+} // namespace flux
+
+#endif // FLUX_OP_UNCHECKED_HPP_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(test-libflux
     test_take.cpp
     test_take_while.cpp
     test_to.cpp
+    test_unchecked.cpp
     test_write_to.cpp
     test_zip.cpp
 

--- a/test/test_unchecked.cpp
+++ b/test/test_unchecked.cpp
@@ -1,0 +1,67 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+
+namespace {
+
+constexpr bool test_unchecked()
+{
+    using namespace flux;
+
+    {
+        auto seq = unchecked(std::array{5, 4, 3, 2, 1});
+
+        using S = decltype(seq);
+
+        static_assert(contiguous_sequence<S>);
+        static_assert(sized_sequence<S>);
+        static_assert(bounded_sequence<S>);
+
+        seq.sort();
+
+        STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5}));
+    }
+
+    {
+        auto ints = std::array{5, 4, 3, 2, 1};
+        auto doubles = std::array{3.0, 2.0, 1.0};
+
+        auto seq = unchecked(zip(ref(ints), ref(doubles)));
+
+        using S = decltype(seq);
+
+        static_assert(random_access_sequence<S>);
+        static_assert(bounded_sequence<S>);
+        static_assert(sized_sequence<S>);
+        static_assert(std::same_as<value_t<S>, std::pair<int, double>>);
+        static_assert(std::same_as<element_t<S>, std::pair<int&, double&>>);
+        static_assert(std::same_as<rvalue_element_t<S>, std::pair<int&&, double&&>>);
+
+        seq.sort({}, [](auto p) { return p.second; });
+
+        STATIC_CHECK(check_equal(doubles, {1.0, 2.0, 3.0}));
+        STATIC_CHECK(check_equal(ints, {3, 4, 5, 2, 1}));
+
+    }
+
+    return true;
+}
+static_assert(test_unchecked());
+
+
+}
+
+TEST_CASE("unchecked adaptor")
+{
+    auto res = test_unchecked();
+    REQUIRE(res);
+}


### PR DESCRIPTION
This is a simple adaptor which acts like a passthrough except that it replaces each call to `read_at()` with a call to `read_at_unchecked()`, and similarly for `move_at()`.

Obviously this makes it unsafe to use in general, but in cases where we are sure we won't accidentally read out of bounds it can sometimes give improved performance.