### PR TITLE
Add flux::unpack() function

### DIFF
--- a/include/flux/core.hpp
+++ b/include/flux/core.hpp
@@ -8,10 +8,10 @@
 
 #include <flux/core/concepts.hpp>
 #include <flux/core/default_impls.hpp>
+#include <flux/core/functional.hpp>
 #include <flux/core/inline_sequence_base.hpp>
 #include <flux/core/macros.hpp>
 #include <flux/core/optional.hpp>
-#include <flux/core/predicates.hpp>
 #include <flux/core/sequence_access.hpp>
 #include <flux/core/simple_sequence_base.hpp>
 

--- a/include/flux/core/functional.hpp
+++ b/include/flux/core/functional.hpp
@@ -3,8 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef FLUX_CORE_PREDICATES_HPP_INCLUDED
-#define FLUX_CORE_PREDICATES_HPP_INCLUDED
+#ifndef FLUX_CORE_FUNCTIONAL_HPP_INCLUDED
+#define FLUX_CORE_FUNCTIONAL_HPP_INCLUDED
 
 #include <flux/core/macros.hpp>
 

--- a/test/test_cartesian_product.cpp
+++ b/test/test_cartesian_product.cpp
@@ -4,10 +4,12 @@
 #include <flux/op/cartesian_product.hpp>
 #include <flux/op/reverse.hpp>
 #include <flux/source/empty.hpp>
+#include <flux/source/iota.hpp>
 #include <flux/op/for_each.hpp>
 
 #include <array>
 #include <iostream>
+#include <string_view>
 
 #include "test_utils.hpp"
 
@@ -106,6 +108,23 @@ constexpr bool test_cartesian_product()
             flux::inc(cart, cur, -2);
             STATIC_CHECK(cart[cur] == std::tuple{100, 1.0f});
         }
+    }
+
+    // Test unpack()
+    {
+        int vals[3][3] = {};
+
+        flux::cartesian_product(flux::ints(0, 3), flux::ints(0, 3))
+            .for_each(flux::unpack([&vals](auto i, auto j) {
+                vals[i][j] = 100;
+            }));
+
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                STATIC_CHECK(vals[i][j] == 100);
+            }
+        }
+
     }
 
     return true;

--- a/test/test_predicates.cpp
+++ b/test/test_predicates.cpp
@@ -5,7 +5,7 @@
 
 #include "catch.hpp"
 
-#include <flux/core/predicates.hpp>
+#include <flux/core/functional.hpp>
 
 #include "test_utils.hpp"
 

--- a/test/test_zip.cpp
+++ b/test/test_zip.cpp
@@ -162,6 +162,23 @@ constexpr bool test_zip()
         STATIC_CHECK(view.size() == 5);
     }
 
+    // test unpack()
+    {
+        auto vals = std::array{0, 1, 2, 3, 4};
+        auto words = std::array<std::string_view, 3>{"0", "1", "2"};
+
+        flux::zip(flux::mut_ref(vals), words)
+            .map(flux::unpack([](int& val, std::string_view str) -> int& {
+                if (str[0] - '0' != val) {
+                    throw std::runtime_error("Something has gone wrong");
+                }
+                return val;
+            }))
+            .fill(100);
+
+        STATIC_CHECK(check_equal(vals, {100, 100, 100, 3, 4}));
+    }
+
     return true;
 }
 static_assert(test_zip());


### PR DESCRIPTION
`unpack` takes an n-ary function as an argument, and returns a function object which takes an n-tuple and calls the original function with the tuple arguments. It's basically a lazy version of `std::apply`, roughly equivalent to

```cpp
auto unpack = [](auto fn) {
    return [fn](auto tuple) -> decltype(auto) {
        return std::apply(fn, tuple);
    };
};
```

It's useful when dealing with sequences whose elements are tuple-like, for example `zip` or `cartesian_product` sequences, because you can use `unpack` to avoid having to manually write an intermediate lambda which uses structured bindings (or std::apply) yourself, for example:

```cpp
flux::cartesian_product(flux::ints(0, 10), flux::ints(0, 10))
    .for_each(flux::unpack([](auto x, auto y) {
         // do something with x and y coords
    });
```