### PR TITLE
Make sure we actually run tests at runtime

### DIFF
--- a/test/test_adjacent.cpp
+++ b/test/test_adjacent.cpp
@@ -25,6 +25,7 @@ constexpr bool tuple_equal(Lhs const& lhs, Rhs const& rhs)
             impl(std::make_index_sequence<std::tuple_size_v<Lhs>>{});
 }
 
+template <bool = true>
 constexpr bool test_pairwise()
 {
     // Basic pairwise
@@ -126,6 +127,7 @@ constexpr bool test_pairwise()
 }
 static_assert(test_pairwise());
 
+template <bool = true>
 constexpr bool test_adjacent()
 {
     // Basic striding
@@ -250,9 +252,9 @@ static_assert(test_adjacent());
 
 TEST_CASE("adjacent")
 {
-    bool res = test_pairwise();
+    bool res = test_pairwise<false>();
     REQUIRE(res);
 
-    res = test_adjacent();
+    res = test_adjacent<false>();
     REQUIRE(res);
 }

--- a/test/test_adjacent_map.cpp
+++ b/test/test_adjacent_map.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_pairwise_map() {
     constexpr auto tuple_sum = [](auto... args) {
         return (args + ...);
@@ -95,6 +96,7 @@ constexpr bool test_pairwise_map() {
 }
 static_assert(test_pairwise_map());
 
+template <bool = true>
 constexpr bool test_adjacent_map()
 {
     constexpr auto tuple_sum = [](auto... args) {
@@ -182,9 +184,9 @@ static_assert(test_adjacent_map());
 
 TEST_CASE("pairwise_map")
 {
-    bool res = test_pairwise_map();
+    bool res = test_pairwise_map<false>();
     REQUIRE(res);
 
-    res = test_adjacent_map();
+    res = test_adjacent_map<false>();
     REQUIRE(res);
 }

--- a/test/test_apply.cpp
+++ b/test/test_apply.cpp
@@ -26,7 +26,7 @@ auto rotate_by = []<flux::random_access_sequence Seq>(Seq&& seq, flux::distance_
     return FLUX_FWD(seq);
 };
 
-
+template <bool = true>
 constexpr bool test_apply()
 {
     // Checking lvalue sequence
@@ -63,5 +63,5 @@ static_assert(test_apply());
 
 TEST_CASE("apply")
 {
-    REQUIRE(test_apply());
+    REQUIRE(test_apply<false>());
 }

--- a/test/test_array_ptr.cpp
+++ b/test/test_array_ptr.cpp
@@ -39,6 +39,7 @@ static_assert(not can_array_ptr<Abstract>);
 static_assert(not can_array_ptr<void>);
 static_assert(not can_array_ptr<int&>);
 
+template <bool = true>
 constexpr bool test_array_ptr_ctor()
 {
     // Default constructor
@@ -159,6 +160,7 @@ constexpr bool test_array_ptr_ctor()
 }
 static_assert(test_array_ptr_ctor());
 
+template <bool = true>
 constexpr bool test_array_ptr_ctad()
 {
     {
@@ -186,6 +188,7 @@ constexpr bool test_array_ptr_ctad()
 static_assert(test_array_ptr_ctad());
 
 // Controversial, this one
+template <bool = true>
 constexpr bool test_array_ptr_equality()
 {
     // Pointers to different arrays are different
@@ -241,6 +244,7 @@ constexpr bool test_array_ptr_equality()
 }
 static_assert(test_array_ptr_equality());
 
+template <bool = true>
 constexpr bool test_array_ptr_sequence_impl()
 {
     {
@@ -346,6 +350,7 @@ constexpr bool test_array_ptr_sequence_impl()
 }
 static_assert(test_array_ptr_sequence_impl());
 
+template <bool = true>
 constexpr bool test_make_array_ptr()
 {
     {
@@ -375,11 +380,11 @@ static_assert(test_make_array_ptr());
 
 TEST_CASE("array_ptr")
 {
-    REQUIRE(test_array_ptr_ctor());
-    REQUIRE(test_array_ptr_ctad());
-    REQUIRE(test_array_ptr_equality());
-    REQUIRE(test_array_ptr_sequence_impl());
-    REQUIRE(test_make_array_ptr());
+    REQUIRE(test_array_ptr_ctor<false>());
+    REQUIRE(test_array_ptr_ctad<false>());
+    REQUIRE(test_array_ptr_equality<false>());
+    REQUIRE(test_array_ptr_sequence_impl<false>());
+    REQUIRE(test_make_array_ptr<false>());
 
     SECTION("bounds checking") {
         int arr[] = {0, 1, 2};

--- a/test/test_bitset.cpp
+++ b/test/test_bitset.cpp
@@ -15,6 +15,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_bitset()
 {
     {
@@ -51,7 +52,7 @@ static_assert(test_bitset());
 
 TEST_CASE("bitset")
 {
-    bool result = test_bitset();
+    bool result = test_bitset<false>();
     REQUIRE(result);
 
     // Swapping bits

--- a/test/test_cache_last.cpp
+++ b/test/test_cache_last.cpp
@@ -9,6 +9,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_cache_last()
 {
     // cache_last turns an unbounded sequence into a bounded one
@@ -63,6 +64,6 @@ static_assert(test_cache_last());
 
 TEST_CASE("cache_last")
 {
-    bool result = test_cache_last();
+    bool result = test_cache_last<false>();
     REQUIRE(result);
 }

--- a/test/test_cartesian_product.cpp
+++ b/test/test_cartesian_product.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_cartesian_product()
 {
     {
@@ -116,5 +117,5 @@ static_assert(test_cartesian_product());
 
 TEST_CASE("cartesian_product")
 {
-    REQUIRE(test_cartesian_product());
+    REQUIRE(test_cartesian_product<false>());
 }

--- a/test/test_cartesian_product_with.cpp
+++ b/test/test_cartesian_product_with.cpp
@@ -15,6 +15,7 @@ namespace {
 
 constexpr auto sum = [](auto... args) { return (args + ...); };
 
+template <bool = true>
 constexpr bool test_cartesian_product_with()
 {
     {
@@ -123,7 +124,7 @@ static_assert(test_cartesian_product_with());
 
 TEST_CASE("cartesian_product_with")
 {
-    REQUIRE(test_cartesian_product_with());
+    REQUIRE(test_cartesian_product_with<false>());
 }
 
 }

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -16,6 +16,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_chain()
 {
     // Basic chaining
@@ -164,6 +165,6 @@ static_assert(test_chain());
 
 TEST_CASE("chain")
 {
-    bool result = test_chain();
+    bool result = test_chain<false>();
     REQUIRE(result);
 }

--- a/test/test_chunk.cpp
+++ b/test/test_chunk.cpp
@@ -38,6 +38,7 @@ struct NotBidir : flux::inline_sequence_base<NotBidir<Base>> {
     };
 };
 
+template <bool = true>
 constexpr bool test_chunk_single_pass()
 {
     // Basic single-pass chunk
@@ -155,6 +156,7 @@ constexpr bool test_chunk_single_pass()
 }
 static_assert(test_chunk_single_pass());
 
+template <bool = true>
 constexpr bool test_chunk_multipass()
 {
     // Basic multipass chunk
@@ -282,6 +284,7 @@ constexpr bool test_chunk_multipass()
 }
 static_assert(test_chunk_multipass());
 
+template <bool = true>
 constexpr bool test_chunk_bidir()
 {
     // Basic bidir chunk
@@ -453,13 +456,13 @@ static_assert(test_chunk_bidir());
 
 TEST_CASE("chunk")
 {
-    bool res = test_chunk_single_pass();
+    bool res = test_chunk_single_pass<false>();
     REQUIRE(res);
 
-    res = test_chunk_multipass();
+    res = test_chunk_multipass<false>();
     REQUIRE(res);
 
-    res = test_chunk_bidir();
+    res = test_chunk_bidir<false>();
     REQUIRE(res);
 
     SECTION("...with istream sequence")

--- a/test/test_chunk_by.cpp
+++ b/test/test_chunk_by.cpp
@@ -25,6 +25,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_chunk_by() {
 
     using P = std::pair<int, int>;
@@ -185,6 +186,6 @@ static_assert(test_chunk_by());
 
 TEST_CASE("chunk_by")
 {
-    bool res = test_chunk_by();
+    bool res = test_chunk_by<false>();
     REQUIRE(res);
 }

--- a/test/test_compare.cpp
+++ b/test/test_compare.cpp
@@ -20,6 +20,7 @@ struct Test {
     constexpr bool operator<(Test other) const { return i < other.i; }
 };
 
+template <bool = true>
 constexpr bool test_compare()
 {
     // equal
@@ -125,5 +126,5 @@ static_assert(test_compare());
 
 TEST_CASE("compare")
 {
-    REQUIRE(test_compare());
+    REQUIRE(test_compare<false>());
 }

--- a/test/test_contains.cpp
+++ b/test/test_contains.cpp
@@ -21,6 +21,7 @@ struct Test {
     int i;
 };
 
+template <bool = true>
 constexpr bool test_contains()
 {
     // Basic contains
@@ -46,6 +47,6 @@ static_assert(test_contains());
 
 TEST_CASE("contains")
 {
-    bool result = test_contains();
+    bool result = test_contains<false>();
     REQUIRE(result);
 }

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -22,6 +22,7 @@ struct S {
     int i;
 };
 
+template <bool = true>
 constexpr bool test_count()
 {
     {
@@ -62,6 +63,6 @@ static_assert(test_count());
 
 TEST_CASE("count")
 {
-    bool result = test_count();
+    bool result = test_count<false>();
     REQUIRE(result);
 }

--- a/test/test_count_if.cpp
+++ b/test/test_count_if.cpp
@@ -24,6 +24,7 @@ struct S {
 
 constexpr auto is_even = [](int i) { return i % 2 == 0; };
 
+template <bool = true>
 constexpr bool test_count_if()
 {
     {
@@ -50,6 +51,6 @@ static_assert(test_count_if());
 
 TEST_CASE("count_if")
 {
-    bool result = test_count_if();
+    bool result = test_count_if<false>();
     REQUIRE(result);
 }

--- a/test/test_drop.cpp
+++ b/test/test_drop.cpp
@@ -14,6 +14,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_drop() {
 
     {
@@ -103,7 +104,7 @@ static_assert(test_drop());
 
 TEST_CASE("drop")
 {
-    bool result = test_drop();
+    bool result = test_drop<false>();
     REQUIRE(result);
 
     // Test dropping a negative number of elements

--- a/test/test_drop_while.cpp
+++ b/test/test_drop_while.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_drop_while()
 {
     {
@@ -79,6 +80,6 @@ static_assert(test_drop_while());
 
 TEST_CASE("drop_while")
 {
-    bool result = test_drop_while();
+    bool result = test_drop_while<false>();
     REQUIRE(result);
 }

--- a/test/test_ends_with.cpp
+++ b/test/test_ends_with.cpp
@@ -20,6 +20,7 @@ struct S {
     constexpr int get() const { return i; }
 };
 
+template <bool = true>
 constexpr bool test_ends_with()
 {
     // Basic ends_with for two reversible sequences
@@ -123,6 +124,6 @@ static_assert(test_ends_with());
 
 TEST_CASE("ends_with")
 {
-    bool result = test_ends_with();
+    bool result = test_ends_with<false>();
     REQUIRE(result);
 }

--- a/test/test_equal.cpp
+++ b/test/test_equal.cpp
@@ -22,6 +22,7 @@ public:
     constexpr int get() const { return i; }
 };
 
+template <bool = true>
 constexpr bool test_equal()
 {
     // Basic equal
@@ -105,6 +106,6 @@ static_assert(test_equal());
 
 TEST_CASE("equal")
 {
-    bool result = test_equal();
+    bool result = test_equal<false>();
     REQUIRE(result);
 }

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -16,6 +16,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_fill()
 {
     // Basic fill()
@@ -68,6 +69,6 @@ static_assert(test_fill());
 
 TEST_CASE("fill")
 {
-    bool result = test_fill();
+    bool result = test_fill<false>();
     REQUIRE(result);
 }

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -37,7 +37,7 @@ static_assert(not std::invocable<filter_fn, int(&)[10], decltype([](int) {})>);
 // Incompatible predicate
 static_assert(not std::invocable<filter_fn, int(&)[10], decltype([](int*) { return true; })>);
 
-
+template <bool = true>
 constexpr bool test_filter()
 {
     // Basic filtering
@@ -153,6 +153,6 @@ static_assert(test_filter());
 
 TEST_CASE("filter")
 {
-    bool result = test_filter();
+    bool result = test_filter<false>();
     REQUIRE(result);
 }

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -30,6 +30,7 @@ static_assert(not std::invocable<find_fn, int[10], S>);
 // Not equality comparable
 static_assert(not std::invocable<find_fn, S[10], S>);
 
+template <bool = true>
 constexpr bool test_find()
 {
     {
@@ -66,6 +67,9 @@ static_assert(test_find());
 
 TEST_CASE("find")
 {
+    bool res = test_find<false>();
+    REQUIRE(res);
+
     {
         std::vector<int> vec{1, 2, 3, 4, 5};
         auto idx = flux::find(vec, 3);

--- a/test/test_flatten.cpp
+++ b/test/test_flatten.cpp
@@ -32,6 +32,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_flatten_single_pass()
 {
     // Single-pass source sequence, inner sequence is multipass
@@ -139,6 +140,7 @@ constexpr bool test_flatten_single_pass()
 }
 static_assert(test_flatten_single_pass());
 
+template <bool = true>
 constexpr bool test_flatten_multipass()
 {
     {
@@ -223,9 +225,9 @@ static_assert(test_flatten_multipass());
 
 TEST_CASE("flatten")
 {
-    bool sp = test_flatten_single_pass();
+    bool sp = test_flatten_single_pass<false>();
     REQUIRE(sp);
 
-    bool mp = test_flatten_multipass();
+    bool mp = test_flatten_multipass<false>();
     REQUIRE(mp);
 }

--- a/test/test_fold.cpp
+++ b/test/test_fold.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_fold()
 {
     {
@@ -51,6 +52,7 @@ constexpr bool test_fold()
 }
 static_assert(test_fold());
 
+template <bool = true>
 constexpr bool test_fold_first()
 {
     {
@@ -85,6 +87,7 @@ constexpr bool test_fold_first()
 }
 static_assert(test_fold_first());
 
+template <bool = true>
 constexpr bool test_sum()
 {
     {
@@ -114,6 +117,7 @@ constexpr bool test_sum()
 }
 static_assert(test_sum());
 
+template <bool = true>
 constexpr bool test_product()
 {
     {
@@ -138,7 +142,7 @@ static_assert(test_product());
 
 TEST_CASE("fold")
 {
-    bool result = test_fold();
+    bool result = test_fold<false>();
     REQUIRE(result);
 
     // Populate a vector in a really inefficient way
@@ -154,12 +158,18 @@ TEST_CASE("fold")
 
 TEST_CASE("fold_first")
 {
-    bool result = test_fold_first();
+    bool result = test_fold_first<false>();
     REQUIRE(result);
 }
 
 TEST_CASE("sum")
 {
-    bool result = test_sum();
+    bool result = test_sum<false>();
+    REQUIRE(result);
+}
+
+TEST_CASE("product")
+{
+    bool result = test_product<false>();
     REQUIRE(result);
 }

--- a/test/test_for_each.cpp
+++ b/test/test_for_each.cpp
@@ -20,6 +20,7 @@ struct S {
     int i_;
 };
 
+template <bool = true>
 constexpr bool test_for_each()
 {
     {
@@ -71,6 +72,6 @@ static_assert(test_for_each());
 
 TEST_CASE("for_each")
 {
-    bool result = test_for_each();
+    bool result = test_for_each<false>();
     REQUIRE(result);
 }

--- a/test/test_from_range.cpp
+++ b/test/test_from_range.cpp
@@ -23,6 +23,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_from_range()
 {
     {
@@ -54,7 +55,7 @@ static_assert(test_from_range());
 
 TEST_CASE("from range")
 {
-    REQUIRE(test_from_range());
+    REQUIRE(test_from_range<false>());
 
     SECTION("bounds checking") {
         std::vector<int> vec{0, 1, 2, 3, 4};

--- a/test/test_front_back.cpp
+++ b/test/test_front_back.cpp
@@ -14,6 +14,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_front()
 {
     // Non-member, non-empty
@@ -99,6 +100,7 @@ constexpr bool test_front()
 }
 static_assert(test_front());
 
+template <bool = true>
 constexpr bool test_back()
 {
     // Non-member, non-empty
@@ -202,12 +204,12 @@ static_assert(test_back());
 
 TEST_CASE("front")
 {
-    bool res = test_front();
+    bool res = test_front<false>();
     REQUIRE(res);
 }
 
 TEST_CASE("back")
 {
-    bool res = test_back();
+    bool res = test_back<false>();
     REQUIRE(res);
 }

--- a/test/test_iota.cpp
+++ b/test/test_iota.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_iota_basic()
 {
     auto f = flux::ints();
@@ -33,6 +34,7 @@ constexpr bool test_iota_basic()
 }
 static_assert(test_iota_basic());
 
+template <bool = true>
 constexpr bool test_iota_from()
 {
     auto f = flux::iota(1u);
@@ -53,6 +55,7 @@ constexpr bool test_iota_from()
 }
 static_assert(test_iota_from());
 
+template <bool = true>
 constexpr bool test_iota_bounded()
 {
     auto f = flux::iota(1u, 6u);
@@ -73,6 +76,7 @@ constexpr bool test_iota_bounded()
 }
 static_assert(test_iota_bounded());
 
+template <bool = true>
 constexpr bool test_iota_custom_type()
 {
     using namespace std::chrono_literals;
@@ -99,8 +103,8 @@ static_assert(test_iota_custom_type());
 
 TEST_CASE("iota")
 {
-    REQUIRE(test_iota_basic());
-    REQUIRE(test_iota_from());
-    REQUIRE(test_iota_bounded());
-    REQUIRE(test_iota_custom_type());
+    REQUIRE(test_iota_basic<false>());
+    REQUIRE(test_iota_from<false>());
+    REQUIRE(test_iota_bounded<false>());
+    REQUIRE(test_iota_custom_type<false>());
 }

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_map()
 {
     {
@@ -122,6 +123,6 @@ static_assert(test_map());
 
 TEST_CASE("map")
 {
-    bool result = test_map();
+    bool result = test_map<false>();
     REQUIRE(result);
 }

--- a/test/test_minmax.cpp
+++ b/test/test_minmax.cpp
@@ -18,7 +18,7 @@ struct IntPair {
     friend bool operator==(IntPair const&, IntPair const&) = default;
 };
 
-
+template <bool = true>
 constexpr bool test_min()
 {
     // Empty range -> no min value
@@ -50,6 +50,7 @@ constexpr bool test_min()
 }
 static_assert(test_min());
 
+template <bool = true>
 constexpr bool test_max()
 {
     // Empty range -> no max value
@@ -81,6 +82,7 @@ constexpr bool test_max()
 }
 static_assert(test_max());
 
+template <bool = true>
 constexpr bool test_minmax()
 {
     // Empty range -> no minmax
@@ -120,4 +122,22 @@ constexpr bool test_minmax()
 }
 static_assert(test_minmax());
 
+}
+
+TEST_CASE("max")
+{
+    bool r = test_max<false>();
+    REQUIRE(r);
+}
+
+TEST_CASE("min")
+{
+    bool r = test_min<false>();
+    REQUIRE(r);
+}
+
+TEST_CASE("minmax")
+{
+    bool r = test_minmax<false>();
+    REQUIRE(r);
 }

--- a/test/test_output_to.cpp
+++ b/test/test_output_to.cpp
@@ -19,6 +19,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_output_to()
 {
     {
@@ -39,7 +40,7 @@ static_assert(test_output_to());
 
 TEST_CASE("output to")
 {
-    bool result = test_output_to();
+    bool result = test_output_to<false>();
     REQUIRE(result);
 
     SECTION("...with contiguous iterators")

--- a/test/test_predicates.cpp
+++ b/test/test_predicates.cpp
@@ -20,6 +20,7 @@ using namespace std::string_view_literals;
 constexpr auto& all_of = std::ranges::all_of;
 constexpr auto& none_of = std::ranges::none_of;
 
+template <bool = true>
 constexpr bool test_predicate_comparators()
 {
     std::array const ones{1, 1, 1, 1, 1, 1};
@@ -61,7 +62,7 @@ constexpr bool test_predicate_comparators()
 }
 static_assert(test_predicate_comparators());
 
-
+template <bool = true>
 constexpr bool test_predicate_combiners()
 {
     {
@@ -122,7 +123,7 @@ static_assert(test_predicate_combiners());
 
 TEST_CASE("predicates")
 {
-    REQUIRE(test_predicate_comparators());
-    REQUIRE(test_predicate_combiners());
+    REQUIRE(test_predicate_comparators<false>());
+    REQUIRE(test_predicate_combiners<false>());
 }
 

--- a/test/test_range_iface.cpp
+++ b/test/test_range_iface.cpp
@@ -15,6 +15,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_range_iface()
 {
     namespace rng = std::ranges;
@@ -143,6 +144,6 @@ static_assert(test_range_iface());
 
 TEST_CASE("range interface")
 {
-    bool res = test_range_iface();
+    bool res = test_range_iface<false>();
     REQUIRE(res);
 }

--- a/test/test_read_only.cpp
+++ b/test/test_read_only.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_read_only() {
 
     // Mutable lvalue ref -> const lvalue ref
@@ -142,6 +143,6 @@ static_assert(test_read_only());
 
 TEST_CASE("read_only")
 {
-    bool res = test_read_only();
+    bool res = test_read_only<false>();
     REQUIRE(res);
 }

--- a/test/test_reverse.cpp
+++ b/test/test_reverse.cpp
@@ -14,6 +14,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_reverse()
 {
     {
@@ -88,6 +89,7 @@ static_assert(test_reverse());
 
 // Regression test for #52
 // https://github.com/tcbrindle/flux/issues/52
+template <bool = true>
 constexpr bool issue_52()
 {
     std::string_view in = "   abc   ";
@@ -110,10 +112,10 @@ static_assert(issue_52());
 
 TEST_CASE("reverse")
 {
-    bool result = test_reverse();
+    bool result = test_reverse<false>();
     REQUIRE(result);
 
-    result = issue_52();
+    result = issue_52<false>();
     REQUIRE(result);
 
     {

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -15,6 +15,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_inclusive_scan()
 {
     // scan returns the same as std::inclusive_scan
@@ -77,6 +78,7 @@ constexpr bool test_inclusive_scan()
 }
 static_assert(test_inclusive_scan());
 
+template <bool = true>
 constexpr bool test_prescan()
 {
     // prescan returns the same as std::exclusive_scan with one extra value
@@ -147,6 +149,7 @@ constexpr bool test_prescan()
 }
 static_assert(test_prescan());
 
+template <bool = true>
 constexpr bool test_scan_first()
 {
     // scan_first returns the same as std::inclusive_scan
@@ -212,10 +215,13 @@ static_assert(test_scan_first());
 
 TEST_CASE("scan")
 {
-    bool res = test_inclusive_scan();
+    bool res = test_inclusive_scan<false>();
     REQUIRE(res);
 
-    res = test_prescan();
+    res = test_prescan<false>();
+    REQUIRE(res);
+
+    res = test_scan_first<false>();
     REQUIRE(res);
 
     SECTION("inclusive scan with stringstream")

--- a/test/test_simple_sequence.cpp
+++ b/test/test_simple_sequence.cpp
@@ -44,6 +44,7 @@ struct ints : flux::simple_sequence_base<ints> {
     }
 };
 
+template <bool = true>
 constexpr bool test_simple_sequence()
 {
     {
@@ -104,6 +105,6 @@ static_assert(test_simple_sequence());
 
 TEST_CASE("simple_sequence")
 {
-    bool result = test_simple_sequence();
+    bool result = test_simple_sequence<false>();
     REQUIRE(result);
 }

--- a/test/test_single.cpp
+++ b/test/test_single.cpp
@@ -11,6 +11,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_single()
 {
     {
@@ -78,6 +79,6 @@ static_assert(test_single());
 
 TEST_CASE("single")
 {
-    bool result = test_single();
+    bool result = test_single<false>();
     REQUIRE(result);
 }

--- a/test/test_slide.cpp
+++ b/test/test_slide.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_slide()
 {
     // Basic sliding
@@ -133,6 +134,6 @@ static_assert(test_slide());
 
 TEST_CASE("slide")
 {
-    bool res = test_slide();
+    bool res = test_slide<false>();
     REQUIRE(res);
 }

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -48,7 +48,7 @@ struct span_seq {
 template <typename T>
 span_seq(T*, size_t) -> span_seq<T>;
 
-constexpr bool test_sort_contexpr()
+constexpr bool test_sort_constexpr()
 {
     {
         int arr[] = {9, 7, 5, 3, 1, 4, 6, 8, 0, 2};
@@ -90,7 +90,7 @@ constexpr bool test_sort_contexpr()
 
     return true;
 }
-static_assert(test_sort_contexpr());
+static_assert(test_sort_constexpr());
 
 
 std::mt19937 gen{};
@@ -202,7 +202,7 @@ void test_adapted_deque_sort(int sz)
 
 TEST_CASE("sort")
 {
-    CHECK(test_sort_contexpr());
+    CHECK(test_sort_constexpr());
 
     test_sort(0);
     test_sort(1);

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -22,6 +22,7 @@ constexpr auto  to_string_view = []<typename Seq>(Seq&& seq) // danger Will Robi
     return std::basic_string_view<flux::value_t<Seq>>(flux::data(seq), flux::usize(seq));
 };
 
+template <bool = true>
 constexpr bool test_split()
 {
     using namespace std::string_view_literals;
@@ -96,6 +97,6 @@ static_assert(test_split());
 
 TEST_CASE("split")
 {
-    bool result = test_split();
+    bool result = test_split<false>();
     REQUIRE(result);
 }

--- a/test/test_starts_with.cpp
+++ b/test/test_starts_with.cpp
@@ -19,6 +19,7 @@ struct S {
     constexpr int get() const { return i; }
 };
 
+template <bool = true>
 constexpr bool test_starts_with()
 {
     // Basic starts_with
@@ -111,6 +112,6 @@ static_assert(test_starts_with());
 
 TEST_CASE("starts_with")
 {
-    bool result = test_starts_with();
+    bool result = test_starts_with<false>();
     REQUIRE(result);
 }

--- a/test/test_stride.cpp
+++ b/test/test_stride.cpp
@@ -29,6 +29,7 @@ struct NotBidir : flux::inline_sequence_base<NotBidir<Base>> {
     };
 };
 
+template <bool = true>
 constexpr bool test_stride_non_bidir()
 {
     // Basic stride, n divides size
@@ -130,6 +131,7 @@ constexpr bool test_stride_non_bidir()
 }
 static_assert(test_stride_non_bidir());
 
+template <bool = true>
 constexpr bool test_stride_bidir()
 {
     // Basic stride, n divides size
@@ -331,10 +333,10 @@ static_assert(test_stride_bidir());
 
 TEST_CASE("stride")
 {
-    bool res = test_stride_non_bidir();
+    bool res = test_stride_non_bidir<false>();
     REQUIRE(res);
 
-    res = test_stride_bidir();
+    res = test_stride_bidir<false>();
     REQUIRE(res);
 
     // Test with bidir-but-not-RA sequence

--- a/test/test_take.cpp
+++ b/test/test_take.cpp
@@ -24,6 +24,7 @@ struct Tester : flux::simple_sequence_base<Tester> {
     }
 };
 
+template <bool = true>
 constexpr bool test_take()
 {
     {
@@ -133,6 +134,7 @@ static_assert(test_take());
 
 // Regression test for #62
 // https://github.com/tcbrindle/flux/issues/62
+template <bool = true>
 constexpr bool issue_62()
 {
     auto seq = flux::ints(0).take(5).filter(flux::pred::true_);
@@ -147,10 +149,10 @@ static_assert(issue_62());
 
 TEST_CASE("take")
 {
-    bool result = test_take();
+    bool result = test_take<false>();
     REQUIRE(result);
 
-    result = issue_62();
+    result = issue_62<false>();
     REQUIRE(result);
 
     // test taking a negative number of elements

--- a/test/test_take_while.cpp
+++ b/test/test_take_while.cpp
@@ -26,6 +26,7 @@ struct ints {
     };
 };
 
+template <bool = true>
 constexpr bool test_take_while()
 {
     {
@@ -82,6 +83,6 @@ static_assert(test_take_while());
 
 TEST_CASE("take_while")
 {
-    bool result = test_take_while();
+    bool result = test_take_while<false>();
     REQUIRE(result);
 }

--- a/test/test_unchecked.cpp
+++ b/test/test_unchecked.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_unchecked()
 {
     using namespace flux;
@@ -62,6 +63,6 @@ static_assert(test_unchecked());
 
 TEST_CASE("unchecked adaptor")
 {
-    auto res = test_unchecked();
+    auto res = test_unchecked<false>();
     REQUIRE(res);
 }

--- a/test/test_zip.cpp
+++ b/test/test_zip.cpp
@@ -15,6 +15,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_zip()
 {
     {
@@ -167,6 +168,7 @@ constexpr bool test_zip()
 static_assert(test_zip());
 
 // https://github.com/tcbrindle/flux/issues/47
+template <bool = true>
 constexpr bool issue_47()
 {
     std::array v = {1, 2, 3, 4, 5};
@@ -182,9 +184,9 @@ static_assert(issue_47());
 
 TEST_CASE("zip")
 {
-    bool result = test_zip();
+    bool result = test_zip<false>();
     REQUIRE(result);
 
-    result = issue_47();
+    result = issue_47<false>();
     REQUIRE(result);
 }

--- a/test/test_zip_algorithms.cpp
+++ b/test/test_zip_algorithms.cpp
@@ -14,6 +14,7 @@
 
 namespace {
 
+template <bool = true>
 constexpr bool test_zip_for_each()
 {
     // two sequences with stateful function obj
@@ -52,6 +53,7 @@ constexpr bool test_zip_for_each()
 }
 static_assert(test_zip_for_each());
 
+template <bool = true>
 constexpr bool test_zip_find_if()
 {
     // successful, two sequences
@@ -139,6 +141,7 @@ constexpr bool test_zip_find_if()
 }
 static_assert(test_zip_find_if());
 
+template <bool = true>
 constexpr bool test_zip_fold()
 {
     // Summing two sequences at the same time
@@ -182,12 +185,12 @@ static_assert(test_zip_fold());
 
 TEST_CASE("zip algorithms")
 {
-    bool r = test_zip_for_each();
+    bool r = test_zip_for_each<false>();
     REQUIRE(r);
 
-    r = test_zip_find_if();
+    r = test_zip_find_if<false>();
     REQUIRE(r);
 
-    r = test_zip_fold();
+    r = test_zip_fold<false>();
     REQUIRE(r);
 }


### PR DESCRIPTION
Because almost the entire library is constexpr, the majority of our tests look like this:

```cpp
constexpr bool test_xxx() {
    // test code
    return true;
}
static_assert(test_xxx());

TEST_CASE("xxx") {
    REQUIRE(test_xxx());
}
```

That is, we do a constexpr test during compilation (which has the added benefit of testing for many guises of UB), and then again at runtime using Catch.

Unfortunately, compilers are getting increasingly smart at noticing that they've already calculated the result of `test_xxx()`, so they can optimise the run-time version to just `REQUIRE(true)`, which isn't exactly in the spirit of what we want as it means we never actually execute the tests at runtime! It also means that the tested functions never show up in our code coverage measurements.

As a workaround, this commit adds an otherwise-useless `template <bool = true>` to every `test_xxx()` function. Then in the runtime version we explicitly call `test_xxx<false>()` to force a separate instantation which should hopefully show up in CodeCov.

This probably won't do wonders for our compile times, but we'll see...