### PR TITLE
Fix issue 47

### DIFF
--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -266,8 +266,8 @@ constexpr bool is_ilist<T, std::initializer_list<E>> = true;
 
 template <typename Seq>
 concept rvalue_sequence =
-    !std::is_reference_v<Seq> &&
-    std::movable<Seq> &&
+    std::is_object_v<Seq> &&
+    std::move_constructible<Seq> &&
     sequence<Seq>;
 
 template <typename Seq>

--- a/include/flux/op/zip.hpp
+++ b/include/flux/op/zip.hpp
@@ -84,7 +84,9 @@ public:
 
     static constexpr bool is_infinite = (infinite_sequence<Bases> && ...);
 
-    static constexpr auto first(auto& self)
+    template <typename Self>
+        requires (sequence<const_like_t<Self, Bases>> && ...)
+    static constexpr auto first(Self& self)
     {
         return std::apply([](auto&&... args) {
             return tuple_t<decltype(flux::first(FLUX_FWD(args)))...>(flux::first(FLUX_FWD(args))...);
@@ -92,6 +94,7 @@ public:
     }
 
     template <typename Self>
+        requires (sequence<const_like_t<Self, Bases>> && ...)
     static constexpr bool is_last(Self& self, cursor_t<Self> const& cur)
     {
         return [&self, &cur]<std::size_t... I>(std::index_sequence<I...>) {
@@ -100,12 +103,14 @@ public:
     }
 
     template <typename Self>
+        requires (sequence<const_like_t<Self, Bases>> && ...)
     static constexpr auto read_at(Self& self, cursor_t<Self> const& cur)
     {
         return read_(flux::read_at, self, cur);
     }
 
     template <typename Self>
+        requires (sequence<const_like_t<Self, Bases>> && ...)
     static constexpr auto& inc(Self& self, cursor_t<Self>& cur)
     {
         [&]<std::size_t... I>(std::index_sequence<I...>) {
@@ -116,8 +121,8 @@ public:
     }
 
     template <typename Self>
-    static constexpr auto& dec(Self& self, cursor_t<Self>& cur)
         requires (bidirectional_sequence<const_like_t<Self, Bases>> && ...)
+    static constexpr auto& dec(Self& self, cursor_t<Self>& cur)
     {
         [&]<std::size_t... I>(std::index_sequence<I...>) {
             (flux::dec(std::get<I>(self.bases_), std::get<I>(cur)), ...);
@@ -127,8 +132,8 @@ public:
     }
 
     template <typename Self>
-    static constexpr auto& inc(Self& self, cursor_t<Self>& cur, distance_t offset)
         requires (random_access_sequence<const_like_t<Self, Bases>> && ...)
+    static constexpr auto& inc(Self& self, cursor_t<Self>& cur, distance_t offset)
     {
         [&]<std::size_t... I>(std::index_sequence<I...>) {
             (flux::inc(std::get<I>(self.bases_), std::get<I>(cur), offset), ...);
@@ -138,9 +143,9 @@ public:
     }
 
     template <typename Self>
+        requires (random_access_sequence<const_like_t<Self, Bases>> && ...)
     static constexpr auto distance(Self& self, cursor_t<Self> const& from,
                                    cursor_t<Self> const& to)
-        requires (random_access_sequence<const_like_t<Self, Bases>> && ...)
     {
         return [&]<std::size_t... I>(std::index_sequence<I...>) {
             return std::min({flux::distance(std::get<I>(self.bases_), std::get<I>(from), std::get<I>(to))...});
@@ -148,17 +153,17 @@ public:
     }
 
     template <typename Self>
-    static constexpr auto last(Self& self)
         requires (random_access_sequence<const_like_t<Self, Bases>> && ...)
-            && (sized_sequence<const_like_t<Self, Bases>> && ...)
+                && (sized_sequence<const_like_t<Self, Bases>> && ...)
+    static constexpr auto last(Self& self)
     {
         auto cur = first(self);
         return inc(self, cur, size(self));
     }
 
     template <typename Self>
-    static constexpr auto size(Self& self)
         requires (sized_sequence<const_like_t<Self, Bases>> && ...)
+    static constexpr auto size(Self& self)
     {
         return std::apply([&](auto&... args) {
             return std::min({flux::size(args)...});
@@ -166,18 +171,21 @@ public:
     }
 
     template <typename Self>
+        requires (sequence<const_like_t<Self, Bases>> && ...)
     static constexpr auto move_at(Self& self, cursor_t<Self> const& cur)
     {
         return read_(flux::move_at, self, cur);
     }
 
     template <typename Self>
+        requires (sequence<const_like_t<Self, Bases>> && ...)
     static constexpr auto read_at_unchecked(Self& self, cursor_t<Self> const& cur)
     {
         return read_(flux::read_at_unchecked, self, cur);
     }
 
     template <typename Self>
+        requires (sequence<const_like_t<Self, Bases>> && ...)
     static constexpr auto move_at_unchecked(Self& self, cursor_t<Self> const& cur)
     {
         return read_(flux::move_at_unchecked, self, cur);

--- a/test/test_zip.cpp
+++ b/test/test_zip.cpp
@@ -166,10 +166,25 @@ constexpr bool test_zip()
 }
 static_assert(test_zip());
 
+// https://github.com/tcbrindle/flux/issues/47
+constexpr bool issue_47()
+{
+    std::array v = {1, 2, 3, 4, 5};
+    auto res = flux::zip(flux::ints(), flux::from(v).filter(flux::pred::gt(3)));
+
+    for ([[maybe_unused]] auto [a, b] : res) {}
+
+    return true;
+}
+static_assert(issue_47());
+
 }
 
 TEST_CASE("zip")
 {
     bool result = test_zip();
+    REQUIRE(result);
+
+    result = issue_47();
     REQUIRE(result);
 }


### PR DESCRIPTION
 * Use `std::move_constructible<S>` constraint in `rvalue_sequence` concept (rather than `std::movable`)
 * Correctly constrain all of `zip_adaptor`'s sequence impl functions