### PR TITLE
Add flatten adaptor

### DIFF
--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -23,6 +23,7 @@
 #include <flux/op/fill.hpp>
 #include <flux/op/filter.hpp>
 #include <flux/op/find.hpp>
+#include <flux/op/flatten.hpp>
 #include <flux/op/fold.hpp>
 #include <flux/op/for_each.hpp>
 #include <flux/op/for_each_while.hpp>

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -208,12 +208,16 @@ public:
 
     template <typename Pred>
         requires std::predicate<Pred&, element_t<Derived>>
+    [[nodiscard]]
     constexpr auto drop_while(Pred pred) &&;
 
     template <typename Pred>
         requires std::predicate<Pred&, element_t<Derived>&>
     [[nodiscard]]
     constexpr auto filter(Pred pred) &&;
+
+    [[nodiscard]]
+    constexpr auto flatten() && requires sequence<element_t<Derived>>;
 
     template <typename Func>
         requires std::invocable<Func&, element_t<Derived>>

--- a/include/flux/op/flatten.hpp
+++ b/include/flux/op/flatten.hpp
@@ -55,6 +55,8 @@ public:
         }
 
     public:
+        using value_type = value_t<InnerSeq>;
+
         static constexpr auto first(self_t& self) -> cursor_type
         {
             cursor_type cur(flux::first(self.base_));
@@ -138,6 +140,8 @@ public:
         }
 
     public:
+        using value_type = value_t<InnerSeq>;
+
         template <typename Self>
             requires can_flatten<Self>
         static constexpr auto first(Self& self) -> cursor_type

--- a/include/flux/op/flatten.hpp
+++ b/include/flux/op/flatten.hpp
@@ -1,0 +1,251 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_FLATTEN_HPP_INCLUDED
+#define FLUX_OP_FLATTEN_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+namespace flux {
+
+namespace detail {
+
+template <sequence Base>
+struct flatten_adaptor : inline_sequence_base<flatten_adaptor<Base>> {
+private:
+    using InnerSeq = element_t<Base>;
+
+    Base base_;
+    optional<InnerSeq> inner_ = nullopt;
+
+public:
+    constexpr explicit flatten_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        using self_t = flatten_adaptor;
+
+        struct cursor_type {
+            constexpr explicit cursor_type(cursor_t<Base>&& outer_cur)
+                : outer_cur(std::move(outer_cur))
+            {}
+
+            cursor_type() = default;
+            cursor_type(cursor_type&&) = default;
+            cursor_type& operator=(cursor_type&&) = default;
+
+            cursor_t<Base> outer_cur;
+            optional<cursor_t<InnerSeq>> inner_cur = nullopt;
+        };
+
+        static constexpr auto satisfy(auto& self, cursor_type& cur) -> void
+        {
+            while (!flux::is_last(self.base_, cur.outer_cur)) {
+                self.inner_ = optional<InnerSeq>(flux::read_at(self.base_, cur.outer_cur));
+                cur.inner_cur = optional(flux::first(*self.inner_));
+                if (!flux::is_last(*self.inner_, *cur.inner_cur)) {
+                    return;
+                }
+                flux::inc(self.base_, cur.outer_cur);
+            }
+        }
+
+    public:
+        static constexpr auto first(self_t& self) -> cursor_type
+        {
+            cursor_type cur(flux::first(self.base_));
+            satisfy(self, cur);
+            return cur;
+        }
+
+        static constexpr auto is_last(self_t& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.outer_cur);
+        }
+
+        static constexpr auto inc(self_t& self, cursor_type& cur) -> void
+        {
+            flux::inc(*self.inner_, *cur.inner_cur);
+            if (flux::is_last(*self.inner_, *cur.inner_cur)) {
+                flux::inc(self.base_, cur.outer_cur);
+                satisfy(self, cur);
+            }
+        }
+
+        static constexpr auto read_at(self_t& self, cursor_type const& cur) -> decltype(auto)
+        {
+            FLUX_ASSERT(self.inner_.has_value());
+            FLUX_ASSERT(cur.inner_cur.has_value());
+            return flux::read_at(*self.inner_, *cur.inner_cur);
+        }
+
+        static constexpr auto last(self_t& self) -> cursor_type
+            requires bounded_sequence<Base>
+        {
+            return cursor_type(flux::last(self.base_));
+        }
+    };
+};
+
+template <multipass_sequence Base>
+    requires std::is_reference_v<element_t<Base>> &&
+             multipass_sequence<element_t<Base>>
+struct flatten_adaptor<Base> : inline_sequence_base<flatten_adaptor<Base>> {
+private:
+    Base base_;
+
+public:
+    constexpr explicit flatten_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        using InnerSeq = element_t<Base>;
+
+        template <typename Self>
+        static constexpr bool can_flatten = [] () consteval {
+            if constexpr (std::is_const_v<Self>) {
+                return multipass_sequence<Base const> &&
+                       std::same_as<element_t<Base const>, std::remove_reference_t<InnerSeq> const&> &&
+                       multipass_sequence<InnerSeq const>;
+            } else {
+                return true;
+            }
+        }();
+
+        struct cursor_type {
+            cursor_t<Base> outer_cur{};
+            cursor_t<InnerSeq> inner_cur{};
+
+            friend auto operator==(cursor_type const&, cursor_type const&) -> bool = default;
+            friend auto operator<=>(cursor_type const&, cursor_type const&)
+                requires ordered_cursor<cursor_t<Base>> && ordered_cursor<cursor_t<InnerSeq>>
+                = default;
+        };
+
+        static constexpr auto satisfy(auto& self, cursor_type& cur) -> void
+        {
+            while (!flux::is_last(self.base_, cur.outer_cur)) {
+                auto&& inner = flux::read_at(self.base_, cur.outer_cur);
+                cur.inner_cur = flux::first(inner);
+                if (!flux::is_last(inner, cur.inner_cur)) {
+                    return;
+                }
+                flux::inc(self.base_, cur.outer_cur);
+            }
+        }
+
+    public:
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto first(Self& self) -> cursor_type
+        {
+            cursor_type cur{.outer_cur = flux::first(self.base_) };
+            satisfy(self, cur);
+            return cur;
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto is_last(Self& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.outer_cur);
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto read_at(Self& self, cursor_type const& cur) -> decltype(auto)
+        {
+            return flux::read_at(flux::read_at(self.base_, cur.outer_cur),
+                                 cur.inner_cur);
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto inc(Self& self, cursor_type& cur) -> void
+        {
+            auto&& inner = flux::read_at(self.base_, cur.outer_cur);
+            flux::inc(inner, cur.inner_cur);
+            if (flux::is_last(inner, cur.inner_cur)) {
+                flux::inc(self.base_, cur.outer_cur);
+                satisfy(self, cur);
+            }
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto for_each_while(Self& self, auto&& pred) -> cursor_type
+        {
+            auto inner_cur = cursor_t<InnerSeq>{};
+            auto outer_cur = flux::for_each_while(self.base_, [&](auto&& inner_seq) {
+                inner_cur = flux::for_each_while(inner_seq, pred);
+                return flux::is_last(inner_seq, inner_cur);
+            });
+            return cursor_type{.outer_cur = std::move(outer_cur),
+                               .inner_cur = std::move(inner_cur)};
+        }
+
+        template <typename Self>
+            requires can_flatten<Self> && bounded_sequence<Base>
+        static constexpr auto last(Self& self) -> cursor_type
+        {
+            return cursor_type{.outer_cur = flux::last(self.base_)};
+        }
+
+        template <typename Self>
+            requires can_flatten<Self> &&
+                     bidirectional_sequence<Base> &&
+                     bidirectional_sequence<InnerSeq> &&
+                     bounded_sequence<InnerSeq>
+        static constexpr auto dec(Self& self, cursor_type& cur) -> void
+        {
+            if (flux::is_last(self.base_, cur.outer_cur)) {
+                flux::dec(self.base_, cur.outer_cur);
+                auto&& inner = flux::read_at(self.base_, cur.outer_cur);
+                cur.inner_cur = flux::last(inner);
+            }
+            while (true) {
+                auto&& inner = flux::read_at(self.base_, cur.outer_cur);
+                if (cur.inner_cur != flux::first(inner)) {
+                    flux::dec(inner, cur.inner_cur);
+                    return;
+                } else {
+                    flux::dec(self.base_, cur.outer_cur);
+                    auto&& inner = flux::read_at(self.base_, cur.outer_cur);
+                    cur.inner_cur = flux::last(inner);
+                }
+            }
+        }
+    };
+
+};
+
+struct flatten_fn {
+    template <adaptable_sequence Seq>
+        requires sequence<element_t<Seq>>
+    [[nodiscard]]
+    constexpr auto operator()(Seq&& seq) const -> sequence auto
+    {
+        return flatten_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
+    }
+};
+
+} // namespace detail
+
+inline constexpr auto flatten = detail::flatten_fn{};
+
+template <typename Derived>
+constexpr auto inline_sequence_base<Derived>::flatten() &&
+        requires sequence<element_t<Derived>>
+{
+    return flux::flatten(std::move(derived()));
+}
+
+} // namespace flux
+
+#endif // FLUX_OP_FLATTEN_HPP_INCLUDED

--- a/include/flux/op/flatten.hpp
+++ b/include/flux/op/flatten.hpp
@@ -123,9 +123,6 @@ public:
             cursor_t<InnerSeq> inner_cur{};
 
             friend auto operator==(cursor_type const&, cursor_type const&) -> bool = default;
-            friend auto operator<=>(cursor_type const&, cursor_type const&)
-                requires ordered_cursor<cursor_t<Base>> && ordered_cursor<cursor_t<InnerSeq>>
-                = default;
         };
 
         static constexpr auto satisfy(auto& self, cursor_type& cur) -> void
@@ -216,8 +213,8 @@ public:
                     return;
                 } else {
                     flux::dec(self.base_, cur.outer_cur);
-                    auto&& inner = flux::read_at(self.base_, cur.outer_cur);
-                    cur.inner_cur = flux::last(inner);
+                    auto&& next_inner = flux::read_at(self.base_, cur.outer_cur);
+                    cur.inner_cur = flux::last(next_inner);
                 }
             }
         }

--- a/include/flux/op/reverse.hpp
+++ b/include/flux/op/reverse.hpp
@@ -143,13 +143,13 @@ struct sequence_traits<detail::reverse_adaptor<Base>>
         const auto end = flux::first(self.base_);
 
         while (cur != end) {
-            if (!std::invoke(pred, flux::read_at(self.base_, flux::prev(self.base_, cur)))) {
+            flux::dec(self.base_, cur);
+            if (!std::invoke(pred, flux::read_at(self.base_, cur))) {
                 break;
             }
-            flux::dec(self.base_, cur);
         }
 
-        return detail::rev_cur(cur);
+        return detail::rev_cur(flux::inc(self.base_, cur));
     }
 };
 

--- a/single_include/flux.hpp
+++ b/single_include/flux.hpp
@@ -2128,12 +2128,16 @@ public:
 
     template <typename Pred>
         requires std::predicate<Pred&, element_t<Derived>>
+    [[nodiscard]]
     constexpr auto drop_while(Pred pred) &&;
 
     template <typename Pred>
         requires std::predicate<Pred&, element_t<Derived>&>
     [[nodiscard]]
     constexpr auto filter(Pred pred) &&;
+
+    [[nodiscard]]
+    constexpr auto flatten() && requires sequence<element_t<Derived>>;
 
     template <typename Func>
         requires std::invocable<Func&, element_t<Derived>>
@@ -4660,6 +4664,259 @@ constexpr auto inline_sequence_base<D>::find_if_not(Pred pred, Proj proj)
 
 #endif // FLUX_OP_FIND_HPP_INCLUDED
 
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_FLATTEN_HPP_INCLUDED
+#define FLUX_OP_FLATTEN_HPP_INCLUDED
+
+
+
+namespace flux {
+
+namespace detail {
+
+template <sequence Base>
+struct flatten_adaptor : inline_sequence_base<flatten_adaptor<Base>> {
+private:
+    using InnerSeq = element_t<Base>;
+
+    Base base_;
+    optional<InnerSeq> inner_ = nullopt;
+
+public:
+    constexpr explicit flatten_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        using self_t = flatten_adaptor;
+
+        struct cursor_type {
+            constexpr explicit cursor_type(cursor_t<Base>&& outer_cur)
+                : outer_cur(std::move(outer_cur))
+            {}
+
+            cursor_type() = default;
+            cursor_type(cursor_type&&) = default;
+            cursor_type& operator=(cursor_type&&) = default;
+
+            cursor_t<Base> outer_cur;
+            optional<cursor_t<InnerSeq>> inner_cur = nullopt;
+        };
+
+        static constexpr auto satisfy(auto& self, cursor_type& cur) -> void
+        {
+            while (!flux::is_last(self.base_, cur.outer_cur)) {
+                self.inner_ = optional<InnerSeq>(flux::read_at(self.base_, cur.outer_cur));
+                cur.inner_cur = optional(flux::first(*self.inner_));
+                if (!flux::is_last(*self.inner_, *cur.inner_cur)) {
+                    return;
+                }
+                flux::inc(self.base_, cur.outer_cur);
+            }
+        }
+
+    public:
+        using value_type = value_t<InnerSeq>;
+
+        static constexpr auto first(self_t& self) -> cursor_type
+        {
+            cursor_type cur(flux::first(self.base_));
+            satisfy(self, cur);
+            return cur;
+        }
+
+        static constexpr auto is_last(self_t& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.outer_cur);
+        }
+
+        static constexpr auto inc(self_t& self, cursor_type& cur) -> void
+        {
+            flux::inc(*self.inner_, *cur.inner_cur);
+            if (flux::is_last(*self.inner_, *cur.inner_cur)) {
+                flux::inc(self.base_, cur.outer_cur);
+                satisfy(self, cur);
+            }
+        }
+
+        static constexpr auto read_at(self_t& self, cursor_type const& cur) -> decltype(auto)
+        {
+            FLUX_ASSERT(self.inner_.has_value());
+            FLUX_ASSERT(cur.inner_cur.has_value());
+            return flux::read_at(*self.inner_, *cur.inner_cur);
+        }
+
+        static constexpr auto last(self_t& self) -> cursor_type
+            requires bounded_sequence<Base>
+        {
+            return cursor_type(flux::last(self.base_));
+        }
+    };
+};
+
+template <multipass_sequence Base>
+    requires std::is_reference_v<element_t<Base>> &&
+             multipass_sequence<element_t<Base>>
+struct flatten_adaptor<Base> : inline_sequence_base<flatten_adaptor<Base>> {
+private:
+    Base base_;
+
+public:
+    constexpr explicit flatten_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        using InnerSeq = element_t<Base>;
+
+        template <typename Self>
+        static constexpr bool can_flatten = [] () consteval {
+            if constexpr (std::is_const_v<Self>) {
+                return multipass_sequence<Base const> &&
+                       std::same_as<element_t<Base const>, std::remove_reference_t<InnerSeq> const&> &&
+                       multipass_sequence<InnerSeq const>;
+            } else {
+                return true;
+            }
+        }();
+
+        struct cursor_type {
+            cursor_t<Base> outer_cur{};
+            cursor_t<InnerSeq> inner_cur{};
+
+            friend auto operator==(cursor_type const&, cursor_type const&) -> bool = default;
+        };
+
+        static constexpr auto satisfy(auto& self, cursor_type& cur) -> void
+        {
+            while (!flux::is_last(self.base_, cur.outer_cur)) {
+                auto&& inner = flux::read_at(self.base_, cur.outer_cur);
+                cur.inner_cur = flux::first(inner);
+                if (!flux::is_last(inner, cur.inner_cur)) {
+                    return;
+                }
+                flux::inc(self.base_, cur.outer_cur);
+            }
+        }
+
+    public:
+        using value_type = value_t<InnerSeq>;
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto first(Self& self) -> cursor_type
+        {
+            cursor_type cur{.outer_cur = flux::first(self.base_) };
+            satisfy(self, cur);
+            return cur;
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto is_last(Self& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.outer_cur);
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto read_at(Self& self, cursor_type const& cur) -> decltype(auto)
+        {
+            return flux::read_at(flux::read_at(self.base_, cur.outer_cur),
+                                 cur.inner_cur);
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto inc(Self& self, cursor_type& cur) -> void
+        {
+            auto&& inner = flux::read_at(self.base_, cur.outer_cur);
+            flux::inc(inner, cur.inner_cur);
+            if (flux::is_last(inner, cur.inner_cur)) {
+                flux::inc(self.base_, cur.outer_cur);
+                satisfy(self, cur);
+            }
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto for_each_while(Self& self, auto&& pred) -> cursor_type
+        {
+            auto inner_cur = cursor_t<InnerSeq>{};
+            auto outer_cur = flux::for_each_while(self.base_, [&](auto&& inner_seq) {
+                inner_cur = flux::for_each_while(inner_seq, pred);
+                return flux::is_last(inner_seq, inner_cur);
+            });
+            return cursor_type{.outer_cur = std::move(outer_cur),
+                               .inner_cur = std::move(inner_cur)};
+        }
+
+        template <typename Self>
+            requires can_flatten<Self> && bounded_sequence<Base>
+        static constexpr auto last(Self& self) -> cursor_type
+        {
+            return cursor_type{.outer_cur = flux::last(self.base_)};
+        }
+
+        template <typename Self>
+            requires can_flatten<Self> &&
+                     bidirectional_sequence<Base> &&
+                     bidirectional_sequence<InnerSeq> &&
+                     bounded_sequence<InnerSeq>
+        static constexpr auto dec(Self& self, cursor_type& cur) -> void
+        {
+            if (flux::is_last(self.base_, cur.outer_cur)) {
+                flux::dec(self.base_, cur.outer_cur);
+                auto&& inner = flux::read_at(self.base_, cur.outer_cur);
+                cur.inner_cur = flux::last(inner);
+            }
+            while (true) {
+                auto&& inner = flux::read_at(self.base_, cur.outer_cur);
+                if (cur.inner_cur != flux::first(inner)) {
+                    flux::dec(inner, cur.inner_cur);
+                    return;
+                } else {
+                    flux::dec(self.base_, cur.outer_cur);
+                    auto&& next_inner = flux::read_at(self.base_, cur.outer_cur);
+                    cur.inner_cur = flux::last(next_inner);
+                }
+            }
+        }
+    };
+
+};
+
+struct flatten_fn {
+    template <adaptable_sequence Seq>
+        requires sequence<element_t<Seq>>
+    [[nodiscard]]
+    constexpr auto operator()(Seq&& seq) const -> sequence auto
+    {
+        return flatten_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
+    }
+};
+
+} // namespace detail
+
+inline constexpr auto flatten = detail::flatten_fn{};
+
+template <typename Derived>
+constexpr auto inline_sequence_base<Derived>::flatten() &&
+        requires sequence<element_t<Derived>>
+{
+    return flux::flatten(std::move(derived()));
+}
+
+} // namespace flux
+
+#endif // FLUX_OP_FLATTEN_HPP_INCLUDED
+
+
 // Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -5352,13 +5609,13 @@ struct sequence_traits<detail::reverse_adaptor<Base>>
         const auto end = flux::first(self.base_);
 
         while (cur != end) {
-            if (!std::invoke(pred, flux::read_at(self.base_, flux::prev(self.base_, cur)))) {
+            flux::dec(self.base_, cur);
+            if (!std::invoke(pred, flux::read_at(self.base_, cur))) {
                 break;
             }
-            flux::dec(self.base_, cur);
         }
 
-        return detail::rev_cur(cur);
+        return detail::rev_cur(flux::inc(self.base_, cur));
     }
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(test-libflux
     test_fill.cpp
     test_filter.cpp
     test_find.cpp
+    test_flatten.cpp
     test_for_each.cpp
     test_fold.cpp
     test_front_back.cpp

--- a/test/test_flatten.cpp
+++ b/test/test_flatten.cpp
@@ -1,0 +1,231 @@
+
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+
+#if defined(_GLIBCXX_RELEASE)
+#  if _GLIBCXX_RELEASE < 12
+#    define NO_CONSTEXPR_VECTOR
+#  endif
+#endif
+
+/*
+ * We have two completely separate implementations of flatten.
+ * The first is single-pass only while the second can go all the way to
+ * bidirectional.
+ *
+ * The multipass version is used when all of the following are true:
+ *  * the outer sequence is multipass
+ *  * the element type of the outer sequence is a reference type
+ *  * the inner sequence is multipass
+ *
+ * Otherwise, the single-pass version is used.
+ */
+
+namespace {
+
+constexpr bool test_flatten_single_pass()
+{
+    // Single-pass source sequence, inner sequence is multipass
+    {
+        std::array<std::array<int, 3>, 3> arr{
+            std::array{1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9}
+        };
+        auto seq = flux::flatten(single_pass_only(std::move(arr)));
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    }
+
+    // Multipass sequence, returns prvalue
+    {
+        std::array<std::array<int, 3>, 3> arr{
+            std::array{1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9}
+        };
+
+        auto seq = flux::map(arr, [](auto s) { return s; }).flatten();
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    }
+
+    // Multipass but returns single-pass
+    {
+        auto arr = std::array{
+            single_pass_only(flux::single(1)),
+            single_pass_only(flux::single(2)),
+            single_pass_only(flux::single(3))
+        };
+
+        auto seq = flux::flatten(std::move(arr));
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(check_equal(seq, {1, 2, 3}));
+    }
+
+    // Short-circuiting internal iteration
+    {
+        std::array<std::array<int, 3>, 3> const arr{
+            std::array{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        auto seq = flux::flatten(single_pass_only(std::ref(arr)));
+        auto five = seq.find(5);
+
+        STATIC_CHECK(&seq[five] == &arr[1][1]);
+    }
+
+    // Empty outer sequence is handled correctly
+    {
+        auto arr = std::array<std::array<int, 3>, 0>{};
+
+        auto seq = flux::flatten(single_pass_only(std::move(arr)));
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(seq.count() == 0);
+    }
+
+#ifndef NO_CONSTEXPR_VECTOR
+    // Empty inner sequence is skipped correctly
+    {
+        std::vector<std::vector<int>> vec_of_vecs{
+            {1, 2, 3}, {}, {4, 5, 6}, {}, {7}, {}, {8, 9}
+        };
+
+        auto seq = single_pass_only(std::move(vec_of_vecs)).flatten();
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    }
+#endif // NO_CONSTEXPR_VECTOR
+
+    return true;
+}
+static_assert(test_flatten_single_pass());
+
+constexpr bool test_flatten_multipass()
+{
+    {
+        std::array<std::array<int, 3>, 3> const arr{
+            std::array{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        auto const seq = flux::flatten(arr);
+
+        static_assert(flux::bidirectional_sequence<decltype(seq)>);
+        static_assert(flux::bounded_sequence<decltype(seq)>);
+
+        STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    }
+
+    {
+        std::array<std::array<int, 3>, 3> const arr{
+            std::array{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        STATIC_CHECK(flux::flatten(arr).sum() == 45);
+    }
+
+    // Short-circuiting internal iter
+    {
+        std::array<std::array<int, 3>, 3> const arr{
+            std::array{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        auto seq = flux::flatten(std::ref(arr));
+        auto five = seq.find(5);
+
+        STATIC_CHECK(&seq[five] == &arr[1][1]);
+    }
+
+    // reversing
+    {
+        std::array<std::array<int, 3>, 3> const arr{
+            std::array{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        auto seq = flux::reverse(flux::flatten(arr));
+
+        static_assert(flux::multipass_sequence<decltype(seq)>);
+
+        STATIC_CHECK(check_equal(seq, {9, 8, 7, 6, 5, 4, 3, 2, 1}));
+    }
+
+    // Empty outer sequence is handled correctly
+    {
+        auto arr = std::array<std::array<int, 3>, 0>{};
+
+        auto seq = flux::flatten(arr);
+
+        using S = decltype(seq);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(seq.is_empty());
+    }
+
+#ifndef NO_CONSTEXPR_VECTOR
+    // Empty inner sequence is skipped correctly
+    {
+        std::vector<std::vector<int>> vec_of_vecs{
+            {1, 2, 3}, {}, {4, 5, 6}, {}, {7}, {}, {8, 9}
+        };
+
+        auto seq = flux::flatten(std::move(vec_of_vecs));
+
+        using S = decltype(seq);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    }
+#endif // NO_CONSTEXPR_VECTOR
+
+    return true;
+}
+static_assert(test_flatten_multipass());
+
+}
+
+TEST_CASE("flatten")
+{
+    bool sp = test_flatten_single_pass();
+    REQUIRE(sp);
+
+    bool mp = test_flatten_multipass();
+    REQUIRE(mp);
+}


### PR DESCRIPTION
This is our version of C++20's views::join

This commit actually has two completely separate implementations: the first is single-pass only while the second can go all the way to bidirectional + bounded if the underlying sequence supports it.

The multipass version is used when all of the following are true:
  * the outer sequence is multipass
  * the element type of the outer sequence is a reference type
  * the inner sequence is multipass

Otherwise, the single-pass version is used.