### PR TITLE
Make flux::from() accept adaptable_sequences only

### DIFF
--- a/benchmark/internal_iteration_benchmark.cpp
+++ b/benchmark/internal_iteration_benchmark.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
         });
 
         bench.run("transform_filter_flux", [&] {
-            auto r = flux::from(bunch_of_ints).map(triple).filter(is_even);
+            auto r = flux::ref(bunch_of_ints).map(triple).filter(is_even);
             int res = r.sum();
             an::doNotOptimizeAway(res);
         });
@@ -118,7 +118,7 @@ int main(int argc, char** argv)
 
         bench.run("concat_take_transform_filter_flux", [&] {
             int res =
-                flux::chain(std::cref(bunch_of_ints), std::cref(moar_ints))
+                flux::chain(flux::ref(bunch_of_ints), flux::ref(moar_ints))
                     .take(1'500'000)
                     .map(triple)
                     .filter(is_even)

--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -149,7 +149,7 @@ app_args_t parse_args(int argc, char** argv) {
         return std::pair{s.substr(0, pos), s.substr(std::min(flux::count(s), pos + 1))};
     };
 
-    for (const auto& [key, val] : flux::from(args).map(to_pair)) {
+    for (const auto& [key, val] : flux::ref(args).map(to_pair)) {
         if (auto it = args_map.find(key); it != args_map.end()) {
             std::invoke(it->second, val);
         } else {

--- a/example/config_parser.cpp
+++ b/example/config_parser.cpp
@@ -59,7 +59,7 @@ token_t parse_line(const std::string& line)
     else if (line.starts_with("[") and line.ends_with("]"))
         return section_t{line.substr(1, line.size() - 2)};
 
-    auto items = flux::from(line).split_string("=").to<std::vector>();
+    auto items = flux::ref(line).split_string("=").to<std::vector>();
     if (items.size() != 2)
         throw std::runtime_error("parse error");
     return option_t{std::string{items[0]}, std::string{items[1]}};

--- a/example/merge_intervals.cpp
+++ b/example/merge_intervals.cpp
@@ -38,7 +38,7 @@ int main()
     // sort intervals according to begin
     flux::sort(intervals, flux::proj(std::less{}, &interval_t::begin));
 
-    flux::from(intervals)
+    flux::ref(intervals)
          .chunk_by(is_overlapped)
          .map(merge)
          .write_to(std::cout);

--- a/example/moving_average.cpp
+++ b/example/moving_average.cpp
@@ -42,7 +42,7 @@ int main() {
     std::vector intervals = {1, 5, 6, 1, 2, 9, 7, -1, 0};
 
     // compute moving average by scan adaptor (more effective for large windows)
-    auto ma = flux::from(intervals)
+    auto ma = flux::ref(intervals)
         .scan(sliding_window, sliding_window_t(3))
         .map(&sliding_window_t::average)
         .to<std::vector>();
@@ -55,7 +55,7 @@ int main() {
     assert(ma.back() == 2); // (7 + -1 + 0) / 3
 
     // compute moving average by slide adaptor (less effective for large windows)
-    auto ma2 = flux::from(intervals)
+    auto ma2 = flux::ref(intervals)
         .slide(3)
         .map([](auto&& win) { return win.sum() / win.size(); })
         .to<std::vector>();

--- a/include/flux/op/from.hpp
+++ b/include/flux/op/from.hpp
@@ -26,9 +26,28 @@ struct from_fn {
     }
 };
 
+struct from_fwd_ref_fn {
+    template <sequence Seq>
+        requires adaptable_sequence<Seq> || std::is_lvalue_reference_v<Seq>
+    [[nodiscard]]
+    constexpr auto operator()(Seq&& seq) const
+    {
+        if constexpr (std::is_lvalue_reference_v<Seq>) {
+            if constexpr (std::is_const_v<std::remove_reference_t<Seq>>) {
+                return flux::ref(seq);
+            } else {
+                return flux::mut_ref(seq);
+            }
+        } else {
+            return from_fn{}(seq);
+        }
+    }
+};
+
 } // namespace detail
 
 inline constexpr auto from = detail::from_fn{};
+inline constexpr auto from_fwd_ref = detail::from_fwd_ref_fn{};
 
 } // namespace flux
 

--- a/include/flux/op/from.hpp
+++ b/include/flux/op/from.hpp
@@ -14,19 +14,14 @@ namespace flux {
 namespace detail {
 
 struct from_fn {
-    template <sequence Seq>
-        requires (std::is_lvalue_reference_v<Seq> || adaptable_sequence<Seq>)
+    template <adaptable_sequence Seq>
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq) const
     {
-        if constexpr (std::is_lvalue_reference_v<Seq>) {
-            if constexpr (std::is_const_v<std::remove_reference_t<Seq>>) {
-                return flux::ref(seq);
-            } else {
-                return flux::mut_ref(seq);
-            }
+        if constexpr (derived_from_inline_sequence_base<Seq>) {
+            return FLUX_FWD(seq);
         } else {
-            return detail::owning_adaptor<Seq>(FLUX_FWD(seq));
+            return owning_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
         }
     }
 };

--- a/include/flux/op/ref.hpp
+++ b/include/flux/op/ref.hpp
@@ -162,12 +162,9 @@ private:
     Base base_;
 
 public:
-    constexpr explicit owning_adaptor(Base&& base)
-        : base_(std::move(base))
+    constexpr explicit owning_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
     {}
-
-    owning_adaptor(owning_adaptor&&) = default;
-    owning_adaptor& operator=(owning_adaptor&&) = default;
 
     constexpr Base& base() & noexcept { return base_; }
     constexpr Base const& base() const& noexcept { return base_; }

--- a/include/flux/op/sort.hpp
+++ b/include/flux/op/sort.hpp
@@ -17,17 +17,7 @@ struct sort_fn {
                  strict_weak_order_for<Cmp, Seq>
     constexpr auto operator()(Seq&& seq, Cmp cmp = {}) const
     {
-        auto wrapper = [&] {
-            if constexpr (std::is_lvalue_reference_v<Seq>) {
-                if constexpr (std::is_const_v<std::remove_reference_t<Seq>>) {
-                    return flux::unchecked(flux::ref(seq));
-                } else {
-                    return flux::unchecked(flux::mut_ref(seq));
-                }
-            } else {
-                return flux::unchecked(FLUX_FWD(seq));
-            }
-        }();
+        auto wrapper = flux::unchecked(flux::from_fwd_ref(FLUX_FWD(seq)));
         detail::pdqsort(wrapper, cmp);
     }
 };

--- a/include/flux/op/to.hpp
+++ b/include/flux/op/to.hpp
@@ -141,7 +141,7 @@ constexpr auto to(Seq&& seq, Args&&... args) -> Container
         }
     } else {
         static_assert(sequence<element_t<Seq>>);
-        return flux::to<Container>(flux::map(flux::from(FLUX_FWD(seq)), [](auto&& elem) {
+        return flux::to<Container>(flux::map(flux::from_fwd_ref(FLUX_FWD(seq)), [](auto&& elem) {
             return flux::to<detail::container_value_t<Container>>(FLUX_FWD(elem));
         }), FLUX_FWD(args)...);
     }

--- a/include/flux/source/istreambuf.hpp
+++ b/include/flux/source/istreambuf.hpp
@@ -28,14 +28,14 @@ struct from_istreambuf_fn {
     auto operator()(std::basic_streambuf<CharT, Traits>* streambuf) const -> sequence auto
     {
         FLUX_ASSERT(streambuf != nullptr);
-        return flux::from(*streambuf);
+        return flux::mut_ref(*streambuf);
     }
 
     template <typename CharT, typename Traits>
     [[nodiscard]]
     auto operator()(std::basic_istream<CharT, Traits>& istream) const -> sequence auto
     {
-        return flux::from(*istream.rdbuf());
+        return flux::mut_ref(*istream.rdbuf());
     }
 };
 

--- a/test/test_cache_last.cpp
+++ b/test/test_cache_last.cpp
@@ -36,7 +36,7 @@ constexpr bool test_cache_last()
     {
         std::array arr{1, 2, 3, 4, 5};
 
-        auto seq = flux::from(arr);
+        auto seq = flux::ref(arr);
         auto cached = flux::cache_last(flux::ref(arr));
 
         STATIC_CHECK(&seq.base() == &cached.base());
@@ -47,7 +47,7 @@ constexpr bool test_cache_last()
     {
         std::array arr{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-        flux::from(arr)
+        flux::mut_ref(arr)
             .take_while([](int i) { return i <= 5; })
             .cache_last()
             .inplace_reverse();

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -84,8 +84,8 @@ constexpr bool test_chain()
         int arr1[] = {0, 1, 2};
         int arr2[] = {3, 4, 5};
 
-        auto seq = flux::chain(single_pass_only(flux::from(arr1)),
-                               single_pass_only(flux::from(arr2)));
+        auto seq = flux::chain(single_pass_only(flux::ref(arr1)),
+                               single_pass_only(flux::ref(arr2)));
 
         using S = decltype(seq);
 
@@ -101,7 +101,7 @@ constexpr bool test_chain()
         int arr2[] = {3, 4, 5};
         auto yes = [](int) { return true; };
 
-        auto seq = flux::chain(flux::filter(flux::ref(arr1), yes), flux::filter(flux::from(arr2), yes));
+        auto seq = flux::chain(flux::filter(flux::ref(arr1), yes), flux::filter(flux::ref(arr2), yes));
 
         using S = decltype(seq);
 

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -36,7 +36,7 @@ constexpr bool test_count()
 
     {
         int arr[] = {1, 2, 3, 4, 5};
-        STATIC_CHECK(flux::from(arr).count() == 5);
+        STATIC_CHECK(flux::ref(arr).count() == 5);
 
         auto seq = flux::take_while(flux::ref(arr), [](int) { return true; });
         static_assert(not flux::sized_sequence<decltype(seq)>);
@@ -49,7 +49,7 @@ constexpr bool test_count()
         STATIC_CHECK(flux::count_eq(arr, 2) == 3);
         STATIC_CHECK(flux::count_eq(arr, 99) == 0);
 
-        auto seq = flux::from(arr);
+        auto seq = flux::ref(arr);
         STATIC_CHECK(seq.count_eq(2) == 3);
         STATIC_CHECK(seq.count_eq(99) == 0);
     }

--- a/test/test_count_if.cpp
+++ b/test/test_count_if.cpp
@@ -31,7 +31,7 @@ constexpr bool test_count_if()
 
         STATIC_CHECK(flux::count_if(arr, is_even) == 5);
 
-        STATIC_CHECK(flux::from(arr).count_if(is_even) == 5);
+        STATIC_CHECK(flux::ref(arr).count_if(is_even) == 5);
     }
 
     {
@@ -39,7 +39,7 @@ constexpr bool test_count_if()
 
         STATIC_CHECK(flux::count_if(arr, flux::proj(is_even, &S::i)));
 
-        STATIC_CHECK(flux::from(arr).count_if(flux::proj(is_even, &S::i)));
+        STATIC_CHECK(flux::ref(arr).count_if(flux::proj(is_even, &S::i)));
     }
 
     return true;

--- a/test/test_drop_while.cpp
+++ b/test/test_drop_while.cpp
@@ -35,7 +35,7 @@ constexpr bool test_drop_while()
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-        auto seq = single_pass_only(flux::from(arr)).drop_while([](int i) { return i < 5; });
+        auto seq = single_pass_only(flux::ref(arr)).drop_while([](int i) { return i < 5; });
 
         using S = decltype(seq);
 

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -40,7 +40,7 @@ constexpr bool test_fill()
     {
         std::array<int, 5> arr{};
 
-        single_pass_only(flux::from(arr)).fill(1);
+        single_pass_only(flux::mut_ref(arr)).fill(1);
 
         STATIC_CHECK(check_equal(arr, {1, 1, 1, 1, 1}));
     }

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -61,7 +61,7 @@ constexpr bool test_filter()
     // Filtering single-pass sequences works okay
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-        auto filtered = single_pass_only(flux::from(arr)).filter(is_even);
+        auto filtered = single_pass_only(flux::ref(arr)).filter(is_even);
         using F = decltype(filtered);
         static_assert(flux::sequence<F>);
         static_assert(not flux::multipass_sequence<F>);

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -45,7 +45,7 @@ constexpr bool test_find()
             return false;
         }
 
-        auto lens = flux::from(ints);
+        auto lens = flux::ref(ints);
 
         cur = lens.find(3);
         if (cur != 3) {
@@ -74,7 +74,7 @@ TEST_CASE("find")
 
     {
         std::vector<int> vec{1, 2, 3, 4, 5};
-        auto idx = flux::from(vec).find(99);
+        auto idx = flux::ref(vec).find(99);
         REQUIRE(idx == std::ssize(vec));
     }
 

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -73,7 +73,7 @@ constexpr bool test_map()
     {
         std::pair<int, int> pairs[] = { {0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}};
 
-        auto mapped = flux::from(pairs).map(&std::pair<int, int>::first);
+        auto mapped = flux::mut_ref(pairs).map(&std::pair<int, int>::first);
 
         using M = decltype(mapped);
         static_assert(flux::random_access_sequence<M>);

--- a/test/test_range_iface.cpp
+++ b/test/test_range_iface.cpp
@@ -103,7 +103,7 @@ constexpr bool test_range_iface()
 
     {
         int arr[] = {1, 2, 3, 4, 5};
-        auto seq = single_pass_only(flux::from(arr));
+        auto seq = single_pass_only(flux::mut_ref(arr));
 
         using V = decltype(seq);
 

--- a/test/test_reverse.cpp
+++ b/test/test_reverse.cpp
@@ -59,12 +59,12 @@ constexpr bool test_reverse()
     {
         std::array arr{0, 1, 2, 3, 4};
 
-        auto seq = flux::from(arr).reverse().reverse();
+        auto seq = flux::ref(arr).reverse().reverse();
 
         using S = decltype(seq);
 
         static_assert(flux::contiguous_sequence<S>);
-        static_assert(std::same_as<S, decltype(flux::from(arr))>);
+        static_assert(std::same_as<S, decltype(flux::ref(arr))>);
 
         STATIC_CHECK(seq.data() == arr.data());
     }

--- a/test/test_take_while.cpp
+++ b/test/test_take_while.cpp
@@ -57,7 +57,7 @@ constexpr bool test_take_while()
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-        auto cur = flux::from(arr)
+        auto cur = flux::ref(arr)
                      .take_while([](int i) { return i < 5; })
                      .find(99);
 

--- a/test/test_to.cpp
+++ b/test/test_to.cpp
@@ -145,7 +145,7 @@ TEST_CASE("to")
             SECTION("...to vector")
             {
                 std::vector<int> vec1{1, 2, 3, 4, 5};
-                auto vec2 = single_pass_only(flux::from(vec1)).to<std::vector<int>>();
+                auto vec2 = single_pass_only(flux::ref(vec1)).to<std::vector<int>>();
                 CHECK(vec1 == vec2);
             }
 
@@ -171,7 +171,7 @@ TEST_CASE("to")
             SECTION("...to vector")
             {
                 std::vector<int> vec1{1, 2, 3, 4, 5};
-                auto vec2 = single_pass_only(flux::from(vec1)).to<std::vector<int, A>>(A{});
+                auto vec2 = single_pass_only(flux::ref(vec1)).to<std::vector<int, A>>(A{});
                 CHECK(std::ranges::equal(vec1, vec2));
             }
 
@@ -315,7 +315,7 @@ TEST_CASE("to")
             SECTION("...to vector")
             {
                 std::vector<int> vec1{1, 2, 3, 4, 5};
-                auto vec2 = single_pass_only(flux::from(vec1)).to<std::vector>();
+                auto vec2 = single_pass_only(flux::ref(vec1)).to<std::vector>();
                 using V = decltype(vec2);
                 static_assert(std::same_as<typename V::value_type, int>);
                 CHECK(vec1 == vec2);

--- a/test/test_write_to.cpp
+++ b/test/test_write_to.cpp
@@ -33,7 +33,7 @@ TEST_CASE("write to")
 
         std::ostringstream oss;
 
-        flux::from(vec).write_to(oss);
+        flux::ref(vec).write_to(oss);
 
         REQUIRE(oss.str() == "[[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]]");
     }


### PR DESCRIPTION
This PR changes the `flux::from()` function so that it accepts only `adaptable_sequence`s, wrapping them in a type that inherits from `inline_sequence_base` to enable chaining via member functions. If the passed-in sequence already inherits from `inline_sequence_base` it is returned by value unchanged.

Previously `from()` handled lvalues by calling `ref()` or `mut_ref()` depending on constness, but this had the unfortunate effect of making it harder to spot when references where being taken. With this change, the user now need to explicitly chose between `from()` (for rvalues) or `ref()`/`mut_ref()` for lvalues as appropriate.

There is one case this doesn't handle, which is where you have a forwarding reference to a sequence which you want to temporarily wrap in an adaptor for the duration of an algorithm call. (We do this in two places in the library, namely in the implementations of `sort()` and `to()`.) For this case, this PR adds a `from_fwd_ref()` function which does what `from()` used to do -- but hopefully with a name that makes it more clear when it should be used.