### PR TITLE
CI: test with GCC13

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Debug, Release]
-        cxx: [g++-11, g++-12]
+        cxx: [g++-11, g++-12, g++-13]
         include:
           - cxx: g++-11
             install: |
@@ -21,6 +21,10 @@ jobs:
           - cxx: g++-12
             install: |
               brew install gcc@12 ninja binutils
+              brew link --force binutils
+          - cxx: g++-13
+            install: |
+              brew install gcc@13 ninja binutils
               brew link --force binutils
 
     steps:


### PR DESCRIPTION
Now that GCC13 has been released, we should add it to our CI set up.