### PR TITLE
Add slide adaptor

### DIFF
--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -36,6 +36,7 @@
 #include <flux/op/ref.hpp>
 #include <flux/op/reverse.hpp>
 #include <flux/op/slice.hpp>
+#include <flux/op/slide.hpp>
 #include <flux/op/split.hpp>
 #include <flux/op/split_string.hpp>
 #include <flux/op/sort.hpp>

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -242,6 +242,9 @@ public:
     constexpr auto reverse() &&
             requires bidirectional_sequence<Derived> && bounded_sequence<Derived>;
 
+    [[nodiscard]]
+    constexpr auto slide(std::integral auto win_sz) && requires multipass_sequence<Derived>;
+
     template <multipass_sequence Pattern>
         requires std::equality_comparable_with<element_t<Derived>, element_t<Pattern>>
     [[nodiscard]]

--- a/include/flux/op/slide.hpp
+++ b/include/flux/op/slide.hpp
@@ -1,0 +1,140 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_SLIDE_HPP_INCLUDED
+#define FLUX_OP_SLIDE_HPP_INCLUDED
+
+#include <flux/core.hpp>
+#include <flux/op/slice.hpp>
+#include <flux/op/stride.hpp>
+
+namespace flux {
+
+namespace detail {
+
+template <multipass_sequence Base>
+struct slide_adaptor : inline_sequence_base<slide_adaptor<Base>> {
+private:
+    Base base_;
+    distance_t win_sz_;
+
+public:
+    constexpr slide_adaptor(decays_to<Base> auto&& base, distance_t win_sz)
+        : base_(FLUX_FWD(base)),
+          win_sz_(win_sz)
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        struct cursor_type {
+            cursor_t<Base> from;
+            cursor_t<Base> to;
+
+            friend constexpr auto operator==(cursor_type const& lhs, cursor_type const& rhs)
+                -> bool
+            {
+                return lhs.from == rhs.from;
+            }
+
+            friend constexpr auto operator<=>(cursor_type const& lhs, cursor_type const& rhs)
+                -> std::strong_ordering
+                requires ordered_cursor<cursor_t<Base>>
+            {
+                return lhs.from <=> rhs.from;
+            }
+        };
+
+    public:
+        static constexpr auto first(auto& self) -> cursor_type {
+            auto cur = flux::first(self.base_);
+            auto end = cur;
+            advance(self.base_, end, self.win_sz_ - 1);
+
+            return cursor_type{.from = std::move(cur), .to = std::move(end)};
+        }
+
+        static constexpr auto is_last(auto& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.to);
+        }
+
+        static constexpr auto inc(auto& self, cursor_type& cur) -> void
+        {
+            flux::inc(self.base_, cur.from);
+            flux::inc(self.base_, cur.to);
+        }
+
+        static constexpr auto read_at(auto& self, cursor_type const& cur)
+            -> decltype(flux::take(flux::slice(self.base_, cur.from, flux::last), self.win_sz_))
+        {
+            return flux::take(flux::slice(self.base_, cur.from, flux::last), self.win_sz_);
+        }
+
+        static constexpr auto last(auto& self) -> cursor_type
+            requires bounded_sequence<Base> && bidirectional_sequence<Base>
+        {
+            auto end = flux::last(self.base_);
+            auto cur = end;
+            advance(self.base_, cur, 1 - self.win_sz_);
+            return cursor_type{.from = std::move(cur), .to = std::move(end)};
+        }
+
+        static constexpr auto dec(auto& self, cursor_type& cur) -> void
+            requires bidirectional_sequence<Base>
+        {
+            flux::dec(self.base_, cur.from);
+            flux::dec(self.base_, cur.to);
+        }
+
+        static constexpr auto inc(auto& self, cursor_type& cur, distance_t offset) -> void
+            requires random_access_sequence<Base>
+        {
+            flux::inc(self.base_, cur.from, offset);
+            flux::inc(self.base_, cur.to, offset);
+        }
+
+        static constexpr auto distance(auto& self, cursor_type const& from, cursor_type const& to)
+            -> distance_t
+            requires random_access_sequence<Base>
+        {
+            return flux::distance(self.base_, from.from, to.from);
+        }
+
+        static constexpr auto size(auto& self) -> distance_t
+            requires sized_sequence<Base>
+        {
+            auto s = (flux::size(self.base_) - self.win_sz_) + 1;
+            return std::max(s, distance_t{0});
+        }
+    };
+};
+
+struct slide_fn {
+    template <adaptable_sequence Seq>
+        requires multipass_sequence<Seq>
+    [[nodiscard]]
+    constexpr auto operator()(Seq&& seq, std::integral auto win_sz) const
+        -> sequence auto
+    {
+        return slide_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq),
+                                                checked_cast<distance_t>(win_sz));
+    }
+};
+
+} // namespace detail
+
+inline constexpr auto slide = detail::slide_fn{};
+
+template <typename D>
+constexpr auto inline_sequence_base<D>::slide(std::integral auto win_sz) &&
+        requires multipass_sequence<D>
+{
+    FLUX_ASSERT(win_sz > 0);
+    return flux::slide(std::move(derived()), std::move(win_sz));
+}
+
+} // namespace slide
+
+#endif // FLUX_OP_SLIDE_HPP_INCLUDED

--- a/single_include/flux.hpp
+++ b/single_include/flux.hpp
@@ -2163,6 +2163,9 @@ public:
     constexpr auto reverse() &&
             requires bidirectional_sequence<Derived> && bounded_sequence<Derived>;
 
+    [[nodiscard]]
+    constexpr auto slide(std::integral auto win_sz) && requires multipass_sequence<Derived>;
+
     template <multipass_sequence Pattern>
         requires std::equality_comparable_with<element_t<Derived>, element_t<Pattern>>
     [[nodiscard]]
@@ -6560,6 +6563,147 @@ constexpr auto inline_sequence_base<D>::reverse() &&
 
 #endif
 
+
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_SLIDE_HPP_INCLUDED
+#define FLUX_OP_SLIDE_HPP_INCLUDED
+
+
+
+
+
+namespace flux {
+
+namespace detail {
+
+template <multipass_sequence Base>
+struct slide_adaptor : inline_sequence_base<slide_adaptor<Base>> {
+private:
+    Base base_;
+    distance_t win_sz_;
+
+public:
+    constexpr slide_adaptor(decays_to<Base> auto&& base, distance_t win_sz)
+        : base_(FLUX_FWD(base)),
+          win_sz_(win_sz)
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        struct cursor_type {
+            cursor_t<Base> from;
+            cursor_t<Base> to;
+
+            friend constexpr auto operator==(cursor_type const& lhs, cursor_type const& rhs)
+                -> bool
+            {
+                return lhs.from == rhs.from;
+            }
+
+            friend constexpr auto operator<=>(cursor_type const& lhs, cursor_type const& rhs)
+                -> std::strong_ordering
+                requires ordered_cursor<cursor_t<Base>>
+            {
+                return lhs.from <=> rhs.from;
+            }
+        };
+
+    public:
+        static constexpr auto first(auto& self) -> cursor_type {
+            auto cur = flux::first(self.base_);
+            auto end = cur;
+            advance(self.base_, end, self.win_sz_ - 1);
+
+            return cursor_type{.from = std::move(cur), .to = std::move(end)};
+        }
+
+        static constexpr auto is_last(auto& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.to);
+        }
+
+        static constexpr auto inc(auto& self, cursor_type& cur) -> void
+        {
+            flux::inc(self.base_, cur.from);
+            flux::inc(self.base_, cur.to);
+        }
+
+        static constexpr auto read_at(auto& self, cursor_type const& cur)
+            -> decltype(flux::take(flux::slice(self.base_, cur.from, flux::last), self.win_sz_))
+        {
+            return flux::take(flux::slice(self.base_, cur.from, flux::last), self.win_sz_);
+        }
+
+        static constexpr auto last(auto& self) -> cursor_type
+            requires bounded_sequence<Base> && bidirectional_sequence<Base>
+        {
+            auto end = flux::last(self.base_);
+            auto cur = end;
+            advance(self.base_, cur, 1 - self.win_sz_);
+            return cursor_type{.from = std::move(cur), .to = std::move(end)};
+        }
+
+        static constexpr auto dec(auto& self, cursor_type& cur) -> void
+            requires bidirectional_sequence<Base>
+        {
+            flux::dec(self.base_, cur.from);
+            flux::dec(self.base_, cur.to);
+        }
+
+        static constexpr auto inc(auto& self, cursor_type& cur, distance_t offset) -> void
+            requires random_access_sequence<Base>
+        {
+            flux::inc(self.base_, cur.from, offset);
+            flux::inc(self.base_, cur.to, offset);
+        }
+
+        static constexpr auto distance(auto& self, cursor_type const& from, cursor_type const& to)
+            -> distance_t
+            requires random_access_sequence<Base>
+        {
+            return flux::distance(self.base_, from.from, to.from);
+        }
+
+        static constexpr auto size(auto& self) -> distance_t
+            requires sized_sequence<Base>
+        {
+            auto s = (flux::size(self.base_) - self.win_sz_) + 1;
+            return std::max(s, distance_t{0});
+        }
+    };
+};
+
+struct slide_fn {
+    template <adaptable_sequence Seq>
+        requires multipass_sequence<Seq>
+    [[nodiscard]]
+    constexpr auto operator()(Seq&& seq, std::integral auto win_sz) const
+        -> sequence auto
+    {
+        return slide_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq),
+                                                checked_cast<distance_t>(win_sz));
+    }
+};
+
+} // namespace detail
+
+inline constexpr auto slide = detail::slide_fn{};
+
+template <typename D>
+constexpr auto inline_sequence_base<D>::slide(std::integral auto win_sz) &&
+        requires multipass_sequence<D>
+{
+    FLUX_ASSERT(win_sz > 0);
+    return flux::slide(std::move(derived()), std::move(win_sz));
+}
+
+} // namespace slide
+
+#endif // FLUX_OP_SLIDE_HPP_INCLUDED
 
 
 // Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(test-libflux
     test_output_to.cpp
     test_range_iface.cpp
     test_reverse.cpp
+    test_slide.cpp
     test_split.cpp
     test_sort.cpp
     test_stride.cpp

--- a/test/test_slide.cpp
+++ b/test/test_slide.cpp
@@ -1,0 +1,138 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+
+namespace {
+
+constexpr bool test_slide()
+{
+    // Basic striding
+    {
+        std::array arr{1, 2, 3, 4, 5};
+
+        auto seq = flux::ref(arr).slide(2);
+
+        using S = decltype(seq);
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
+
+        STATIC_CHECK(seq.size() == 4);
+        STATIC_CHECK(seq.distance(seq.first(), seq.last()) == 4);
+
+        auto cur = flux::first(seq);
+        STATIC_CHECK(check_equal(seq[cur], {1, 2}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {2, 3}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {3, 4}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {4, 5}));
+        STATIC_CHECK(seq.is_last(seq.inc(cur)));
+
+        STATIC_CHECK(cur == seq.last());
+        STATIC_CHECK(seq.is_last(seq.last()));
+    }
+
+    // const iteration works if the underlying is const-iterable
+    {
+        auto const seq = flux::slide(std::array{1, 2, 3, 4, 5}, 2);
+
+        using S = decltype(seq);
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
+
+        STATIC_CHECK(flux::size(seq) == 4);
+
+        auto cur = flux::first(seq);
+        STATIC_CHECK(check_equal(flux::read_at(seq, cur), {1, 2}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(check_equal(flux::read_at(seq, cur), {2, 3}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(check_equal(flux::read_at(seq, cur), {3, 4}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(check_equal(flux::read_at(seq, cur), {4, 5}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(flux::is_last(seq, cur));
+    }
+
+    // slide with window size > sequence size is an empty sequence
+    {
+        auto seq = flux::slide(std::array{1, 2, 3}, 10);
+
+        STATIC_CHECK(seq.is_empty());
+        STATIC_CHECK(seq.is_last(seq.first()));
+    }
+
+    // slide with empty sequence is an empty sequence
+    {
+        auto seq = flux::slide(flux::empty<int>, 5);
+
+        STATIC_CHECK(seq.is_empty());
+        STATIC_CHECK(seq.is_last(seq.first()));
+    }
+
+    // slide with window size == sequence size has one element
+    {
+        auto seq = flux::slide(std::array{1, 2, 3, 4, 5}, 5);
+
+        STATIC_CHECK(flux::count(seq) == 1);
+        STATIC_CHECK(check_equal(seq.front().value(), {1, 2, 3, 4, 5}));
+    }
+
+    // slide(n) + stride(n) is equivalent to chunk(n), if n divides size
+    {
+        std::array arr{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+        auto slide_n_stride = flux::slide(arr, 3).stride(3);
+
+        auto chunk = flux::chunk(arr, 3);
+
+        // I love that this actually works
+        STATIC_CHECK(flux::equal(slide_n_stride, chunk, flux::equal));
+    }
+
+    // Reverse iteration works when underlying is bidir + bounded
+    {
+        auto seq = flux::slide(std::array{1, 2, 3, 4, 5}, 2).reverse();
+
+        using S = decltype(seq);
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
+
+        auto cur = flux::first(seq);
+        STATIC_CHECK(check_equal(seq[cur], {4, 5}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {3, 4}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {2, 3}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {1, 2}));
+        STATIC_CHECK(seq.is_last(seq.inc(cur)));
+
+        STATIC_CHECK(cur == seq.last());
+        STATIC_CHECK(seq.is_last(seq.last()));
+    }
+
+    return true;
+}
+static_assert(test_slide());
+
+}
+
+TEST_CASE("slide")
+{
+    bool res = test_slide();
+    REQUIRE(res);
+}


### PR DESCRIPTION
This takes a runtime window size `n`, and yields sliding windows of size `n` over the source sequence. For example, given a source sequence `[1, 2, 3, 4, 5]` and a window size of 2, will return

    [[1, 2], [2, 3], [3, 4], [4, 5]]

It is multipass only, since we need to use two cursors to keep track of the start and end of the window.