### PR TITLE
Fix Github Actions yet again

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,6 @@ jobs:
               brew install gcc@13 ninja
           - cxx: /usr/local/opt/llvm/bin/clang++
             install: |
-              brew update
               brew install llvm@16 ninja
 
     steps:


### PR DESCRIPTION
The LLVM 16 build on MacOS has suddenly started failing, because Github changed something and now installing Python 3.11 (a prerequisite of LLVM) causes a conflict with files already in /usr/local on the host.

According to https://github.com/actions/runner-images/issues/7894 removing the `brew update` line should get things working again, even though I only added that line in the first place because LLVM wouldn't install without it *sigh*