### PR TITLE
Fix CodeCov action

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -36,7 +36,7 @@ jobs:
       working-directory: ${{runner.workspace}}/build/test/CMakeFiles/test-libflux.dir
       run: |
         lcov --directory . --capture --gcov gcov-13 --output-file coverage.info
-        lcov --remove coverage.info '/usr/local/*' '*/test/*' --output-file coverage.info
+        lcov --remove coverage.info '*/test/*' --output-file coverage.info
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
Homebrew has updated `lcov` from v1.16 to 2.0, and it looks like we're now getting lots of warnings and errors during data collection.