### PR TITLE
Fix element type of cartesian_product_with

### DIFF
--- a/include/flux/op/cartesian_product_with.hpp
+++ b/include/flux/op/cartesian_product_with.hpp
@@ -34,7 +34,7 @@ public:
         static constexpr auto read_at(Self& self, cursor_t<Self> const& cur)
             -> decltype(auto)
         {
-            return [&]<std::size_t... N>(std::index_sequence<N...>) {
+            return [&]<std::size_t... N>(std::index_sequence<N...>) -> decltype(auto) {
                 return std::invoke(self.func_, flux::read_at(std::get<N>(self.bases_), std::get<N>(cur))...);
             }(std::index_sequence_for<Bases...>{});
         }

--- a/test/test_cartesian_product_with.cpp
+++ b/test/test_cartesian_product_with.cpp
@@ -1,10 +1,7 @@
 
 #include "catch.hpp"
 
-#include <flux/op/cartesian_product_with.hpp>
-#include <flux/op/reverse.hpp>
-#include <flux/source/empty.hpp>
-#include <flux/op/for_each.hpp>
+#include <flux.hpp>
 
 #include <array>
 #include <iostream>
@@ -115,6 +112,24 @@ constexpr bool test_cartesian_product_with()
         int s = 0;
         cart.for_each([&s](int i) { s += i; });
         STATIC_CHECK(s == 0);
+    }
+
+    // Product returns a correct reference type
+    {
+        double vals[3][3] = {};
+        auto get = [&vals](auto i, auto j) -> double& { return vals[i][j]; };
+
+        auto seq = flux::cartesian_product_with(get, flux::iota(0, 3), flux::iota(0, 3));
+
+        static_assert(std::same_as<flux::element_t<decltype(seq)>, double&>);
+
+        seq.fill(100.0);
+
+        for (auto const& r : vals) {
+            for (double const& d : r) {
+                STATIC_CHECK(d == 100.0);
+            }
+        }
     }
 
     return true;

--- a/test/test_cartesian_product_with.cpp
+++ b/test/test_cartesian_product_with.cpp
@@ -4,7 +4,6 @@
 #include <flux.hpp>
 
 #include <array>
-#include <iostream>
 
 #include "test_utils.hpp"
 
@@ -125,9 +124,9 @@ constexpr bool test_cartesian_product_with()
 
         seq.fill(100.0);
 
-        for (auto const& r : vals) {
-            for (double const& d : r) {
-                STATIC_CHECK(d == 100.0);
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                STATIC_CHECK(vals[i][j] == 100.0);
             }
         }
     }


### PR DESCRIPTION
We were missing a `-> decltype(auto)` off a lambda and so always returning by value. Oops.