### PR TITLE
Add adjacent<N> adaptor

### DIFF
--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -8,6 +8,7 @@
 
 #include <flux/core.hpp>
 
+#include <flux/op/adjacent.hpp>
 #include <flux/op/all_any_none.hpp>
 #include <flux/op/begin_end.hpp>
 #include <flux/op/cache_last.hpp>

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -203,6 +203,10 @@ public:
      * Adaptors
      */
 
+    template <distance_t N>
+    [[nodiscard]]
+    constexpr auto adjacent() && requires multipass_sequence<Derived>;
+
     [[nodiscard]]
     constexpr auto cache_last() &&
             requires bounded_sequence<Derived> ||
@@ -237,6 +241,9 @@ public:
         requires std::invocable<Func&, element_t<Derived>>
     [[nodiscard]]
     constexpr auto map(Func func) &&;
+
+    [[nodiscard]]
+    constexpr auto pairwise() && requires multipass_sequence<Derived>;
 
     [[nodiscard]]
     constexpr auto reverse() &&

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -207,6 +207,11 @@ public:
     [[nodiscard]]
     constexpr auto adjacent() && requires multipass_sequence<Derived>;
 
+    template <distance_t N, typename Func>
+        requires multipass_sequence<Derived>
+    [[nodiscard]]
+    constexpr auto adjacent_map(Func func) &&;
+
     [[nodiscard]]
     constexpr auto cache_last() &&
             requires bounded_sequence<Derived> ||
@@ -244,6 +249,11 @@ public:
 
     [[nodiscard]]
     constexpr auto pairwise() && requires multipass_sequence<Derived>;
+
+    template <typename Func>
+        requires multipass_sequence<Derived>
+    [[nodiscard]]
+    constexpr auto pairwise_map(Func func) &&;
 
     [[nodiscard]]
     constexpr auto reverse() &&

--- a/include/flux/op/adjacent.hpp
+++ b/include/flux/op/adjacent.hpp
@@ -153,6 +153,13 @@ public:
         {
             return flux::distance(self.base_, from.arr.back(), to.arr.back());
         }
+
+        static constexpr auto size(auto& self) -> distance_t
+            requires sized_sequence<Base>
+        {
+            auto s = (flux::size(self.base_) - N) + 1;
+            return (std::max)(s, distance_t{0});
+        }
     };
 };
 

--- a/include/flux/op/adjacent.hpp
+++ b/include/flux/op/adjacent.hpp
@@ -121,8 +121,12 @@ public:
         {
             cursor_type out{};
             out.arr.back() = flux::last(self.base_);
+            auto const first = flux::first(self.base_);
             for (auto i : flux::ints(0, N-1).reverse()) {
-                out.arr[i] = flux::prev(self.base_, out.arr[i+1]);
+                out.arr[i] = out.arr[i + 1];
+                if (out.arr[i] != first) {
+                    flux::dec(self.base_, out.arr[i]);
+                }
             }
             return out;
         }
@@ -133,6 +137,21 @@ public:
             std::apply([&self](auto&... curs) {
                 (flux::dec(self.base_, curs), ...);
             }, cur.arr);
+        }
+
+        static constexpr auto inc(auto& self, cursor_type& cur, distance_t offset) -> void
+            requires random_access_sequence<Base>
+        {
+            std::apply([&self, offset](auto&... curs) {
+                (flux::inc(self.base_, curs, offset), ...);
+            }, cur.arr);
+        }
+
+        static constexpr auto distance(auto& self, cursor_type const& from, cursor_type const& to)
+            -> distance_t
+            requires random_access_sequence<Base>
+        {
+            return flux::distance(self.base_, from.arr.back(), to.arr.back());
         }
     };
 };

--- a/include/flux/op/adjacent.hpp
+++ b/include/flux/op/adjacent.hpp
@@ -114,6 +114,14 @@ public:
         {
             return do_read(flux::move_at_unchecked, self, cur);
         }
+
+        static constexpr auto last(auto& self) -> cursor_type
+            requires bounded_sequence<Base>
+        {
+            cursor_type out{};
+            out.arr.back() = flux::last(self.base_);
+            return out;
+        }
     };
 };
 

--- a/include/flux/op/adjacent.hpp
+++ b/include/flux/op/adjacent.hpp
@@ -1,0 +1,156 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_ADJACENT_HPP_INCLUDED
+#define FLUX_OP_ADJACENT_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+#include <flux/op/begin_end.hpp>
+#include <flux/op/zip.hpp>
+#include <flux/source/iota.hpp>
+
+
+namespace flux {
+
+namespace detail {
+
+template <typename Base, distance_t N>
+struct adjacent_adaptor : inline_sequence_base<adjacent_adaptor<Base, N>> {
+private:
+    Base base_;
+
+public:
+    constexpr explicit adjacent_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        struct cursor_type {
+            std::array<cursor_t<Base>, N> arr{};
+
+            friend constexpr auto operator==(cursor_type const& lhs, cursor_type const& rhs)
+                -> bool
+            {
+                return lhs.arr.back() == rhs.arr.back();
+            }
+
+            friend constexpr auto operator<=>(cursor_type const& lhs, cursor_type const& rhs)
+                -> std::strong_ordering
+                requires ordered_cursor<cursor_t<Base>>
+            {
+                return lhs.arr.back() <=> rhs.arr.back();
+            }
+        };
+
+        static constexpr auto do_read(auto const& fn, auto& self, cursor_type const& cur)
+        {
+            return std::apply([&](auto const&... curs) {
+                return pair_or_tuple_t<decltype(fn(self.base_, curs))...>(
+                    fn(self.base_, curs)...);
+            }, cur.arr);
+        }
+
+        template <std::size_t I>
+        using base_value_t = value_t<Base>;
+
+        template <std::size_t... Is>
+        static auto make_value_type(std::index_sequence<Is...>) -> pair_or_tuple_t<base_value_t<Is>...>;
+
+    public:
+
+        static inline constexpr bool is_infinite = infinite_sequence<Base>;
+
+        using value_type = decltype(make_value_type(std::make_index_sequence<N>{}));
+
+        static constexpr auto first(auto& self) -> cursor_type
+        {
+            cursor_type out{flux::first(self.base_), };
+
+            for (auto i : flux::ints(1, N)) {
+                out.arr[i] = out.arr[i - 1];
+                if (!flux::is_last(self.base_, out.arr[i])) {
+                    flux::inc(self.base_, out.arr[i]);
+                }
+            }
+            return out;
+        }
+
+        static constexpr auto is_last(auto& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.arr.back());
+        }
+
+        static constexpr auto inc(auto& self, cursor_type& cur) -> void
+        {
+            std::apply([&](auto&... curs) {
+                (flux::inc(self.base_, curs), ...);
+            }, cur.arr);
+        }
+
+        static constexpr auto read_at(auto& self, cursor_type const& cur)
+            -> decltype(do_read(flux::read_at, self, cur))
+        {
+            return do_read(flux::read_at, self, cur);
+        }
+
+        static constexpr auto move_at(auto& self, cursor_type const& cur)
+            -> decltype(do_read(flux::move_at, self, cur))
+        {
+            return do_read(flux::move_at, self, cur);
+        }
+
+        static constexpr auto read_at_unchecked(auto& self, cursor_type const& cur)
+            -> decltype(do_read(flux::read_at_unchecked, self, cur))
+        {
+            return do_read(flux::read_at_unchecked, self, cur);
+        }
+
+        static constexpr auto move_at_unchecked(auto& self, cursor_type const& cur)
+            -> decltype(do_read(flux::move_at_unchecked, self, cur))
+        {
+            return do_read(flux::move_at_unchecked, self, cur);
+        }
+    };
+};
+
+template <distance_t N>
+struct adjacent_fn {
+    template <adaptable_sequence Seq>
+        requires multipass_sequence<Seq>
+    [[nodiscard]]
+    constexpr auto operator()(Seq&& seq) const -> multipass_sequence auto
+    {
+        return adjacent_adaptor<std::decay_t<Seq>, N>(FLUX_FWD(seq));
+    }
+};
+
+} // namespace detail
+
+template <distance_t N>
+    requires (N > 0)
+inline constexpr auto adjacent = detail::adjacent_fn<N>{};
+
+inline constexpr auto pairwise = adjacent<2>;
+
+template <typename D>
+template <distance_t N>
+constexpr auto inline_sequence_base<D>::adjacent() &&
+    requires multipass_sequence<D>
+{
+    return flux::adjacent<N>(std::move(derived()));
+}
+
+template <typename D>
+constexpr auto inline_sequence_base<D>::pairwise() &&
+    requires multipass_sequence<D>
+{
+    return flux::pairwise(std::move(derived()));
+}
+
+} // namespace flux
+
+#endif // FLUX_OP_ADJACENT_HPP_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(test-libflux
     test_apply.cpp
 
     test_adjacent.cpp
+    test_adjacent_map.cpp
     test_all_any_none.cpp
     test_bounds_checked.cpp
     test_cache_last.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(test-libflux
     test_simple_sequence.cpp
     test_apply.cpp
 
+    test_adjacent.cpp
     test_all_any_none.cpp
     test_bounds_checked.cpp
     test_cache_last.cpp

--- a/test/test_adjacent.cpp
+++ b/test/test_adjacent.cpp
@@ -37,17 +37,17 @@ constexpr bool test_pairwise()
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::random_access_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
 
         static_assert(std::same_as<flux::element_t<S>, std::pair<int&, int&>>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, std::pair<int&&, int&&>>);
         static_assert(std::same_as<flux::value_t<S>, std::pair<int, int>>);
 
 
-//        STATIC_CHECK(seq.size() == 4);
-//        STATIC_CHECK(seq.distance(seq.first(), seq.last()) == 4);
+        STATIC_CHECK(seq.size() == 4);
+        STATIC_CHECK(seq.distance(seq.first(), seq.last()) == 4);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(tuple_equal(seq[cur], std::pair{1, 2}));
@@ -67,11 +67,11 @@ constexpr bool test_pairwise()
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::random_access_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
 
-//        STATIC_CHECK(flux::size(seq) == 4);
+        STATIC_CHECK(flux::size(seq) == 4);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(tuple_equal(flux::read_at(seq, cur), std::array{1, 2}));
@@ -108,9 +108,9 @@ constexpr bool test_pairwise()
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::random_access_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(tuple_equal(seq[cur], std::pair{4, 5}));
@@ -138,12 +138,12 @@ constexpr bool test_adjacent()
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::random_access_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
 
-//        STATIC_CHECK(seq.size() == 4);
-//        STATIC_CHECK(seq.distance(seq.first(), seq.last()) == 4);
+        STATIC_CHECK(seq.size() == 3);
+        STATIC_CHECK(seq.distance(seq.first(), seq.last()) == 3);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(tuple_equal(seq[cur], std::array{1, 2, 3}));
@@ -162,11 +162,11 @@ constexpr bool test_adjacent()
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::random_access_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
 
-        //STATIC_CHECK(flux::size(seq) == 3);
+        STATIC_CHECK(flux::size(seq) == 3);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(tuple_equal(flux::read_at(seq, cur), std::tuple{1, 2, 3}));
@@ -228,9 +228,9 @@ constexpr bool test_adjacent()
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::random_access_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(tuple_equal(seq[cur], std::array{3, 4, 5}));

--- a/test/test_adjacent.cpp
+++ b/test/test_adjacent.cpp
@@ -38,7 +38,7 @@ constexpr bool test_pairwise()
         static_assert(flux::multipass_sequence<S>);
         static_assert(not flux::bidirectional_sequence<S>);
         static_assert(not flux::random_access_sequence<S>);
-        static_assert(not flux::bounded_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::sized_sequence<S>);
 
         static_assert(std::same_as<flux::element_t<S>, std::pair<int&, int&>>);
@@ -56,8 +56,8 @@ constexpr bool test_pairwise()
         STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::pair{4, 5}));
         STATIC_CHECK(seq.is_last(seq.inc(cur)));
 
-//        STATIC_CHECK(cur == seq.last());
-//        STATIC_CHECK(seq.is_last(seq.last()));
+        STATIC_CHECK(cur == seq.last());
+        STATIC_CHECK(seq.is_last(seq.last()));
     }
 
     // const iteration works if the underlying is const-iterable
@@ -68,7 +68,7 @@ constexpr bool test_pairwise()
         static_assert(flux::multipass_sequence<S>);
         static_assert(not flux::bidirectional_sequence<S>);
         static_assert(not flux::random_access_sequence<S>);
-        static_assert(not flux::bounded_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::sized_sequence<S>);
 
 //        STATIC_CHECK(flux::size(seq) == 4);
@@ -141,7 +141,7 @@ constexpr bool test_adjacent()
         static_assert(flux::multipass_sequence<S>);
         static_assert(not flux::bidirectional_sequence<S>);
         static_assert(not flux::random_access_sequence<S>);
-        static_assert(not flux::bounded_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::sized_sequence<S>);
 
 //        STATIC_CHECK(seq.size() == 4);
@@ -153,8 +153,8 @@ constexpr bool test_adjacent()
         STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::array{3, 4, 5}));
         STATIC_CHECK(seq.is_last(seq.inc(cur)));
 
-   //     STATIC_CHECK(cur == seq.last());
-   //     STATIC_CHECK(seq.is_last(seq.last()));
+        STATIC_CHECK(cur == seq.last());
+        STATIC_CHECK(seq.is_last(seq.last()));
     }
 
     // const iteration works if the underlying is const-iterable
@@ -165,7 +165,7 @@ constexpr bool test_adjacent()
         static_assert(flux::multipass_sequence<S>);
         static_assert(not flux::bidirectional_sequence<S>);
         static_assert(not flux::random_access_sequence<S>);
-        static_assert(not flux::bounded_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::sized_sequence<S>);
 
         //STATIC_CHECK(flux::size(seq) == 3);

--- a/test/test_adjacent.cpp
+++ b/test/test_adjacent.cpp
@@ -36,7 +36,7 @@ constexpr bool test_pairwise()
 
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
-        static_assert(not flux::bidirectional_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
         static_assert(not flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::sized_sequence<S>);
@@ -66,7 +66,7 @@ constexpr bool test_pairwise()
 
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
-        static_assert(not flux::bidirectional_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
         static_assert(not flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::sized_sequence<S>);
@@ -101,29 +101,27 @@ constexpr bool test_pairwise()
         STATIC_CHECK(tuple_equal(seq.front().value(), std::pair{1, 2}));
     }
 
-#if 0
     // Reverse iteration works when underlying is bidir + bounded
     {
-        auto seq = flux::pairwise(std::array{1, 2, 3, 4, 5}, 2).reverse();
+        auto seq = flux::pairwise(std::array{1, 2, 3, 4, 5}).reverse();
 
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(flux::random_access_sequence<S>);
+        static_assert(not flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
 
         auto cur = flux::first(seq);
-        STATIC_CHECK(check_equal(seq[cur], {4, 5}));
-        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {3, 4}));
-        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {2, 3}));
-        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {1, 2}));
+        STATIC_CHECK(tuple_equal(seq[cur], std::pair{4, 5}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::pair{3, 4}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::pair{2, 3}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::pair{1, 2}));
         STATIC_CHECK(seq.is_last(seq.inc(cur)));
 
         STATIC_CHECK(cur == seq.last());
         STATIC_CHECK(seq.is_last(seq.last()));
     }
-#endif
 
     return true;
 }
@@ -139,7 +137,7 @@ constexpr bool test_adjacent()
 
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
-        static_assert(not flux::bidirectional_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
         static_assert(not flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::sized_sequence<S>);
@@ -163,7 +161,7 @@ constexpr bool test_adjacent()
 
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
-        static_assert(not flux::bidirectional_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
         static_assert(not flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::sized_sequence<S>);
@@ -222,7 +220,7 @@ constexpr bool test_adjacent()
 
         STATIC_CHECK(flux::equal(adj_n_stride, chunk, flux::equal, tuple_to_array));
     }
-#if 0
+
     // Reverse iteration works when underlying is bidir + bounded
     {
         auto seq = flux::adjacent<3>(std::array{1, 2, 3, 4, 5}).reverse();
@@ -230,21 +228,20 @@ constexpr bool test_adjacent()
         using S = decltype(seq);
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(flux::random_access_sequence<S>);
+        static_assert(not flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
 
         auto cur = flux::first(seq);
-        STATIC_CHECK(check_equal(seq[cur], {4, 5}));
-        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {3, 4}));
-        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {2, 3}));
-        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {1, 2}));
+        STATIC_CHECK(tuple_equal(seq[cur], std::array{3, 4, 5}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::array{2, 3, 4}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::array{1, 2, 3}));
         STATIC_CHECK(seq.is_last(seq.inc(cur)));
 
         STATIC_CHECK(cur == seq.last());
         STATIC_CHECK(seq.is_last(seq.last()));
     }
-#endif
+
     return true;
 }
 static_assert(test_adjacent());

--- a/test/test_adjacent.cpp
+++ b/test/test_adjacent.cpp
@@ -11,7 +11,6 @@
 
 #include <array>
 
-#include <iostream>
 
 namespace {
 

--- a/test/test_adjacent.cpp
+++ b/test/test_adjacent.cpp
@@ -1,0 +1,261 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+
+#include <iostream>
+
+namespace {
+
+template <typename Lhs, typename Rhs>
+constexpr bool tuple_equal(Lhs const& lhs, Rhs const& rhs)
+{
+    auto impl = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        return ((std::get<Is>(lhs) == std::get<Is>(rhs)) && ...);
+    };
+
+    return std::tuple_size_v<Lhs> == std::tuple_size_v<Rhs> &&
+            impl(std::make_index_sequence<std::tuple_size_v<Lhs>>{});
+}
+
+constexpr bool test_pairwise()
+{
+    // Basic pairwise
+    {
+        std::array arr{1, 2, 3, 4, 5};
+
+        auto seq = flux::ref(arr).pairwise();
+
+        using S = decltype(seq);
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(not flux::bidirectional_sequence<S>);
+        static_assert(not flux::random_access_sequence<S>);
+        static_assert(not flux::bounded_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+
+        static_assert(std::same_as<flux::element_t<S>, std::pair<int&, int&>>);
+        static_assert(std::same_as<flux::rvalue_element_t<S>, std::pair<int&&, int&&>>);
+        static_assert(std::same_as<flux::value_t<S>, std::pair<int, int>>);
+
+
+//        STATIC_CHECK(seq.size() == 4);
+//        STATIC_CHECK(seq.distance(seq.first(), seq.last()) == 4);
+
+        auto cur = flux::first(seq);
+        STATIC_CHECK(tuple_equal(seq[cur], std::pair{1, 2}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::tuple{2, 3}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::array{3, 4}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::pair{4, 5}));
+        STATIC_CHECK(seq.is_last(seq.inc(cur)));
+
+//        STATIC_CHECK(cur == seq.last());
+//        STATIC_CHECK(seq.is_last(seq.last()));
+    }
+
+    // const iteration works if the underlying is const-iterable
+    {
+        auto const seq = flux::pairwise(std::array{1, 2, 3, 4, 5});
+
+        using S = decltype(seq);
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(not flux::bidirectional_sequence<S>);
+        static_assert(not flux::random_access_sequence<S>);
+        static_assert(not flux::bounded_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+
+//        STATIC_CHECK(flux::size(seq) == 4);
+
+        auto cur = flux::first(seq);
+        STATIC_CHECK(tuple_equal(flux::read_at(seq, cur), std::array{1, 2}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(tuple_equal(flux::read_at(seq, cur), std::pair{2, 3}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(tuple_equal(flux::read_at(seq, cur), std::pair{3, 4}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(tuple_equal(flux::read_at(seq, cur), std::pair{4, 5}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(flux::is_last(seq, cur));
+    }
+
+    // pairwise with empty sequence is an empty sequence
+    {
+        auto seq = flux::pairwise(flux::empty<int>);
+
+        STATIC_CHECK(seq.is_empty());
+        STATIC_CHECK(seq.is_last(seq.first()));
+    }
+
+    // pairwise with two-element sequence has one element
+    {
+        auto seq = flux::pairwise(std::array{1, 2});
+
+        STATIC_CHECK(flux::count(seq) == 1);
+        STATIC_CHECK(tuple_equal(seq.front().value(), std::pair{1, 2}));
+    }
+
+#if 0
+    // Reverse iteration works when underlying is bidir + bounded
+    {
+        auto seq = flux::pairwise(std::array{1, 2, 3, 4, 5}, 2).reverse();
+
+        using S = decltype(seq);
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
+
+        auto cur = flux::first(seq);
+        STATIC_CHECK(check_equal(seq[cur], {4, 5}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {3, 4}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {2, 3}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {1, 2}));
+        STATIC_CHECK(seq.is_last(seq.inc(cur)));
+
+        STATIC_CHECK(cur == seq.last());
+        STATIC_CHECK(seq.is_last(seq.last()));
+    }
+#endif
+
+    return true;
+}
+static_assert(test_pairwise());
+
+constexpr bool test_adjacent()
+{
+    // Basic striding
+    {
+        std::array arr{1, 2, 3, 4, 5};
+
+        auto seq = flux::ref(arr).adjacent<3>();
+
+        using S = decltype(seq);
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(not flux::bidirectional_sequence<S>);
+        static_assert(not flux::random_access_sequence<S>);
+        static_assert(not flux::bounded_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+
+//        STATIC_CHECK(seq.size() == 4);
+//        STATIC_CHECK(seq.distance(seq.first(), seq.last()) == 4);
+
+        auto cur = flux::first(seq);
+        STATIC_CHECK(tuple_equal(seq[cur], std::array{1, 2, 3}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::array{2, 3, 4}));
+        STATIC_CHECK(tuple_equal(seq[seq.inc(cur)], std::array{3, 4, 5}));
+        STATIC_CHECK(seq.is_last(seq.inc(cur)));
+
+   //     STATIC_CHECK(cur == seq.last());
+   //     STATIC_CHECK(seq.is_last(seq.last()));
+    }
+
+    // const iteration works if the underlying is const-iterable
+    {
+        auto const seq = flux::adjacent<3>(std::array{1, 2, 3, 4, 5});
+
+        using S = decltype(seq);
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(not flux::bidirectional_sequence<S>);
+        static_assert(not flux::random_access_sequence<S>);
+        static_assert(not flux::bounded_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+
+        //STATIC_CHECK(flux::size(seq) == 3);
+
+        auto cur = flux::first(seq);
+        STATIC_CHECK(tuple_equal(flux::read_at(seq, cur), std::tuple{1, 2, 3}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(tuple_equal(flux::read_at(seq, cur), std::tuple{2, 3, 4}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(tuple_equal(flux::read_at(seq, cur), std::tuple{3, 4, 5}));
+        flux::inc(seq, cur);
+        STATIC_CHECK(flux::is_last(seq, cur));
+    }
+
+    // adjacent with window size > sequence size is an empty sequence
+    {
+        auto seq = flux::adjacent<10>(std::array{1, 2, 3});
+
+        STATIC_CHECK(seq.is_empty());
+        STATIC_CHECK(seq.is_last(seq.first()));
+    }
+
+    // adjacent with empty sequence is an empty sequence
+    {
+        auto seq = flux::adjacent<5>(flux::empty<int>);
+
+        STATIC_CHECK(seq.is_empty());
+        STATIC_CHECK(seq.is_last(seq.first()));
+    }
+
+    // adjacent with window size == sequence size has one element
+    {
+        auto seq = flux::adjacent<5>(std::array{1, 2, 3, 4, 5});
+
+        STATIC_CHECK(flux::count(seq) == 1);
+        STATIC_CHECK(tuple_equal(seq.front().value(), std::array{1, 2, 3, 4, 5}));
+    }
+
+    // adjacent<n> + stride(n) is equivalent to chunk(n), if n divides size
+    {
+        std::array arr{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+        auto adj_n_stride = flux::adjacent<3>(arr).stride(3);
+
+        auto chunk = flux::chunk(arr, 3);
+
+        auto tuple_to_array = []<typename T>(T&& tuple) {
+            using array_t =  std::array<std::decay_t<std::tuple_element_t<0, T>>,
+                                        std::tuple_size_v<T>>;
+            return std::apply([](auto&&... args) {
+                return array_t{FLUX_FWD(args)...};
+            }, FLUX_FWD(tuple));
+        };
+
+        STATIC_CHECK(flux::equal(adj_n_stride, chunk, flux::equal, tuple_to_array));
+    }
+#if 0
+    // Reverse iteration works when underlying is bidir + bounded
+    {
+        auto seq = flux::adjacent<3>(std::array{1, 2, 3, 4, 5}).reverse();
+
+        using S = decltype(seq);
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
+
+        auto cur = flux::first(seq);
+        STATIC_CHECK(check_equal(seq[cur], {4, 5}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {3, 4}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {2, 3}));
+        STATIC_CHECK(check_equal(seq[seq.inc(cur)], {1, 2}));
+        STATIC_CHECK(seq.is_last(seq.inc(cur)));
+
+        STATIC_CHECK(cur == seq.last());
+        STATIC_CHECK(seq.is_last(seq.last()));
+    }
+#endif
+    return true;
+}
+static_assert(test_adjacent());
+
+}
+
+TEST_CASE("adjacent")
+{
+    bool res = test_pairwise();
+    REQUIRE(res);
+
+    res = test_adjacent();
+    REQUIRE(res);
+}

--- a/test/test_adjacent_map.cpp
+++ b/test/test_adjacent_map.cpp
@@ -1,0 +1,190 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+
+namespace {
+
+constexpr bool test_pairwise_map() {
+    constexpr auto tuple_sum = [](auto... args) {
+        return (args + ...);
+    };
+
+    // Basic pairwise_map
+    {
+        std::array arr{1, 2, 3, 4, 5};
+
+        auto seq = flux::ref(arr).pairwise_map(tuple_sum);
+
+        using S = decltype(seq);
+
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
+
+        STATIC_CHECK(seq.size() ==  4);
+
+        STATIC_CHECK(check_equal(seq, {3, 5, 7, 9}));
+    }
+
+    // Can const-iterate
+    {
+        std::array arr{1, 2, 3, 4, 5};
+
+        auto const seq = flux::pairwise_map(arr, tuple_sum);
+
+        using S = decltype(seq);
+
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
+
+        STATIC_CHECK(flux::size(seq) ==  4);
+
+        STATIC_CHECK(check_equal(seq, {3, 5, 7, 9}));
+    }
+
+    // Short sequence -> empty sequence
+    {
+        auto seq = flux::single(3).pairwise_map(tuple_sum);
+
+        static_assert(seq.is_empty());
+        static_assert(seq.size() == 0);
+        static_assert(seq.is_last(seq.first()));
+    }
+
+    // Empty sequence -> empty sequence
+    {
+        auto seq = flux::pairwise_map(flux::empty<int>, tuple_sum);
+
+        static_assert(seq.is_empty());
+        static_assert(seq.size() == 0);
+        static_assert(seq.is_last(seq.first()));
+    }
+
+    // pairwise_map with 2-element sequence has one element
+    {
+        auto seq = flux::pairwise_map(std::array{1, 2}, tuple_sum);
+
+        STATIC_CHECK(seq.size() == 1);
+        STATIC_CHECK(seq.front().value() == 3);
+    }
+
+    // Reverse iteration works as expected
+    {
+        std::array arr{1, 2, 3, 4, 5};
+        auto seq = flux::ref(arr).pairwise_map(tuple_sum).reverse();
+
+        STATIC_CHECK(seq.size() == 4);
+        STATIC_CHECK(check_equal(seq, {9, 7, 5, 3}));
+    }
+
+    return true;
+}
+static_assert(test_pairwise_map());
+
+constexpr bool test_adjacent_map()
+{
+    constexpr auto tuple_sum = [](auto... args) {
+        return (args + ...);
+    };
+
+    // Basic pairwise_map
+    {
+        std::array arr{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+        auto seq = flux::ref(arr).adjacent_map<4>(tuple_sum);
+
+        using S = decltype(seq);
+
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
+
+        STATIC_CHECK(seq.size() ==  7);
+
+        STATIC_CHECK(check_equal(seq, {10, 14, 18, 22, 26, 30, 34}));
+    }
+
+    // Can const-iterate
+    {
+        std::array arr{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+        auto const seq = flux::adjacent_map<4>(arr, tuple_sum);
+
+        using S = decltype(seq);
+
+        static_assert(flux::multipass_sequence<S>);
+        static_assert(flux::bidirectional_sequence<S>);
+        static_assert(flux::random_access_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(flux::sized_sequence<S>);
+
+        STATIC_CHECK(flux::size(seq) ==  7);
+
+        STATIC_CHECK(check_equal(seq, {10, 14, 18, 22, 26, 30, 34}));
+    }
+
+    // Short sequence -> empty sequence
+    {
+        auto seq = flux::single(3).adjacent_map<10>(tuple_sum);
+
+        static_assert(seq.is_empty());
+        static_assert(seq.size() == 0);
+        static_assert(seq.is_last(seq.first()));
+    }
+
+    // Empty sequence -> empty sequence
+    {
+        auto seq = flux::adjacent_map<5>(flux::empty<int>, tuple_sum);
+
+        static_assert(seq.is_empty());
+        static_assert(seq.size() == 0);
+        static_assert(seq.is_last(seq.first()));
+    }
+
+    // adjacent_map<N> with N-element sequence has one element
+    {
+        auto seq = flux::adjacent_map<5>(std::array{1, 2, 3, 4, 5}, tuple_sum);
+
+        STATIC_CHECK(seq.size() == 1);
+        STATIC_CHECK(seq.front().value() == 15);
+    }
+
+    // Reverse iteration works as expected
+    {
+        std::array arr{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        auto seq = flux::ref(arr).adjacent_map<4>(tuple_sum).reverse();
+
+        STATIC_CHECK(seq.size() == 7);
+        STATIC_CHECK(check_equal(seq, {34, 30, 26, 22, 18, 14, 10}));
+    }
+
+    return true;
+}
+static_assert(test_adjacent_map());
+
+}
+
+TEST_CASE("pairwise_map")
+{
+    bool res = test_pairwise_map();
+    REQUIRE(res);
+
+    res = test_adjacent_map();
+    REQUIRE(res);
+}

--- a/test/test_slide.cpp
+++ b/test/test_slide.cpp
@@ -15,7 +15,7 @@ namespace {
 
 constexpr bool test_slide()
 {
-    // Basic striding
+    // Basic sliding
     {
         std::array arr{1, 2, 3, 4, 5};
 


### PR DESCRIPTION
This is like `slide(n)`, except that it takes a compile-time size parameter N and yields a std::tuple of elements (or std::pair when N==2) rather than a subsequence.
