### PR TITLE
Fix GH Actions yet again

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Build
       run: |
-        brew install gcc@12 lcov ninja
+        brew install gcc@12 lcov ninja binutils
         brew link --force binutils
         cmake -E make_directory ${{runner.workspace}}/build
         cd ${{runner.workspace}}/build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
         include:
           - install: |
-              brew install gcc@12 ninja
+              brew install gcc@12 ninja binutils
               brew link --force binutils
 
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           - cxx: g++-11
             install: |
-              brew install gcc@11 ninja
+              brew install gcc@11 ninja binutils
               brew link --force binutils
           - cxx: g++-12
             install: |
-              brew install gcc@12 ninja
+              brew install gcc@12 ninja binutils
               brew link --force binutils
 
     steps:

--- a/.github/workflows/santizers.yml
+++ b/.github/workflows/santizers.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - cxx: g++-12
             install: |
-              brew install gcc@12 ninja
+              brew install gcc@12 ninja binutils
               brew link --force binutils
 
     steps:


### PR DESCRIPTION
It's Monday, so that means GitHub Actions and/or Homebrew has changed something again.

It worked two days ago.

The Linux build scripts seem to be complaining that the binutils package isn't installed, which either means that the GCC packages have been updated so they don't need them anymore (undoing the changes in #11), or else it's some sort of mistake and binutils should be auto-installed but isn't.

We'll try the latter possibility first.