### PR TITLE
Fixes cursor iteration for set_union

### DIFF
--- a/include/flux/op/set_adaptors.hpp
+++ b/include/flux/op/set_adaptors.hpp
@@ -128,7 +128,7 @@ public:
                      bounded_sequence<Base1> && bounded_sequence<Base2>
         static constexpr auto last(Self& self) -> cursor_type
         {
-            return cursor_type{flux::last(self.base1_), flux::last(self.base2_)};
+            return cursor_type{flux::last(self.base1_), flux::last(self.base2_), cursor_type::second};
         }
 
         template <typename Self>

--- a/test/test_set_adaptors.cpp
+++ b/test/test_set_adaptors.cpp
@@ -153,6 +153,20 @@ constexpr bool test_set_union()
         STATIC_CHECK(check_equal(union_seq, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}));
     }
 
+    // test cursor iteration
+    {
+        int arr1[] = {0,    2,    4,   6};
+        int arr2[] = {   1,    3,    5};
+        auto union_seq = flux::set_union(flux::ref(arr1), flux::ref(arr2));
+
+        auto first = flux::first(union_seq);
+        auto last = flux::last(union_seq);
+        while (first != last) {
+            flux::inc(union_seq, first);
+        }
+        STATIC_CHECK(first == last);
+    }
+
     return true;
 }
 

--- a/test/test_to.cpp
+++ b/test/test_to.cpp
@@ -211,6 +211,14 @@ TEST_CASE("to")
 
             CHECK(check_equal(vec, {"The", "quick", "brown", "fox"}));
         }
+
+        SECTION("from set_union adaptor")
+        {
+            auto union_seq = flux::set_union(std::array{1,2,3}, std::array{4,5});
+            auto vec = flux::to<std::vector<int>>(union_seq);
+
+            CHECK(check_equal(vec, {1,2,3,4,5}));
+        }
     }
 
     SECTION("...using CTAD")


### PR DESCRIPTION
last() must return a cursor with cursor_type::second otherwise comparing against a cursor obtained via successive inc() calls fails.

This change also allows flux::to work with set_union.