### PR TITLE
Rename count(val) overload to count_eq()

### DIFF
--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -271,7 +271,7 @@ public:
     /// Returns the number of elements in the sequence which are equal to `value`
     template <typename Value, typename Proj = std::identity>
         requires std::equality_comparable_with<projected_t<Proj, Derived>, Value const&>
-    constexpr auto count(Value const& value, Proj proj = {});
+    constexpr auto count_eq(Value const& value, Proj proj = {});
 
     template <typename Pred, typename Proj = std::identity>
         requires predicate_for<Pred, Derived, Proj>

--- a/include/flux/op/count.hpp
+++ b/include/flux/op/count.hpp
@@ -28,7 +28,9 @@ struct count_fn {
             return counter;
         }
     }
+};
 
+struct count_eq_fn {
     template <sequence Seq, typename Value, typename Proj = std::identity>
         requires std::equality_comparable_with<projected_t<Proj, Seq>, Value const&>
     [[nodiscard]]
@@ -67,6 +69,7 @@ struct count_if_fn {
 } // namespace detail
 
 inline constexpr auto count = detail::count_fn{};
+inline constexpr auto count_eq = detail::count_eq_fn{};
 inline constexpr auto count_if = detail::count_if_fn{};
 
 template <typename D>
@@ -78,9 +81,9 @@ constexpr auto inline_sequence_base<D>::count()
 template <typename D>
 template <typename Value, typename Proj>
     requires std::equality_comparable_with<projected_t<Proj, D>, Value const&>
-constexpr auto inline_sequence_base<D>::count(Value const& value, Proj proj)
+constexpr auto inline_sequence_base<D>::count_eq(Value const& value, Proj proj)
 {
-    return flux::count(derived(), value, std::move(proj));
+    return flux::count_eq(derived(), value, std::move(proj));
 }
 
 template <typename D>

--- a/single_include/flux.hpp
+++ b/single_include/flux.hpp
@@ -2191,7 +2191,7 @@ public:
     /// Returns the number of elements in the sequence which are equal to `value`
     template <typename Value, typename Proj = std::identity>
         requires std::equality_comparable_with<projected_t<Proj, Derived>, Value const&>
-    constexpr auto count(Value const& value, Proj proj = {});
+    constexpr auto count_eq(Value const& value, Proj proj = {});
 
     template <typename Pred, typename Proj = std::identity>
         requires predicate_for<Pred, Derived, Proj>
@@ -4051,7 +4051,9 @@ struct count_fn {
             return counter;
         }
     }
+};
 
+struct count_eq_fn {
     template <sequence Seq, typename Value, typename Proj = std::identity>
         requires std::equality_comparable_with<projected_t<Proj, Seq>, Value const&>
     [[nodiscard]]
@@ -4090,6 +4092,7 @@ struct count_if_fn {
 } // namespace detail
 
 inline constexpr auto count = detail::count_fn{};
+inline constexpr auto count_eq = detail::count_eq_fn{};
 inline constexpr auto count_if = detail::count_if_fn{};
 
 template <typename D>
@@ -4101,9 +4104,9 @@ constexpr auto inline_sequence_base<D>::count()
 template <typename D>
 template <typename Value, typename Proj>
     requires std::equality_comparable_with<projected_t<Proj, D>, Value const&>
-constexpr auto inline_sequence_base<D>::count(Value const& value, Proj proj)
+constexpr auto inline_sequence_base<D>::count_eq(Value const& value, Proj proj)
 {
-    return flux::count(derived(), value, std::move(proj));
+    return flux::count_eq(derived(), value, std::move(proj));
 }
 
 template <typename D>

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -46,22 +46,22 @@ constexpr bool test_count()
 
     {
         int arr[] = {1, 2, 2, 2, 3, 4, 5};
-        STATIC_CHECK(flux::count(arr, 2) == 3);
-        STATIC_CHECK(flux::count(arr, 99) == 0);
+        STATIC_CHECK(flux::count_eq(arr, 2) == 3);
+        STATIC_CHECK(flux::count_eq(arr, 99) == 0);
 
         auto seq = flux::from(arr);
-        STATIC_CHECK(seq.count(2) == 3);
-        STATIC_CHECK(seq.count(99) == 0);
+        STATIC_CHECK(seq.count_eq(2) == 3);
+        STATIC_CHECK(seq.count_eq(99) == 0);
     }
 
     {
         S arr[] = {1, 2, 2, 2, 3, 4, 5};
 
-        STATIC_CHECK(flux::count(arr, 2, &S::i) == 3);
-        STATIC_CHECK(flux::from(arr).count(2, &S::get) == 3);
+        STATIC_CHECK(flux::count_eq(arr, 2, &S::i) == 3);
+        STATIC_CHECK(flux::from(arr).count_eq(2, &S::get) == 3);
 
-        STATIC_CHECK(flux::count(arr, 99, &S::i) == 0);
-        STATIC_CHECK(flux::from(arr).count(99, &S::get) == 0);
+        STATIC_CHECK(flux::count_eq(arr, 99, &S::i) == 0);
+        STATIC_CHECK(flux::from(arr).count_eq(99, &S::get) == 0);
     }
 
     return true;


### PR DESCRIPTION
Now

   `count(seq)` is equivalent to `count_if(seq, pred::true_)`

   `count_eq(seq, val)` is equivalent to `count_if(seq, pred::eq(val))`