### PR TITLE
Add zip algorithms

### DIFF
--- a/docs/reference/algorithms.rst
+++ b/docs/reference/algorithms.rst
@@ -507,3 +507,38 @@ Algorithms
 ..  function::
     auto write_to(sequence auto&& seq, std::ostream& os) -> std::ostream&;
 
+``zip_find_if``
+---------------
+
+..  function::
+    template <typename Pred, sequence... Seqs> \
+        requires std::predicate<Pred&, element_t<Seqs>...> \
+    auto zip_find_if(Pred pred, Seqs&&... seqs) -> std::tuple<cursor_t<Seqs>...>;
+
+``zip_fold``
+------------
+
+..  type::
+    template <typename Func, typename Init, typename... Seqs> \
+    zip_fold_result_t = std::decay_t<std::invoke_result_t<Func&, Init, element_t<Seqs>...>>;
+
+..  function::
+    template <typename Func, typename Init, sequence... Seqs> \
+        requires see_below \
+    auto zip_fold(Func func, Init init, Seqs&&... seqs) -> zip_fold_result_t<Func, Init, Seqs...>;
+
+``zip_for_each``
+----------------
+
+..  function::
+    template <typename Func, sequence... Seqs> \
+        requires std::invocable<Func&, element_t<Seqs>...> \
+    auto zip_for_each(Func func, Seqs&&... seqs) -> Func;
+
+``zip_for_each_while``
+----------------------
+
+..  function::
+    template <typename Pred, sequence... Seqs> \
+        requires see_below \
+    auto zip_for_each_while(Pred pred, Seqs&&... seqs) -> std::tuple<cursor_t<Seqs>...>;

--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -38,9 +38,9 @@
 #include <flux/op/reverse.hpp>
 #include <flux/op/slice.hpp>
 #include <flux/op/slide.hpp>
+#include <flux/op/sort.hpp>
 #include <flux/op/split.hpp>
 #include <flux/op/split_string.hpp>
-#include <flux/op/sort.hpp>
 #include <flux/op/stride.hpp>
 #include <flux/op/swap_elements.hpp>
 #include <flux/op/take.hpp>
@@ -49,6 +49,7 @@
 #include <flux/op/unchecked.hpp>
 #include <flux/op/write_to.hpp>
 #include <flux/op/zip.hpp>
+#include <flux/op/zip_algorithms.hpp>
 
 #include <flux/source/array_ptr.hpp>
 #include <flux/source/empty.hpp>

--- a/include/flux/op/zip_algorithms.hpp
+++ b/include/flux/op/zip_algorithms.hpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_ZIP_ALGORITHMS_HPP_INCLUDED
+#define FLUX_OP_ZIP_ALGORITHMS_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+#include <flux/op/for_each_while.hpp>
+
+namespace flux {
+
+namespace detail {
+
+struct zip_for_each_while_fn {
+    template <typename Pred, sequence... Seqs>
+        requires std::invocable<Pred&, element_t<Seqs>...> &&
+                 boolean_testable<std::invoke_result_t<Pred&, element_t<Seqs>...>>
+    constexpr auto operator()(Pred pred, Seqs&&... seqs) const
+        -> std::tuple<cursor_t<Seqs>...>
+    {
+        if constexpr (sizeof...(Seqs) == 0) {
+            return std::tuple<>{};
+        } else if constexpr (sizeof...(Seqs) == 1) {
+            return std::tuple<cursor_t<Seqs>...>(flux::for_each_while(seqs..., std::ref(pred)));
+        } else {
+            return [&pred, &...seqs = seqs, ...curs = flux::first(seqs)]() mutable {
+                while (!(flux::is_last(seqs, curs) || ...)) {
+                    if (!std::invoke(pred, flux::read_at_unchecked(seqs, curs)...)) {
+                        break;
+                    }
+                    (flux::inc(seqs, curs), ...);
+                }
+                return std::tuple<cursor_t<Seqs>...>(std::move(curs)...);
+            }();
+        }
+    }
+};
+
+} // namespace detail
+
+inline constexpr auto zip_for_each_while = detail::zip_for_each_while_fn{};
+
+namespace detail {
+
+struct zip_for_each_fn {
+    template <std::move_constructible Func, sequence... Seqs>
+        requires std::invocable<Func&, element_t<Seqs>...>
+    constexpr auto operator()(Func func, Seqs&&... seqs) const -> Func
+    {
+        zip_for_each_while([&func](auto&&... elems) {
+            std::invoke(func, FLUX_FWD(elems)...);
+            return true;
+        }, seqs...);
+        return func;
+    }
+};
+
+struct zip_find_if_fn {
+    template <typename Pred, sequence... Seqs>
+        requires std::predicate<Pred&, element_t<Seqs>...>
+    constexpr auto operator()(Pred pred, Seqs&&... seqs) const
+        -> std::tuple<cursor_t<Seqs>...>
+    {
+        return zip_for_each_while(std::not_fn(pred), seqs...);
+    }
+};
+
+template <typename Func, typename Init, typename... Seqs>
+using zip_fold_result_t = std::decay_t<std::invoke_result_t<Func&, Init, element_t<Seqs>...>>;
+
+template <typename Func, typename Init, typename R, typename... Seqs>
+concept zip_foldable =
+    std::invocable<Func&, R, element_t<Seqs>...> &&
+    std::convertible_to<Init, R> &&
+    std::assignable_from<R&, std::invoke_result_t<Func&, R, element_t<Seqs>...>>;
+
+struct zip_fold_fn {
+    template <typename Func, std::movable Init, sequence... Seqs,
+              typename R = zip_fold_result_t<Func, Init, Seqs...>>
+        requires zip_foldable<Func, Init, R, Seqs...>
+    constexpr auto operator()(Func func, Init init, Seqs&&... seqs) const -> R
+    {
+        R init_ = R(std::move(init));
+        zip_for_each_while([&func, &init_](auto&&... elems) {
+            init_ = std::invoke(func, std::move(init_), FLUX_FWD(elems)...);
+            return true;
+        }, seqs...);
+        return init_;
+    }
+};
+
+} // namespace detail
+
+inline constexpr auto zip_for_each = detail::zip_for_each_fn{};
+inline constexpr auto zip_find_if = detail::zip_find_if_fn{};
+inline constexpr auto zip_fold = detail::zip_fold_fn{};
+
+} // namespace pred
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(test-libflux
     test_unchecked.cpp
     test_write_to.cpp
     test_zip.cpp
+    test_zip_algorithms.cpp
 
     test_array_ptr.cpp
     test_bitset.cpp

--- a/test/test_zip_algorithms.cpp
+++ b/test/test_zip_algorithms.cpp
@@ -121,6 +121,20 @@ constexpr bool test_zip_find_if()
         STATIC_CHECK(r == 2);
     }
 
+    // Check we can use zip_find_if to implement the STL's mismatch
+    {
+        int const arr1[] = {1, 2, 3, 4, 5};
+        std::array arr2 = {1, 2, 3, 5, 4};
+
+        auto [iter1, iter2] = std::ranges::mismatch(arr1, arr2);
+
+        auto [cur1, cur2] = flux::zip_find_if(std::not_equal_to{}, arr1, arr2);
+
+        STATIC_CHECK(*iter1 == arr1[cur1]);
+        STATIC_CHECK(*iter2 == arr2[cur2]);
+
+    }
+
     return true;
 }
 static_assert(test_zip_find_if());

--- a/test/test_zip_algorithms.cpp
+++ b/test/test_zip_algorithms.cpp
@@ -1,0 +1,179 @@
+
+// Copyright (c) 2022 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+#include <string_view>
+
+namespace {
+
+constexpr bool test_zip_for_each()
+{
+    // two sequences with stateful function obj
+    {
+        int arr1[] = {1, 2, 3, 4, 5};
+        std::array const arr2 = {100.0, 200.0, 300.0};
+
+        struct counter {
+            int int_sum = 0;
+            double double_sum = 0.0;
+
+            constexpr auto operator()(int i, double d) {
+                int_sum += i;
+                double_sum += d;
+            }
+        };
+
+        auto c = flux::zip_for_each(counter{}, arr1, arr2);
+
+        // Make sure we're getting the right type back out
+        static_assert(std::same_as<counter, decltype(c)>);
+
+        STATIC_CHECK(c.int_sum == 1 + 2 + 3);
+        STATIC_CHECK(c.double_sum = 100.0 + 200.0 + 300.0);
+    }
+
+    // zip_for_each with no sequences never calls the fn
+    {
+        bool called = false;
+        flux::zip_for_each([&] { called = true; });
+
+        STATIC_CHECK(called == false);
+    }
+
+    return true;
+}
+static_assert(test_zip_for_each());
+
+constexpr bool test_zip_find_if()
+{
+    // successful, two sequences
+    {
+        int arr1[] = {1, 2, 3, 4, 5};
+        std::array const arr2{5, 4, 3, 2, 1};
+
+        auto [idx1, idx2] = flux::zip_find_if(std::equal_to{}, arr1, arr2);
+
+        STATIC_CHECK(idx1 == 2);
+        STATIC_CHECK(idx2 == 2);
+    }
+
+    // unsuccessful, two sequences
+    {
+        int arr1[] = {1, 2, 3, 4, 5};
+        std::array const arr2{100.0, 200.0, 300.0};
+
+        auto [idx1, idx2] = flux::zip_find_if([](int i, double d) {
+            return i == 1 && d < 100;
+        }, arr1, arr2);
+
+        STATIC_CHECK(idx1 == 3); // We didn't exhaust sequence 1
+        STATIC_CHECK(idx2 == 3);
+        STATIC_CHECK(flux::is_last(arr2, idx2));
+    }
+
+    // successful, one sequence, equivalent to find_if
+    {
+        int arr[] = {1, 2, 3, 4, 5};
+
+        auto [idx] = flux::zip_find_if(flux::pred::eq(3), arr);
+
+        STATIC_CHECK(idx == 2);
+    }
+
+    // unsuccessful, one sequence
+    {
+        int arr[] = {1, 2, 3, 4, 5};
+
+        auto [idx] = flux::zip_find_if(flux::pred::gt(10), arr);
+
+        STATIC_CHECK(flux::is_last(arr, idx));
+    }
+
+    // zero sequences (just make sure it compiles)
+    {
+        auto r = flux::zip_find_if([] { return true; });
+        STATIC_CHECK(r == std::tuple<>{});
+    }
+
+    // Check we can use zip_find_if to implement the STL's adjacent_find
+    {
+        int const arr[] = {1, 2, 3, 3, 4, 5, 6};
+
+        auto adjacent_find = [](flux::sequence auto&& seq) {
+            auto [a, b] = flux::zip_find_if(std::equal_to{}, seq, flux::ref(seq).drop(1));
+            if (flux::is_last(seq, b)) {
+                return b;
+            } else {
+                return a;
+            }
+        };
+
+        auto r = adjacent_find(arr);
+
+        STATIC_CHECK(r == 2);
+    }
+
+    return true;
+}
+static_assert(test_zip_find_if());
+
+constexpr bool test_zip_fold()
+{
+    // Summing two sequences at the same time
+    {
+        int arr1[] = {1, 2, 3, 4, 5};
+        std::array const arr2 = {100.0, 200.0, 300.0};
+
+        struct counter {
+            int int_sum;
+            double double_sum;
+        };
+
+        auto r = flux::zip_fold([](counter c, int i, double d) {
+            c.int_sum += i;
+            c.double_sum += d;
+            return c;
+        }, counter{}, arr1, arr2);
+
+        static_assert(std::same_as<counter, decltype(r)>);
+
+        STATIC_CHECK(r.int_sum == 6);
+        STATIC_CHECK(r.double_sum == 600.0);
+    }
+
+    // We can implement something like an adjacent_fold
+    {
+        int const arr[] = {1, 2, 3, 4, 5};
+
+        auto plus = [](auto... a) { return (a + ...); };
+
+        auto sum = flux::zip_fold(plus, 0, arr, flux::ref(arr).drop(1), flux::ref(arr).drop(2));
+
+        STATIC_CHECK(sum == (1 + 2 + 3) + (2 + 3 + 4) + (3 + 4 + 5));
+    }
+
+    return true;
+}
+static_assert(test_zip_fold());
+
+}
+
+TEST_CASE("zip algorithms")
+{
+    bool r = test_zip_for_each();
+    REQUIRE(r);
+
+    r = test_zip_find_if();
+    REQUIRE(r);
+
+    r = test_zip_fold();
+    REQUIRE(r);
+}


### PR DESCRIPTION
This commit adds four new algorithms which duplicate the existing low-level single-sequence algorithms we already have, but operate on a variadic pack of sequences in lock-step.

First up is `zip_for_each_while()`, the multi-sequence analogue of our existing `for_each_while()` -- except that it's not a customisation point (though it will call a customised `for_each_while()` if passed a single sequence). Like the single-sequence version, it's effectively `find_if_not()` with a weakened precondition on the passed-in predicate and forms the root of all of the other functions.

The other functions are:
 * `zip_for_each()`, which just calls `zip_for_each_while()` with a predicate that always returns true
 * `zip_find_if()` which just calls `zip_for_each_while()` with a negated predicate
 * `zip_fold()`, which calls `zip_for_each()` with a function that updates the accumulator in each call

So basically exactly what we do in the single-sequence case, but generalised to operate on multiple sequences at once.

Thanks to @codereport for pointing out that `zip_find_if` is a much better name than `mismatch`