### PR TITLE
Ensure take() and drop() handle out-of-range arguments

### DIFF
--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -230,7 +230,7 @@ public:
     constexpr auto chunk_by(Pred pred) &&;
 
     [[nodiscard]]
-    constexpr auto drop(distance_t count) &&;
+    constexpr auto drop(std::integral auto count) &&;
 
     template <typename Pred>
         requires std::predicate<Pred&, element_t<Derived>>

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -283,7 +283,7 @@ public:
     constexpr auto stride(std::integral auto by) &&;
 
     [[nodiscard]]
-    constexpr auto take(distance_t count) &&;
+    constexpr auto take(std::integral auto count) &&;
 
     template <typename Pred>
         requires std::predicate<Pred&, element_t<Derived>>

--- a/include/flux/op/take.hpp
+++ b/include/flux/op/take.hpp
@@ -101,8 +101,8 @@ public:
             -> distance_t
             requires random_access_sequence<Base>
         {
-            return std::min(flux::distance(self.base_, from.base_cur, to.base_cur),
-                            num::checked_sub(from.length, to.length));
+            return (std::min)(flux::distance(self.base_, from.base_cur, to.base_cur),
+                              num::checked_sub(from.length, to.length));
         }
 
         static constexpr auto data(auto& self)
@@ -115,7 +115,7 @@ public:
         static constexpr auto size(auto& self)
             requires sized_sequence<Base>
         {
-            return std::min(flux::size(self.base_), self.count_);
+            return (std::min)(flux::size(self.base_), self.count_);
         }
 
         static constexpr auto last(auto& self) -> cursor_type
@@ -142,9 +142,14 @@ public:
 struct take_fn {
     template <adaptable_sequence Seq>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, distance_t count) const
+    constexpr auto operator()(Seq&& seq, std::integral auto count) const
     {
-        return take_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq), count);
+        auto count_ = checked_cast<distance_t>(count);
+        if (count_ < 0) {
+            runtime_error("Negative argument passed to take()");
+        }
+
+        return take_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq), count_);
     }
 };
 
@@ -153,9 +158,9 @@ struct take_fn {
 inline constexpr auto take = detail::take_fn{};
 
 template <typename Derived>
-constexpr auto inline_sequence_base<Derived>::take(distance_t count) &&
+constexpr auto inline_sequence_base<Derived>::take(std::integral auto count) &&
 {
-    return detail::take_adaptor<Derived>(std::move(derived()), count);
+    return flux::take(std::move(derived()), count);
 }
 
 } // namespace flux

--- a/test/test_take.cpp
+++ b/test/test_take.cpp
@@ -10,6 +10,7 @@
 #include "test_utils.hpp"
 
 #include <array>
+#include <list>
 
 namespace {
 
@@ -39,6 +40,7 @@ constexpr bool test_take()
         static_assert(flux::sized_sequence<T const>);
 
         STATIC_CHECK(taken.size() == 3);
+        STATIC_CHECK(taken.data() == arr);
         STATIC_CHECK(check_equal(taken, {0, 1, 2}));
     }
 
@@ -71,6 +73,41 @@ constexpr bool test_take()
         STATIC_CHECK(check_equal(taken, {0, 1, 2}));
     }
 
+    // test taking all the elements
+    {
+        auto arr = std::array{1, 2, 3, 4, 5};
+
+        auto taken = flux::ref(arr).take(5);
+
+        STATIC_CHECK(taken.size() == 5);
+        STATIC_CHECK(taken.data() == arr.data());
+        STATIC_CHECK(check_equal(taken, arr));
+    }
+
+    // test taking "too many" elements
+    {
+        auto arr = std::array{1, 2, 3, 4, 5};
+
+        auto taken = flux::take(flux::ref(arr), 1'000'000);
+
+        STATIC_CHECK(taken.usize() == arr.size());
+        STATIC_CHECK(taken.data() == arr.data());
+        STATIC_CHECK(check_equal(taken, arr));
+    }
+
+    // test taking zero elements
+    {
+        auto arr = std::array{1, 2, 3, 4, 5};
+
+        auto taken = flux::take(flux::ref(arr), 0);
+
+        STATIC_CHECK(taken.is_empty());
+        STATIC_CHECK(taken.size() == 0);
+        STATIC_CHECK(taken.distance(taken.first(), taken.last()) == 0);
+        // We still want this to be true
+        STATIC_CHECK(taken.data() == arr.data());
+    }
+
     return true;
 }
 static_assert(test_take());
@@ -81,4 +118,13 @@ TEST_CASE("take")
 {
     bool result = test_take();
     REQUIRE(result);
+
+    // test taking a negative number of elements
+    {
+        std::list list{1, 2, 3, 4, 5};
+
+        REQUIRE_THROWS_AS(flux::take(flux::from_range(list), -1000), flux::unrecoverable_error);
+
+        REQUIRE_THROWS_AS(flux::from_range(list).take(-1000), flux::unrecoverable_error);
+    }
 }


### PR DESCRIPTION
 * Make `take()` and `drop()` accept arguments of any integral type, and perform a checked cast to `distance_t`
 * If passed a negative argument, raise a `runtime_error()`
 * Correctly handle arguments larger than the sequence size by taking/dropping the entire sequence, and ensure we report the correct thing in `size()`.