### PR TITLE
Fix issue #52

### DIFF
--- a/include/flux/op/reverse.hpp
+++ b/include/flux/op/reverse.hpp
@@ -28,9 +28,6 @@ struct rev_cur {
     }
 };
 
-template <typename B>
-rev_cur(B&&) -> rev_cur<std::remove_cvref_t<B>>;
-
 template <bidirectional_sequence Base>
     requires bounded_sequence<Base>
 struct reverse_adaptor : inline_sequence_base<reverse_adaptor<Base>>
@@ -80,12 +77,12 @@ struct sequence_traits<detail::reverse_adaptor<Base>>
 
     static constexpr auto first(auto& self)
     {
-        return detail::rev_cur(flux::last(self.base_));
+        return detail::rev_cur<cursor_t<Base>>(flux::last(self.base_));
     }
 
     static constexpr auto last(auto& self)
     {
-        return detail::rev_cur(flux::first(self.base_));
+        return detail::rev_cur<cursor_t<Base>>(flux::first(self.base_));
     }
 
     static constexpr auto is_last(auto& self, auto const& cur) -> bool
@@ -149,7 +146,7 @@ struct sequence_traits<detail::reverse_adaptor<Base>>
             }
         }
 
-        return detail::rev_cur(flux::inc(self.base_, cur));
+        return detail::rev_cur<cursor_t<Base>>(flux::inc(self.base_, cur));
     }
 };
 

--- a/include/flux/op/reverse.hpp
+++ b/include/flux/op/reverse.hpp
@@ -13,29 +13,12 @@ namespace flux {
 
 namespace detail {
 
-template <typename BaseCur>
-struct rev_cur {
-    BaseCur base_cur;
-
-    friend bool operator==(rev_cur const&, rev_cur const&)
-        requires std::equality_comparable<BaseCur>
-        = default;
-
-    friend std::strong_ordering operator<=>(rev_cur const& lhs, rev_cur const& rhs)
-        requires std::three_way_comparable<BaseCur>
-    {
-        return rhs <=> lhs;
-    }
-};
-
 template <bidirectional_sequence Base>
     requires bounded_sequence<Base>
 struct reverse_adaptor : inline_sequence_base<reverse_adaptor<Base>>
 {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
-
-    friend struct sequence_traits<reverse_adaptor>;
 
 public:
     constexpr explicit reverse_adaptor(decays_to<Base> auto&& base)
@@ -44,6 +27,107 @@ public:
 
     [[nodiscard]] constexpr auto base() const& -> Base const& { return base_; }
     [[nodiscard]] constexpr auto base() && -> Base&& { return std::move(base_); }
+
+    struct flux_sequence_traits {
+    private:
+        struct cursor_type {
+            cursor_t<Base> base_cur;
+
+            friend bool operator==(cursor_type const&, cursor_type const&)
+                requires std::equality_comparable<cursor_t<Base>>
+            = default;
+
+            friend auto operator<=>(cursor_type const& lhs, cursor_type const& rhs)
+                -> std::strong_ordering
+                requires std::three_way_comparable<cursor_t<Base>, std::strong_ordering>
+            {
+                return rhs <=> lhs;
+            }
+        };
+
+    public:
+        using value_type = value_t<Base>;
+
+        static constexpr auto first(auto& self) -> cursor_type
+        {
+            return cursor_type(flux::last(self.base_));
+        }
+
+        static constexpr auto last(auto& self) -> cursor_type
+        {
+            return cursor_type(flux::first(self.base_));
+        }
+
+        static constexpr auto is_last(auto& self, cursor_type const& cur) -> bool
+        {
+            return cur.base_cur == flux::first(self.base_);
+        }
+
+        static constexpr auto read_at(auto& self, cursor_type const& cur) -> decltype(auto)
+        {
+            return flux::read_at(self.base_, flux::prev(self.base_, cur.base_cur));
+        }
+
+        static constexpr auto read_at_unchecked(auto& self, cursor_type const& cur) -> decltype(auto)
+        {
+            return flux::read_at_unchecked(self.base_, flux::prev(self.base_, cur.base_cur));
+        }
+
+        static constexpr auto move_at(auto& self, cursor_type const& cur) -> decltype(auto)
+        {
+            return flux::move_at(self.base_, flux::prev(self.base_, cur.base_cur));
+        }
+
+        static constexpr auto move_at_unchecked(auto& self, cursor_type const& cur) -> decltype(auto)
+        {
+            return flux::move_at_unchecked(self.base_, flux::prev(self.base_, cur.base_cur));
+        }
+
+        static constexpr auto inc(auto& self, cursor_type& cur) -> void
+        {
+            flux::dec(self.base_, cur.base_cur);
+        }
+
+
+        static constexpr auto dec(auto& self, cursor_type& cur) -> void
+        {
+            flux::inc(self.base_, cur.base_cur);
+        }
+
+        static constexpr auto inc(auto& self, cursor_type& cur, distance_t dist) -> void
+            requires random_access_sequence<decltype(self.base_)>
+        {
+            flux::inc(self.base_, cur.base_cur, -dist);
+        }
+
+        static constexpr auto distance(auto& self, cursor_type const& from, cursor_type const& to)
+            -> distance_t
+            requires random_access_sequence<decltype(self.base_)>
+        {
+            return flux::distance(self.base_, to.base_cur, from.base_cur);
+        }
+
+        static constexpr auto size(auto& self) -> distance_t
+            requires sized_sequence<decltype(self.base_)>
+        {
+            return flux::size(self.base_);
+        }
+
+        static constexpr auto for_each_while(auto& self, auto&& pred)
+        {
+            auto cur = flux::last(self.base_);
+            const auto end = flux::first(self.base_);
+
+            while (cur != end) {
+                flux::dec(self.base_, cur);
+                if (!std::invoke(pred, flux::read_at(self.base_, cur))) {
+                    break;
+                }
+            }
+
+            return cursor_type(flux::inc(self.base_, cur));
+        }
+    };
 };
 
 template <typename>
@@ -69,86 +153,6 @@ struct reverse_fn {
 };
 
 } // namespace detail
-
-template <typename Base>
-struct sequence_traits<detail::reverse_adaptor<Base>>
-{
-    using value_type = value_t<Base>;
-
-    static constexpr auto first(auto& self)
-    {
-        return detail::rev_cur<cursor_t<Base>>(flux::last(self.base_));
-    }
-
-    static constexpr auto last(auto& self)
-    {
-        return detail::rev_cur<cursor_t<Base>>(flux::first(self.base_));
-    }
-
-    static constexpr auto is_last(auto& self, auto const& cur) -> bool
-    {
-        return cur.base_cur == flux::first(self.base_);
-    }
-
-    static constexpr auto read_at(auto& self, auto const& cur) -> decltype(auto)
-    {
-        return flux::read_at(self.base_, flux::prev(self.base_, cur.base_cur));
-    }
-
-    static constexpr auto inc(auto& self, auto& cur) -> auto&
-    {
-        flux::dec(self.base_, cur.base_cur);
-        return cur;
-    }
-
-    static constexpr auto dec(auto& self, auto& cur) -> auto&
-    {
-        flux::inc(self.base_, cur.base_cur);
-        return cur;
-    }
-
-    static constexpr auto inc(auto& self, auto& cur, auto dist) -> auto&
-        requires random_access_sequence<decltype(self.base_)>
-    {
-        flux::inc(self.base_, cur.base_cur, -dist);
-        return cur;
-    }
-
-    static constexpr auto distance(auto& self, auto const& from, auto const& to)
-        requires random_access_sequence<decltype(self.base_)>
-    {
-        return flux::distance(self.base_, to.base_cur, from.base_cur);
-    }
-
-    // FIXME: GCC11 ICE
-#if GCC_ICE
-    static constexpr auto size(auto& self)
-        requires sized_sequence<decltype(self.base_)>
-    {
-        return flux::size(self.base_);
-    }
-#endif
-
-    static constexpr auto move_at(auto& self, auto const& cur) -> decltype(auto)
-    {
-        return flux::move_at(self.base_, cur.base_cur);
-    }
-
-    static constexpr auto for_each_while(auto& self, auto&& pred)
-    {
-        auto cur = flux::last(self.base_);
-        const auto end = flux::first(self.base_);
-
-        while (cur != end) {
-            flux::dec(self.base_, cur);
-            if (!std::invoke(pred, flux::read_at(self.base_, cur))) {
-                break;
-            }
-        }
-
-        return detail::rev_cur<cursor_t<Base>>(flux::inc(self.base_, cur));
-    }
-};
 
 inline constexpr auto reverse = detail::reverse_fn{};
 

--- a/test/test_reverse.cpp
+++ b/test/test_reverse.cpp
@@ -86,11 +86,34 @@ constexpr bool test_reverse()
 }
 static_assert(test_reverse());
 
+// Regression test for #52
+// https://github.com/tcbrindle/flux/issues/52
+constexpr bool issue_52()
+{
+    std::string_view in = "   abc   ";
+    std::string_view out = "abc";
+
+    auto is_space = flux::pred::in(' ', '\t', '\n', '\r');
+
+    auto seq = flux::drop_while(in, is_space)
+                    .reverse()
+                    .drop_while(is_space)
+                    .reverse();
+
+    STATIC_CHECK(check_equal(seq, out));
+
+    return true;
+}
+static_assert(issue_52());
+
 }
 
 TEST_CASE("reverse")
 {
     bool result = test_reverse();
+    REQUIRE(result);
+
+    result = issue_52();
     REQUIRE(result);
 
     {
@@ -106,6 +129,6 @@ TEST_CASE("reverse")
         // static_assert(flux::sized_sequence<R>);
        // static_assert(flux::bounded_sequence<R>);
 
-       // REQUIRE(check_equal(rlist, {4, 3, 2, 1, 0}));
+        REQUIRE(check_equal(rlist, {4, 3, 2, 1, 0}));
     }
 }

--- a/test/test_reverse.cpp
+++ b/test/test_reverse.cpp
@@ -123,11 +123,10 @@ TEST_CASE("reverse")
         using R = decltype(rlist);
 
         static_assert(flux::regular_cursor<flux::cursor_t<R>>);
-      //  static_assert(flux::bidirectional_sequence<R>);
-     //   static_assert(not flux::random_access_sequence<R>);
-        // FIXME: GCC ICE
-        // static_assert(flux::sized_sequence<R>);
-       // static_assert(flux::bounded_sequence<R>);
+        static_assert(flux::bidirectional_sequence<R>);
+        static_assert(not flux::random_access_sequence<R>);
+        static_assert(flux::sized_sequence<R>);
+        static_assert(flux::bounded_sequence<R>);
 
         REQUIRE(check_equal(rlist, {4, 3, 2, 1, 0}));
     }


### PR DESCRIPTION
`reverse_adaptor` needs to wrap the underlying cursor in order to provide a "reversed" `operator<=>` when the underlying cursor is ordered. To do so it uses an internal type called `rev_cur`.

Previously we were being cute and using CTAD to just call `rev_cur(base_cur)`. But if `base_cur` itself is a specialisation of `rev_cur` then this will result in the base cursor being copy/move constructed rather than wrapped.

To avoid this issue we'll explicitly instantiate `rev_cur<cursor_t<Base>>(base_cur)` instead.