### PR TITLE
Remove projections (!)

### DIFF
--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -301,15 +301,6 @@ concept derived_from_inline_sequence_base = requires(T t) {
 
 } // namespace detail
 
-/*
- * More useful concepts and associated types
- */
-template <typename Proj, sequence Seq>
-using projected_t = std::invoke_result_t<Proj&, element_t<Seq>>;
-
-template <typename Pred, typename Seq, typename Proj>
-concept predicate_for =
-    std::predicate<Pred&, std::invoke_result_t<Proj&, element_t<Seq>>>;
 
 /*
  * Default sequence_traits implementation

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -238,7 +238,7 @@ public:
     constexpr auto drop_while(Pred pred) &&;
 
     template <typename Pred>
-        requires std::predicate<Pred&, element_t<Derived>&>
+        requires std::predicate<Pred&, element_t<Derived>>
     [[nodiscard]]
     constexpr auto filter(Pred pred) &&;
 
@@ -295,51 +295,51 @@ public:
      */
 
     /// Returns `true` if every element of the sequence satisfies the predicate
-    template <typename Pred, typename Proj = std::identity>
-        requires predicate_for<Pred, Derived, Proj>
+    template <typename Pred>
+        requires std::predicate<Pred&, element_t<Derived>>
     [[nodiscard]]
-    constexpr auto all(Pred pred, Proj proj = {});
+    constexpr auto all(Pred pred);
 
-    template <typename Pred, typename Proj = std::identity>
-        requires predicate_for<Pred, Derived, Proj>
+    template <typename Pred>
+        requires std::predicate<Pred&, element_t<Derived>>
     [[nodiscard]]
-    constexpr auto any(Pred pred, Proj proj = {});
+    constexpr auto any(Pred pred);
 
-    template <typename Value, typename Proj = std::identity>
-        requires std::equality_comparable_with<projected_t<Proj, Derived>, Value const&>
-    constexpr auto contains(Value const& value, Proj proj = {}) -> bool;
+    template <typename Value>
+        requires std::equality_comparable_with<element_t<Derived>, Value const&>
+    constexpr auto contains(Value const& value) -> bool;
 
     /// Returns the number of elements in the sequence
     constexpr auto count();
 
     /// Returns the number of elements in the sequence which are equal to `value`
-    template <typename Value, typename Proj = std::identity>
-        requires std::equality_comparable_with<projected_t<Proj, Derived>, Value const&>
-    constexpr auto count_eq(Value const& value, Proj proj = {});
+    template <typename Value>
+        requires std::equality_comparable_with<element_t<Derived>, Value const&>
+    constexpr auto count_eq(Value const& value);
 
-    template <typename Pred, typename Proj = std::identity>
-        requires predicate_for<Pred, Derived, Proj>
-    constexpr auto count_if(Pred pred, Proj proj = {});
+    template <typename Pred>
+        requires std::predicate<Pred&, element_t<Derived>>
+    constexpr auto count_if(Pred pred);
 
     template <typename Value>
         requires writable_sequence_of<Derived, Value const&>
     constexpr auto fill(Value const& value) -> void;
 
     /// Returns a cursor pointing to the first occurrence of `value` in the sequence
-    template <typename Value, typename Proj = std::identity>
-        requires std::equality_comparable_with<projected_t<Proj, Derived>, Value const&>
+    template <typename Value>
+        requires std::equality_comparable_with<element_t<Derived>, Value const&>
     [[nodiscard]]
-    constexpr auto find(Value const&, Proj proj = {});
+    constexpr auto find(Value const&);
 
-    template <typename Pred, typename Proj = std::identity>
-        requires predicate_for<Pred, Derived, Proj>
+    template <typename Pred>
+        requires std::predicate<Pred&, element_t<Derived>>
     [[nodiscard]]
-    constexpr auto find_if(Pred pred, Proj proj = {});
+    constexpr auto find_if(Pred pred);
 
-    template <typename Pred, typename Proj = std::identity>
-        requires predicate_for<Pred, Derived, Proj>
+    template <typename Pred>
+        requires std::predicate<Pred&, element_t<Derived>>
     [[nodiscard]]
-    constexpr auto find_if_not(Pred pred, Proj proj = {});
+    constexpr auto find_if_not(Pred pred);
 
     template <typename D = Derived, typename Func, typename Init>
         requires foldable<Derived, Func, Init>
@@ -352,9 +352,9 @@ public:
     [[nodiscard]]
     constexpr auto fold_first(Func func);
 
-    template <typename Func, typename Proj = std::identity>
-        requires std::invocable<Func&, projected_t<Proj, Derived>>
-    constexpr auto for_each(Func func, Proj proj = {}) -> Func;
+    template <typename Func>
+        requires std::invocable<Func&, element_t<Derived>>
+    constexpr auto for_each(Func func) -> Func;
 
     template <typename Pred>
         requires std::invocable<Pred&, element_t<Derived>> &&
@@ -365,19 +365,22 @@ public:
         requires bounded_sequence<Derived> &&
                  detail::element_swappable_with<Derived, Derived>;
 
-    template <typename Cmp = std::ranges::less, typename Proj = std::identity>
-    constexpr auto max(Cmp cmp = Cmp{}, Proj proj = Proj{});
+    template <typename Cmp = std::ranges::less>
+        requires strict_weak_order_for<Cmp, Derived>
+    constexpr auto max(Cmp cmp = Cmp{});
 
-    template <typename Cmp = std::ranges::less, typename Proj = std::identity>
-    constexpr auto min(Cmp cmp = Cmp{}, Proj proj = Proj{});
+    template <typename Cmp = std::ranges::less>
+        requires strict_weak_order_for<Cmp, Derived>
+    constexpr auto min(Cmp cmp = Cmp{});
 
-    template <typename Cmp = std::ranges::less, typename Proj = std::identity>
-    constexpr auto minmax(Cmp cmp = Cmp{}, Proj proj = Proj{});
+    template <typename Cmp = std::ranges::less>
+        requires strict_weak_order_for<Cmp, Derived>
+    constexpr auto minmax(Cmp cmp = Cmp{});
 
-    template <typename Pred, typename Proj = std::identity>
-        requires predicate_for<Pred, Derived, Proj>
+    template <typename Pred>
+        requires std::predicate<Pred&, element_t<Derived>>
     [[nodiscard]]
-    constexpr auto none(Pred pred, Proj proj = {});
+    constexpr auto none(Pred pred);
 
     template <typename Iter>
         requires std::weakly_incrementable<Iter> &&
@@ -388,12 +391,12 @@ public:
         requires foldable<Derived, std::plus<>, value_t<Derived>> &&
                  std::default_initializable<value_t<Derived>>;
 
-    template <typename Cmp = std::less<>, typename Proj = std::identity>
+    template <typename Cmp = std::ranges::less>
         requires random_access_sequence<Derived> &&
                  bounded_sequence<Derived> &&
                  detail::element_swappable_with<Derived, Derived> &&
-                 std::predicate<Cmp&, projected_t<Proj, Derived>, projected_t<Proj, Derived>>
-    constexpr void sort(Cmp cmp = {}, Proj proj = {});
+                 strict_weak_order_for<Cmp, Derived>
+    constexpr void sort(Cmp cmp = {});
 
     constexpr auto product()
         requires foldable<Derived, std::multiplies<>, value_t<Derived>> &&

--- a/include/flux/core/predicates.hpp
+++ b/include/flux/core/predicates.hpp
@@ -11,7 +11,66 @@
 #include <functional>
 #include <type_traits>
 
-namespace flux::pred {
+namespace flux {
+
+template <typename Fn, typename Proj = std::identity>
+struct proj {
+    Fn fn;
+    Proj proj{};
+
+    template <typename... Args>
+    constexpr auto operator()(Args&&... args)
+        noexcept(noexcept(std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...)))
+        -> decltype(std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...))
+    {
+        return std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...);
+    }
+
+    template <typename... Args>
+    constexpr auto operator()(Args&&... args) const
+        noexcept(noexcept(std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...)))
+        -> decltype(std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...))
+    {
+        return std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...);
+    }
+};
+
+template <typename F, typename P = std::identity>
+proj(F, P = {}) -> proj<F, P>;
+
+template <typename Fn, typename Lhs = std::identity, typename Rhs = std::identity>
+struct proj2 {
+    Fn fn;
+    Lhs lhs{};
+    Rhs rhs{};
+
+    template <typename Arg1, typename Arg2>
+    constexpr auto operator()(Arg1&& arg1, Arg2&& arg2)
+        noexcept(noexcept(std::invoke(fn, std::invoke(lhs, FLUX_FWD(arg1)),
+                                          std::invoke(rhs, FLUX_FWD(arg2)))))
+        -> decltype(std::invoke(fn, std::invoke(lhs, FLUX_FWD(arg1)),
+                                    std::invoke(rhs, FLUX_FWD(arg2))))
+    {
+        return std::invoke(fn, std::invoke(lhs, FLUX_FWD(arg1)),
+                           std::invoke(rhs, FLUX_FWD(arg2)));
+    }
+
+    template <typename Arg1, typename Arg2>
+    constexpr auto operator()(Arg1&& arg1, Arg2&& arg2) const
+        noexcept(noexcept(std::invoke(fn, std::invoke(lhs, FLUX_FWD(arg1)),
+                                      std::invoke(rhs, FLUX_FWD(arg2)))))
+            -> decltype(std::invoke(fn, std::invoke(lhs, FLUX_FWD(arg1)),
+                                    std::invoke(rhs, FLUX_FWD(arg2))))
+    {
+        return std::invoke(fn, std::invoke(lhs, FLUX_FWD(arg1)),
+                           std::invoke(rhs, FLUX_FWD(arg2)));
+    }
+};
+
+template <typename F, typename L = std::identity, typename R = std::identity>
+proj2(F, L = {}, R = {}) -> proj2<F, L, R>;
+
+namespace pred {
 
 namespace detail {
 
@@ -138,6 +197,8 @@ inline constexpr auto odd = detail::predicate([](auto const& val) -> bool {
   return val % decltype(val){2} != decltype(val){0};
 });
 
-} // namespaces
+} // namespace pred
+
+} // namespace flux
 
 #endif

--- a/include/flux/core/predicates.hpp
+++ b/include/flux/core/predicates.hpp
@@ -16,22 +16,22 @@ namespace flux {
 template <typename Fn, typename Proj = std::identity>
 struct proj {
     Fn fn;
-    Proj proj{};
+    Proj prj{};
 
     template <typename... Args>
     constexpr auto operator()(Args&&... args)
-        noexcept(noexcept(std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...)))
-        -> decltype(std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...))
+        noexcept(noexcept(std::invoke(fn, std::invoke(prj, FLUX_FWD(args))...)))
+        -> decltype(std::invoke(fn, std::invoke(prj, FLUX_FWD(args))...))
     {
-        return std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...);
+        return std::invoke(fn, std::invoke(prj, FLUX_FWD(args))...);
     }
 
     template <typename... Args>
     constexpr auto operator()(Args&&... args) const
-        noexcept(noexcept(std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...)))
-        -> decltype(std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...))
+        noexcept(noexcept(std::invoke(fn, std::invoke(prj, FLUX_FWD(args))...)))
+        -> decltype(std::invoke(fn, std::invoke(prj, FLUX_FWD(args))...))
     {
-        return std::invoke(fn, std::invoke(proj, FLUX_FWD(args))...);
+        return std::invoke(fn, std::invoke(prj, FLUX_FWD(args))...);
     }
 };
 

--- a/include/flux/op/all_any_none.hpp
+++ b/include/flux/op/all_any_none.hpp
@@ -14,12 +14,12 @@ namespace flux {
 namespace all_detail {
 
 struct fn {
-    template <sequence Seq, typename Proj = std::identity,
-              predicate_for<Seq, Proj> Pred>
-    constexpr bool operator()(Seq&& seq, Pred pred, Proj proj = {}) const
+    template <sequence Seq, typename Pred>
+        requires std::predicate<Pred&, element_t<Seq>>
+    constexpr bool operator()(Seq&& seq, Pred pred) const
     {
         return is_last(seq, for_each_while(seq, [&](auto&& elem) {
-            return std::invoke(pred, std::invoke(proj, FLUX_FWD(elem)));
+            return std::invoke(pred, FLUX_FWD(elem));
         }));
     }
 };
@@ -31,12 +31,12 @@ inline constexpr auto all = all_detail::fn{};
 namespace none_detail {
 
 struct fn {
-    template <sequence Seq, typename Proj = std::identity,
-              predicate_for<Seq, Proj> Pred>
-    constexpr bool operator()(Seq&& seq, Pred pred, Proj proj = {}) const
+    template <sequence Seq, typename Pred>
+        requires std::predicate<Pred&, element_t<Seq>>
+    constexpr bool operator()(Seq&& seq, Pred pred) const
     {
         return is_last(seq, for_each_while(seq, [&](auto&& elem) {
-            return !std::invoke(pred, std::invoke(proj, FLUX_FWD(elem)));
+            return !std::invoke(pred, FLUX_FWD(elem));
         }));
     }
 };
@@ -48,12 +48,12 @@ inline constexpr auto none = none_detail::fn{};
 namespace any_detail {
 
 struct fn {
-    template <sequence Seq, typename Proj = std::identity,
-              predicate_for<Seq, Proj> Pred>
-    constexpr bool operator()(Seq&& seq, Pred pred, Proj proj = {}) const
+    template <sequence Seq, typename Pred>
+        requires std::predicate<Pred&, element_t<Seq>>
+    constexpr bool operator()(Seq&& seq, Pred pred) const
     {
         return !is_last(seq, for_each_while(seq, [&](auto&& elem) {
-            return !std::invoke(pred, std::invoke(proj, FLUX_FWD(elem)));
+            return !std::invoke(pred, FLUX_FWD(elem));
         }));
     }
 };
@@ -63,27 +63,27 @@ struct fn {
 inline constexpr auto any = any_detail::fn{};
 
 template <typename D>
-template <typename Pred, typename Proj>
-    requires predicate_for<Pred, D, Proj>
-constexpr auto inline_sequence_base<D>::all(Pred pred, Proj proj)
+template <typename Pred>
+    requires std::predicate<Pred&, element_t<D>>
+constexpr auto inline_sequence_base<D>::all(Pred pred)
 {
-    return flux::all(derived(), std::move(pred), std::move(proj));
+    return flux::all(derived(), std::move(pred));
 }
 
 template <typename D>
-template <typename Pred, typename Proj>
-    requires predicate_for<Pred, D, Proj>
-constexpr auto inline_sequence_base<D>::any(Pred pred, Proj proj)
+template <typename Pred>
+    requires std::predicate<Pred&, element_t<D>>
+constexpr auto inline_sequence_base<D>::any(Pred pred)
 {
-    return flux::any(derived(), std::move(pred), std::move(proj));
+    return flux::any(derived(), std::move(pred));
 }
 
 template <typename D>
-template <typename Pred, typename Proj>
-    requires predicate_for<Pred, D, Proj>
-constexpr auto inline_sequence_base<D>::none(Pred pred, Proj proj)
+template <typename Pred>
+    requires std::predicate<Pred&, element_t<D>>
+constexpr auto inline_sequence_base<D>::none(Pred pred)
 {
-    return flux::none(derived(), std::move(pred), std::move(proj));
+    return flux::none(derived(), std::move(pred));
 }
 
 } // namespace flux

--- a/include/flux/op/chunk_by.hpp
+++ b/include/flux/op/chunk_by.hpp
@@ -121,7 +121,7 @@ public:
 };
 
 struct chunk_by_fn {
-    template <adaptable_sequence Seq, typename Pred>
+    template <adaptable_sequence Seq, std::move_constructible Pred>
         requires multipass_sequence<Seq> &&
                  std::predicate<Pred&, element_t<Seq>, element_t<Seq>>
     [[nodiscard]]

--- a/include/flux/op/compare.hpp
+++ b/include/flux/op/compare.hpp
@@ -21,20 +21,18 @@ concept is_comparison_category =
     std::same_as<Cmp, std::partial_ordering>;
 
 struct compare_fn {
-    template <sequence Seq1, sequence Seq2, typename Cmp = std::compare_three_way,
-              typename Proj1 = std::identity, typename Proj2 = std::identity>
-        requires std::invocable<Cmp&, projected_t<Proj1, Seq1>, projected_t<Proj2, Seq2>> &&
-                 is_comparison_category<std::decay_t<std::invoke_result_t<Cmp&, projected_t<Proj1, Seq1>, projected_t<Proj2, Seq2>>>>
-    constexpr auto operator()(Seq1&& seq1, Seq2&& seq2, Cmp cmp = {},
-                              Proj1 proj1 = {}, Proj2 proj2 = {}) const
-        -> std::decay_t<std::invoke_result_t<Cmp&, projected_t<Proj1, Seq1>, projected_t<Proj2, Seq2>>>
+    template <sequence Seq1, sequence Seq2, typename Cmp = std::compare_three_way>
+        requires std::invocable<Cmp&, element_t<Seq1>, element_t<Seq2>> &&
+                 is_comparison_category<std::decay_t<std::invoke_result_t<Cmp&, element_t<Seq1>, element_t<Seq2>>>>
+    constexpr auto operator()(Seq1&& seq1, Seq2&& seq2, Cmp cmp = {}) const
+        -> std::decay_t<std::invoke_result_t<Cmp&, element_t<Seq1>, element_t<Seq2>>>
     {
         auto cur1 = flux::first(seq1);
         auto cur2 = flux::first(seq2);
 
         while (!flux::is_last(seq1, cur1) && !flux::is_last(seq2, cur2)) {
-            if (auto r = std::invoke(cmp, std::invoke(proj1, flux::read_at(seq1, cur1)),
-                                          std::invoke(proj2, flux::read_at(seq2, cur2))); r != 0) {
+            if (auto r = std::invoke(cmp, flux::read_at(seq1, cur1), flux::read_at(seq2, cur2));
+                r != 0) {
                 return r;
             }
             flux::inc(seq1, cur1);

--- a/include/flux/op/contains.hpp
+++ b/include/flux/op/contains.hpp
@@ -13,13 +13,13 @@ namespace flux {
 namespace detail {
 
 struct contains_fn {
-    template <sequence Seq, typename Value, typename Proj = std::identity>
-        requires std::equality_comparable_with<projected_t<Proj, Seq>, Value const&>
-    constexpr auto operator()(Seq&& seq, Value const& value, Proj proj = {}) const
+    template <sequence Seq, typename Value>
+        requires std::equality_comparable_with<element_t<Seq>, Value const&>
+    constexpr auto operator()(Seq&& seq, Value const& value) const
         -> bool
     {
         return !flux::is_last(seq, flux::for_each_while(seq, [&](auto&& elem) {
-            return std::invoke(proj, FLUX_FWD(elem)) != value;
+            return FLUX_FWD(elem) != value;
         }));
     }
 };
@@ -30,11 +30,11 @@ struct contains_fn {
 inline constexpr auto contains = detail::contains_fn{};
 
 template <typename D>
-template <typename Value, typename Proj>
-    requires std::equality_comparable_with<projected_t<Proj, D>, Value const&>
-constexpr auto inline_sequence_base<D>::contains(Value const& value, Proj proj) -> bool
+template <typename Value>
+    requires std::equality_comparable_with<element_t<D>, Value const&>
+constexpr auto inline_sequence_base<D>::contains(Value const& value) -> bool
 {
-    return flux::contains(derived(), value, std::move(proj));
+    return flux::contains(derived(), value);
 }
 
 } // namespace flux

--- a/include/flux/op/count.hpp
+++ b/include/flux/op/count.hpp
@@ -31,15 +31,15 @@ struct count_fn {
 };
 
 struct count_eq_fn {
-    template <sequence Seq, typename Value, typename Proj = std::identity>
-        requires std::equality_comparable_with<projected_t<Proj, Seq>, Value const&>
+    template <sequence Seq, typename Value>
+        requires std::equality_comparable_with<element_t<Seq>, Value const&>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Value const& value, Proj proj = {}) const
+    constexpr auto operator()(Seq&& seq, Value const& value) const
         -> distance_t
     {
         distance_t counter = 0;
         flux::for_each_while(seq, [&](auto&& elem) {
-            if (value == std::invoke(proj, FLUX_FWD(elem))) {
+            if (value == FLUX_FWD(elem)) {
                 ++counter;
             }
             return true;
@@ -49,15 +49,15 @@ struct count_eq_fn {
 };
 
 struct count_if_fn {
-    template <sequence Seq, typename Pred, typename Proj = std::identity>
-        requires predicate_for<Pred, Seq, Proj>
+    template <sequence Seq, typename Pred>
+        requires std::predicate<Pred&, element_t<Seq>>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Pred pred, Proj proj = {}) const
+    constexpr auto operator()(Seq&& seq, Pred pred) const
         -> distance_t
     {
         distance_t counter = 0;
         flux::for_each_while(seq, [&](auto&& elem) {
-            if (std::invoke(pred, std::invoke(proj, FLUX_FWD(elem)))) {
+            if (std::invoke(pred, FLUX_FWD(elem))) {
                 ++counter;
             }
             return true;
@@ -79,19 +79,19 @@ constexpr auto inline_sequence_base<D>::count()
 }
 
 template <typename D>
-template <typename Value, typename Proj>
-    requires std::equality_comparable_with<projected_t<Proj, D>, Value const&>
-constexpr auto inline_sequence_base<D>::count_eq(Value const& value, Proj proj)
+template <typename Value>
+    requires std::equality_comparable_with<element_t<D>, Value const&>
+constexpr auto inline_sequence_base<D>::count_eq(Value const& value)
 {
-    return flux::count_eq(derived(), value, std::move(proj));
+    return flux::count_eq(derived(), value);
 }
 
 template <typename D>
-template <typename Pred, typename Proj>
-    requires predicate_for<Pred, D, Proj>
-constexpr auto inline_sequence_base<D>::count_if(Pred pred, Proj proj)
+template <typename Pred>
+    requires std::predicate<Pred&, element_t<D>>
+constexpr auto inline_sequence_base<D>::count_if(Pred pred)
 {
-    return flux::count_if(derived(), std::move(pred), std::move(proj));
+    return flux::count_if(derived(), std::move(pred));
 }
 
 } // namespace flux

--- a/include/flux/op/drop_while.hpp
+++ b/include/flux/op/drop_while.hpp
@@ -61,7 +61,7 @@ public:
 };
 
 struct drop_while_fn {
-    template <adaptable_sequence Seq, typename Pred>
+    template <adaptable_sequence Seq, std::move_constructible Pred>
         requires std::predicate<Pred&, element_t<Seq>>
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq, Pred pred) const

--- a/include/flux/op/equal.hpp
+++ b/include/flux/op/equal.hpp
@@ -13,11 +13,9 @@ namespace flux {
 namespace detail {
 
 struct equal_fn {
-    template <sequence Seq1, sequence Seq2, typename Cmp = std::equal_to<>,
-              typename Proj1 = std::identity, typename Proj2 = std::identity>
-        requires std::predicate<Cmp&, projected_t<Proj1, Seq1>, projected_t<Proj2, Seq2>>
-    constexpr auto operator()(Seq1&& seq1, Seq2&& seq2, Cmp cmp = {},
-                              Proj1 proj1 = {}, Proj2 proj2 = {}) const -> bool
+    template <sequence Seq1, sequence Seq2, typename Cmp = std::ranges::equal_to>
+        requires std::predicate<Cmp&, element_t<Seq1>, element_t<Seq2>>
+    constexpr auto operator()(Seq1&& seq1, Seq2&& seq2, Cmp cmp = {}) const -> bool
     {
         if constexpr (sized_sequence<Seq1> && sized_sequence<Seq2>) {
             if (flux::size(seq1) != flux::size(seq2)) {
@@ -29,8 +27,7 @@ struct equal_fn {
         auto cur2 = flux::first(seq2);
 
         while (!flux::is_last(seq1, cur1) && !flux::is_last(seq2, cur2)) {
-            if (!std::invoke(cmp, std::invoke(proj1, flux::read_at(seq1, cur1)),
-                             std::invoke(proj2, flux::read_at(seq2, cur2)))) {
+            if (!std::invoke(cmp, flux::read_at(seq1, cur1), flux::read_at(seq2, cur2))) {
                 return false;
             }
             flux::inc(seq1, cur1);

--- a/include/flux/op/filter.hpp
+++ b/include/flux/op/filter.hpp
@@ -15,7 +15,6 @@ namespace flux {
 namespace detail {
 
 template <sequence Base, typename Pred>
-    requires std::predicate<Pred&, element_t<Base>&>
 class filter_adaptor : public inline_sequence_base<filter_adaptor<Base, Pred>>
 {
     FLUX_NO_UNIQUE_ADDRESS Base base_;
@@ -113,8 +112,8 @@ public:
 
 
 struct filter_fn {
-    template <adaptable_sequence Seq, typename Pred>
-        requires std::predicate<Pred&, element_t<Seq>&>
+    template <adaptable_sequence Seq, std::move_constructible Pred>
+        requires std::predicate<Pred&, element_t<Seq>>
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq, Pred pred) const
     {
@@ -128,7 +127,7 @@ inline constexpr auto filter = detail::filter_fn{};
 
 template <typename D>
 template <typename Pred>
-    requires std::predicate<Pred&, element_t<D>&>
+    requires std::predicate<Pred&, element_t<D>>
 constexpr auto inline_sequence_base<D>::filter(Pred pred) &&
 {
     return detail::filter_adaptor<D, Pred>(std::move(derived()), std::move(pred));

--- a/include/flux/op/find.hpp
+++ b/include/flux/op/find.hpp
@@ -13,37 +13,36 @@ namespace flux {
 namespace detail {
 
 struct find_fn {
-    template <sequence Seq, typename Value, typename Proj = std::identity>
-        requires std::equality_comparable_with<projected_t<Proj, Seq>, Value const&>
-    constexpr auto operator()(Seq&& seq, Value const& value,
-                              Proj proj = {}) const -> cursor_t<Seq>
+    template <sequence Seq, typename Value>
+        requires std::equality_comparable_with<element_t<Seq>, Value const&>
+    constexpr auto operator()(Seq&& seq, Value const& value) const -> cursor_t<Seq>
     {
         return for_each_while(seq, [&](auto&& elem) {
-            return std::invoke(proj, FLUX_FWD(elem)) != value;
+            return FLUX_FWD(elem) != value;
         });
     }
 };
 
 struct find_if_fn {
-    template <sequence Seq, typename Pred, typename Proj = std::identity>
-        requires std::predicate<Pred&, projected_t<Proj, Seq>>
-    constexpr auto operator()(Seq&& seq, Pred pred, Proj proj = {}) const
+    template <sequence Seq, typename Pred>
+        requires std::predicate<Pred&, element_t<Seq>>
+    constexpr auto operator()(Seq&& seq, Pred pred) const
         -> cursor_t<Seq>
     {
         return for_each_while(seq, [&](auto&& elem) {
-            return !std::invoke(pred, std::invoke(proj, FLUX_FWD(elem)));
+            return !std::invoke(pred, FLUX_FWD(elem));
         });
     }
 };
 
 struct find_if_not_fn {
-    template <sequence Seq, typename Pred, typename Proj = std::identity>
-        requires std::predicate<Pred&, projected_t<Proj, Seq>>
-    constexpr auto operator()(Seq&& seq, Pred pred, Proj proj = {}) const
+    template <sequence Seq, typename Pred>
+        requires std::predicate<Pred&, element_t<Seq>>
+    constexpr auto operator()(Seq&& seq, Pred pred) const
         -> cursor_t<Seq>
     {
         return for_each_while(seq, [&](auto&& elem) {
-            return std::invoke(pred, std::invoke(proj, FLUX_FWD(elem)));
+            return std::invoke(pred, FLUX_FWD(elem));
         });
     }
 };
@@ -55,27 +54,27 @@ inline constexpr auto find_if = detail::find_if_fn{};
 inline constexpr auto find_if_not = detail::find_if_not_fn{};
 
 template <typename D>
-template <typename Value, typename Proj>
-    requires std::equality_comparable_with<projected_t<Proj, D>, Value const&>
-constexpr auto inline_sequence_base<D>::find(Value const& val, Proj proj)
+template <typename Value>
+    requires std::equality_comparable_with<element_t<D>, Value const&>
+constexpr auto inline_sequence_base<D>::find(Value const& val)
 {
-    return flux::find(derived(), val, std::ref(proj));
+    return flux::find(derived(), val);
 }
 
 template <typename D>
-template <typename Pred, typename Proj>
-    requires predicate_for<Pred, D, Proj>
-constexpr auto inline_sequence_base<D>::find_if(Pred pred, Proj proj)
+template <typename Pred>
+    requires std::predicate<Pred&, element_t<D>>
+constexpr auto inline_sequence_base<D>::find_if(Pred pred)
 {
-    return flux::find_if(derived(), std::ref(pred), std::ref(proj));
+    return flux::find_if(derived(), std::ref(pred));
 }
 
 template <typename D>
-template <typename Pred, typename Proj>
-    requires predicate_for<Pred, D, Proj>
-constexpr auto inline_sequence_base<D>::find_if_not(Pred pred, Proj proj)
+template <typename Pred>
+    requires std::predicate<Pred&, element_t<D>>
+constexpr auto inline_sequence_base<D>::find_if_not(Pred pred)
 {
-    return flux::find_if_not(derived(), std::ref(pred), std::ref(proj));
+    return flux::find_if_not(derived(), std::ref(pred));
 }
 
 } // namespace flux

--- a/include/flux/op/for_each.hpp
+++ b/include/flux/op/for_each.hpp
@@ -14,13 +14,13 @@ namespace detail {
 
 struct for_each_fn {
 
-    template <sequence Seq, typename Func, typename Proj = std::identity>
-        requires (std::invocable<Func&, projected_t<Proj, Seq>> &&
+    template <sequence Seq, typename Func>
+        requires (std::invocable<Func&, element_t<Seq>> &&
                   !infinite_sequence<Seq>)
-    constexpr auto operator()(Seq&& seq, Func func, Proj proj = {}) const -> Func
+    constexpr auto operator()(Seq&& seq, Func func) const -> Func
     {
         (void) flux::for_each_while(FLUX_FWD(seq), [&](auto&& elem) {
-            std::invoke(func, std::invoke(proj, FLUX_FWD(elem)));
+            std::invoke(func, FLUX_FWD(elem));
             return true;
         });
         return func;
@@ -32,11 +32,11 @@ struct for_each_fn {
 inline constexpr auto for_each = detail::for_each_fn{};
 
 template <typename D>
-template <typename Func, typename Proj>
-    requires std::invocable<Func&, projected_t<Proj, D>>
-constexpr auto inline_sequence_base<D>::for_each(Func func, Proj proj) -> Func
+template <typename Func>
+    requires std::invocable<Func&, element_t<D>>
+constexpr auto inline_sequence_base<D>::for_each(Func func) -> Func
 {
-    return flux::for_each(derived(), std::move(func), std::move(proj));
+    return flux::for_each(derived(), std::move(func));
 }
 
 } // namespace flux

--- a/include/flux/op/requirements.hpp
+++ b/include/flux/op/requirements.hpp
@@ -30,6 +30,16 @@ concept foldable =
     std::invocable<Func&, Init, element_t<Seq>> &&
     detail::foldable_<Seq, Func, Init>;
 
+template <typename Fn, typename Seq1, typename Seq2 = Seq1>
+concept strict_weak_order_for =
+    sequence<Seq1> &&
+    sequence<Seq2> &&
+    std::strict_weak_order<Fn&, element_t<Seq1>, element_t<Seq2>> &&
+    std::strict_weak_order<Fn&, value_t<Seq1>&, element_t<Seq2>> &&
+    std::strict_weak_order<Fn&, element_t<Seq1>, value_t<Seq2>&> &&
+    std::strict_weak_order<Fn&, value_t<Seq1>&, value_t<Seq2>&> &&
+    std::strict_weak_order<Fn&, common_element_t<Seq1>, common_element_t<Seq2>>;
+
 } // namespace flux
 
 #endif // FLUX_OP_REQUIREMENTS_HPP_INCLUDED

--- a/include/flux/op/search.hpp
+++ b/include/flux/op/search.hpp
@@ -13,9 +13,10 @@ namespace flux {
 namespace detail {
 
 struct search_fn {
-    template <multipass_sequence Haystack, multipass_sequence Needle>
-        // Requires...
-    constexpr auto operator()(Haystack&& h, Needle&& n) const
+    template <multipass_sequence Haystack, multipass_sequence Needle,
+              typename Cmp = std::ranges::equal_to>
+        requires std::predicate<Cmp&, element_t<Haystack>, element_t<Needle>>
+    constexpr auto operator()(Haystack&& h, Needle&& n, Cmp cmp = {}) const
         -> bounds_t<Haystack>
     {
         auto hfirst = flux::first(h);
@@ -33,7 +34,7 @@ struct search_fn {
                     return {cur1, cur1};
                 }
 
-                if (read_at(h, cur1) != read_at(n, cur2)) {
+                if (!std::invoke(cmp, read_at(h, cur1), read_at(n, cur2))) {
                     break;
                 }
 

--- a/include/flux/op/sort.hpp
+++ b/include/flux/op/sort.hpp
@@ -11,15 +11,14 @@ namespace flux {
 namespace detail {
 
 struct sort_fn {
-    template <random_access_sequence Seq, typename Cmp = std::less<>,
-              typename Proj = std::identity>
+    template <random_access_sequence Seq, typename Cmp = std::ranges::less>
         requires bounded_sequence<Seq> &&
                  element_swappable_with<Seq, Seq> &&
-                 std::predicate<Cmp&, projected_t<Proj, Seq>, projected_t<Proj, Seq>>
-    constexpr auto operator()(Seq&& seq, Cmp cmp = {}, Proj proj = {}) const
+                 strict_weak_order_for<Cmp, Seq>
+    constexpr auto operator()(Seq&& seq, Cmp cmp = {}) const
     {
         auto wrapper = flux::unchecked(flux::ref(seq));
-        detail::pdqsort(wrapper, cmp, proj);
+        detail::pdqsort(wrapper, cmp);
     }
 };
 
@@ -28,14 +27,14 @@ struct sort_fn {
 inline constexpr auto sort = detail::sort_fn{};
 
 template <typename D>
-template <typename Cmp, typename Proj>
+template <typename Cmp>
     requires random_access_sequence<D> &&
              bounded_sequence<D> &&
              detail::element_swappable_with<D, D> &&
-             std::predicate<Cmp&, projected_t<Proj, D>, projected_t<Proj, D>>
-constexpr void inline_sequence_base<D>::sort(Cmp cmp, Proj proj)
+             strict_weak_order_for<Cmp, D>
+constexpr void inline_sequence_base<D>::sort(Cmp cmp)
 {
-    return flux::sort(derived(), std::move(cmp), std::move(proj));
+    return flux::sort(derived(), std::ref(cmp));
 }
 
 } // namespace flux

--- a/include/flux/op/take_while.hpp
+++ b/include/flux/op/take_while.hpp
@@ -35,8 +35,8 @@ public:
 };
 
 struct take_while_fn {
-    template <adaptable_sequence Seq, typename Pred>
-        requires std::predicate<Pred&, element_t<Seq>&>
+    template <adaptable_sequence Seq, std::move_constructible Pred>
+        requires std::predicate<Pred&, element_t<Seq>>
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq, Pred pred) const
     {

--- a/test/test_adjacent.cpp
+++ b/test/test_adjacent.cpp
@@ -209,15 +209,16 @@ constexpr bool test_adjacent()
 
         auto chunk = flux::chunk(arr, 3);
 
-        auto tuple_to_array = []<typename T>(T&& tuple) {
-            using array_t =  std::array<std::decay_t<std::tuple_element_t<0, T>>,
-                                        std::tuple_size_v<T>>;
+        auto tuple_to_array = []<typename T, typename D = std::decay_t<T>>(T&& tuple) {
+            using array_t =  std::array<std::decay_t<std::tuple_element_t<0, D>>,
+                                        std::tuple_size_v<D>>;
             return std::apply([](auto&&... args) {
                 return array_t{FLUX_FWD(args)...};
             }, FLUX_FWD(tuple));
         };
 
-        STATIC_CHECK(flux::equal(adj_n_stride, chunk, flux::equal, tuple_to_array));
+        STATIC_CHECK(flux::equal(adj_n_stride, chunk,
+                                 flux::proj2(flux::equal, tuple_to_array)));
     }
 
     // Reverse iteration works when underlying is bidir + bounded

--- a/test/test_compare.cpp
+++ b/test/test_compare.cpp
@@ -111,7 +111,8 @@ constexpr bool test_compare()
         std::array<Test, 3> arr1{Test{1}, {2}, {3}};
         Test arr2[] = {{1}, {2}, {3}};
 
-        auto r = flux::compare(arr1, arr2, {}, &Test::i, [](Test t) { return t.i; });
+        auto r = flux::compare(arr1, arr2,
+                               flux::proj2(std::compare_three_way{}, &Test::i, [](Test t) { return t.i; }));
         static_assert(std::same_as<decltype(r), std::strong_ordering>);
         STATIC_CHECK(r == std::strong_ordering::equal);
     }

--- a/test/test_contains.cpp
+++ b/test/test_contains.cpp
@@ -38,28 +38,6 @@ constexpr bool test_contains()
         STATIC_CHECK(not seq.contains('Z'));
     }
 
-    // Contains with projection
-    {
-        Test arr[] = { 1, 2, 3, 4, 5 };
-
-        STATIC_CHECK(flux::contains(arr, 3, &Test::get));
-        STATIC_CHECK(flux::contains(arr, 3, [](Test const& t) { return t.i; }));
-        STATIC_CHECK(not flux::contains(arr, 99, &Test::i));
-        STATIC_CHECK(flux::from(arr).contains(5, &Test::get));
-    }
-
-    // Check that contains short-circuits
-    {
-        int counter = 0;
-
-        int arr[] = {10, 20, 30, 40, 50};
-
-        bool b = flux::contains(arr, 40, [&](int i) { ++counter; return i; });
-
-        STATIC_CHECK(b);
-        STATIC_CHECK(counter == 4);
-    }
-
     return true;
 }
 static_assert(test_contains());

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -54,16 +54,6 @@ constexpr bool test_count()
         STATIC_CHECK(seq.count_eq(99) == 0);
     }
 
-    {
-        S arr[] = {1, 2, 2, 2, 3, 4, 5};
-
-        STATIC_CHECK(flux::count_eq(arr, 2, &S::i) == 3);
-        STATIC_CHECK(flux::from(arr).count_eq(2, &S::get) == 3);
-
-        STATIC_CHECK(flux::count_eq(arr, 99, &S::i) == 0);
-        STATIC_CHECK(flux::from(arr).count_eq(99, &S::get) == 0);
-    }
-
     return true;
 }
 static_assert(test_count());

--- a/test/test_count_if.cpp
+++ b/test/test_count_if.cpp
@@ -37,9 +37,9 @@ constexpr bool test_count_if()
     {
         S arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-        STATIC_CHECK(flux::count_if(arr, is_even, &S::i));
+        STATIC_CHECK(flux::count_if(arr, flux::proj(is_even, &S::i)));
 
-        STATIC_CHECK(flux::from(arr).count_if(is_even, &S::get));
+        STATIC_CHECK(flux::from(arr).count_if(flux::proj(is_even, &S::i)));
     }
 
     return true;

--- a/test/test_equal.cpp
+++ b/test/test_equal.cpp
@@ -32,6 +32,14 @@ constexpr bool test_equal()
         STATIC_CHECK(flux::equal(arr1, arr2));
     }
 
+    // Basic equal, same size but different elements
+    {
+        int arr1[] = {1, 2, 3, 4, 5};
+        int arr2[] = {1, 2, 99, 4, 5};
+
+        STATIC_CHECK(not flux::equal(arr1, arr2));
+    }
+
     // Different but comparable element types
     {
         int arr1[] = {1, 2, 3, 4, 5};

--- a/test/test_equal.cpp
+++ b/test/test_equal.cpp
@@ -76,7 +76,7 @@ constexpr bool test_equal()
         S arr1[] = {1, 2, 3, 4, 5};
         T arr2[] = {1, 2, 3, 4, 5};
 
-        STATIC_CHECK(flux::equal(arr1, arr2, {}, &S::i, &T::get));
+        STATIC_CHECK(flux::equal(arr1, arr2, flux::proj2(std::equal_to<>{}, &S::i, &T::get)));
     }
 
     // Two empty sequences compare equal if their element types are comparable

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -30,12 +30,6 @@ static_assert(not std::invocable<find_fn, int[10], S>);
 // Not equality comparable
 static_assert(not std::invocable<find_fn, S[10], S>);
 
-// Okay
-static_assert(std::invocable<find_fn, S[10], int, decltype(&S::i_)>);
-
-// Non-callable projection
-static_assert(not std::invocable<find_fn, int[10], int, int>);
-
 constexpr bool test_find()
 {
     {
@@ -60,20 +54,6 @@ constexpr bool test_find()
 
         cur = lens.find(99);
         if (!lens.is_last(cur)) {
-            return false;
-        }
-    }
-
-    {
-        S ss[] = { S{1}, S{2}, S{3}, S{4}, S{5} };
-
-        auto cur = flux::find(ss, 3, &S::i_);
-        if (cur != 2) {
-            return false;
-        }
-
-        cur = flux::find(ss, 99, &S::i_);
-        if (!flux::is_last(ss, cur)) {
             return false;
         }
     }

--- a/test/test_for_each.cpp
+++ b/test/test_for_each.cpp
@@ -52,15 +52,6 @@ constexpr bool test_for_each()
     }
 
     {
-        int sum = 0;
-        auto arr = std::array<S, 4>{ S{&sum, 0}, S{&sum, 2}, S{&sum, 4}, S{&sum, 6}};
-
-        flux::for_each(arr, [&sum](int i) { sum += i; },  &S::i_);
-
-        STATIC_CHECK(sum == 12);
-    }
-
-    {
         struct counter {
             constexpr void operator()(int i) { sum += i; }
             int sum = 0;

--- a/test/test_minmax.cpp
+++ b/test/test_minmax.cpp
@@ -37,13 +37,13 @@ constexpr bool test_min()
     // Can use custom comparator and projection
     {
         IntPair arr[] = { {1, 2}, {3, 4}, {5, 6}};
-        STATIC_CHECK(flux::min(arr, std::greater<>{}, &IntPair::a).value() == IntPair{5, 6});
+        STATIC_CHECK(flux::min(arr, flux::proj(std::greater<>{}, &IntPair::a)).value() == IntPair{5, 6});
     }
 
     // If several elements are equally minimal, returns the first
     {
         IntPair arr[] = { {1, 2}, {1, 3}, {1, 4}};
-        STATIC_CHECK(flux::min(arr, {}, &IntPair::a)->b == 2);
+        STATIC_CHECK(flux::min(arr, flux::proj(std::ranges::less{}, &IntPair::a))->b == 2);
     }
 
     return true;
@@ -68,13 +68,13 @@ constexpr bool test_max()
     // Can use custom comparator and projection
     {
         IntPair arr[] = { {1, 2}, {3, 4}, {5, 6}};
-        STATIC_CHECK(flux::max(arr, std::greater<>{}, &IntPair::a).value() == IntPair{1, 2});
+        STATIC_CHECK(flux::max(arr, flux::proj(std::greater<>{}, &IntPair::a)).value() == IntPair{1, 2});
     }
 
     // If several elements are equally maximal, returns the last
     {
         IntPair arr[] = { {1, 2}, {1, 3}, {1, 4}};
-        STATIC_CHECK(flux::max(arr, {}, &IntPair::a)->b == 4);
+        STATIC_CHECK(flux::max(arr, flux::proj(std::ranges::less{}, &IntPair::a))->b == 4);
     }
 
     return true;
@@ -103,7 +103,7 @@ constexpr bool test_minmax()
     // Can use custom comparator and projection
     {
         IntPair arr[] = { {1, 2}, {3, 4}, {5, 6}};
-        auto result = flux::minmax(arr, std::greater<>{}, &IntPair::a).value();
+        auto result = flux::minmax(arr, flux::proj(std::greater<>{}, &IntPair::a)).value();
         STATIC_CHECK(result.min == IntPair{5, 6});
         STATIC_CHECK(result.max == IntPair{1, 2});
     }
@@ -111,7 +111,7 @@ constexpr bool test_minmax()
     // If several elements are equally minimal/maximal, returns the first/last resp.
     {
         IntPair arr[] = { {1, 2}, {1, 3}, {1, 4}};
-        auto result = flux::minmax(arr, {}, &IntPair::a).value();
+        auto result = flux::minmax(arr, flux::proj(std::ranges::less{}, &IntPair::a)).value();
         STATIC_CHECK(result.min == IntPair{1, 2});
         STATIC_CHECK(result.max == IntPair{1, 4});
     }

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -82,8 +82,8 @@ constexpr bool test_sort_contexpr()
         };
 
         flux::zip(std::array{3, 2, 4, 1}, flux::ref(arr))
-            .sort(std::ranges::greater{},
-                  [](auto const& elem) { return std::get<0>(elem); });
+            .sort(flux::proj(std::ranges::greater{},
+                           [](auto const& elem) { return std::get<0>(elem); }));
 
         STATIC_CHECK(check_equal(arr, {"charlie"sv, "alpha"sv, "bravo"sv, "delta"sv}));
     }
@@ -158,7 +158,7 @@ void test_sort_projected(int sz)
     std::iota(ptr, ptr + sz, Int{0});
     std::shuffle(ptr, ptr + sz, gen);
 
-    flux::sort(span_seq(ptr, sz), {}, &Int::i);
+    flux::sort(span_seq(ptr, sz), flux::proj(std::less<>{}, &Int::i));
 
     CHECK(std::is_sorted(ptr, ptr + sz, [](Int lhs, Int rhs) {
         return lhs.i < rhs.i;
@@ -174,9 +174,8 @@ void test_heapsort(int sz)
 
     auto seq = span_seq(ptr, sz);
     auto cmp = std::ranges::less{};
-    auto proj = std::identity{};
-    flux::detail::make_heap(seq, cmp, proj);
-    flux::detail::sort_heap(seq, cmp, proj);
+    flux::detail::make_heap(seq, cmp);
+    flux::detail::sort_heap(seq, cmp);
 
     CHECK(std::is_sorted(ptr, ptr + sz));
     delete[] ptr;

--- a/test/test_unchecked.cpp
+++ b/test/test_unchecked.cpp
@@ -46,7 +46,7 @@ constexpr bool test_unchecked()
         static_assert(std::same_as<element_t<S>, std::pair<int&, double&>>);
         static_assert(std::same_as<rvalue_element_t<S>, std::pair<int&&, double&&>>);
 
-        seq.sort({}, [](auto p) { return p.second; });
+        seq.sort(flux::proj(std::less<>{}, [](auto p) { return p.second; }));
 
         STATIC_CHECK(check_equal(doubles, {1.0, 2.0, 3.0}));
         STATIC_CHECK(check_equal(ints, {3, 4, 5, 2, 1}));


### PR DESCRIPTION
I like projections in std::ranges. But they come don't come for free: there is a (small?) overhead in terms of compile times, and an added burden in terms of specification, concept formulation and documentation.

What this PR does is add two new function adaptors/combinators which provide the equivalent functionality to projection arguments to algorithms, but in an opt-in basis. So instead of saying, for example

```cpp
flux::sort(vec, std::less{}, &T::member);
```

you now say

```cpp
flux::sort(vec, flux::proj(std::less{}, &T::member));
```

This arguably makes it more clear what's actually happening -- that we're modifying the comparator function object.

The `proj` adaptor takes an n-ary callable `F` and a unary projection `P` and returns a new n-ary callable which, when invoked with arguments `args...`, calls `F(P(args)...)` -- that is, it applies the projection to each argument before calling `F`.

This covers most uses of projections in the library. The exceptions are algorithms which take two sequences and two (different) projections -- `equal()` and `compare()` for example. For this case we have another adaptor `proj2` (which should really be called `binary_project` or something like that, but it's a bit too long). This takes a binary callable `F` and two unary projections `L` and `R`, and constructs a binary callable which, when invokes with arguments `a` and `b` calls `F(L(a), R(b))` -- that is, it applies the left and right projection functions to the left and right arguments. (Theoretically we could make it all variadic and have N projections for an n-ary callable, but we only ever need two in Flux.)

Both `proj` and `proj2` are actually aggregate classes used via CTAD, meaning you can use designated initialisers to say, for example

```cpp
flux::equal(seq1, seq2, flux::proj2{.fn = std::equal_to{}, .lhs = &T::member, .rhs = &U::member});
```

which I actually think reads quite well.
