### PR TITLE
Simplify read_only() implementation

### DIFF
--- a/include/flux/op/read_only.hpp
+++ b/include/flux/op/read_only.hpp
@@ -13,108 +13,30 @@ namespace flux {
 
 namespace detail {
 
+template <typename T>
+struct cast_to_const {
+    constexpr auto operator()(auto&& elem) const -> T { return FLUX_FWD(elem); }
+};
+
 template <sequence Base>
     requires (not read_only_sequence<Base>)
-struct read_only_adaptor : inline_sequence_base<read_only_adaptor<Base>> {
+struct read_only_adaptor : map_adaptor<Base, cast_to_const<const_element_t<Base>>> {
 private:
-    FLUX_NO_UNIQUE_ADDRESS Base base_;
+    using map = map_adaptor<Base, cast_to_const<const_element_t<Base>>>;
 
 public:
-    constexpr read_only_adaptor(decays_to<Base> auto&& base)
-        : base_(FLUX_FWD(base))
+    constexpr explicit read_only_adaptor(decays_to<Base> auto&& base)
+        : map(FLUX_FWD(base), cast_to_const<const_element_t<Base>>{})
     {}
 
-    struct flux_sequence_traits {
-    private:
-        using const_rvalue_element_t = std::common_reference_t<
-            value_t<Base> const&&, rvalue_element_t<Base>>;
-
-    public:
-        using value_type = value_t<Base>;
-
-        static constexpr auto first(auto& self) -> cursor_t<Base> { return flux::first(self.base_); }
-
-        static constexpr auto is_last(auto& self, cursor_t<Base> const& cur) -> bool
-        {
-            return flux::is_last(self.base_,  cur);
-        }
-
-        static constexpr auto inc(auto& self, cursor_t<Base>& cur) -> void
-        {
-            flux::inc(self.base_, cur);
-        }
-
-        static constexpr auto read_at(auto& self, cursor_t<Base> const& cur)
-            -> const_element_t<Base>
-        {
-            return static_cast<const_element_t<Base>>(flux::read_at(self.base_, cur));
-        }
-
-        static constexpr auto read_at_unchecked(auto& self, cursor_t<Base> const& cur)
-            -> const_element_t<Base>
-        {
-            return static_cast<const_element_t<Base>>(flux::read_at_unchecked(self.base_, cur));
-        }
-
-        static constexpr auto move_at(auto& self, cursor_t<Base> const& cur)
-            -> const_rvalue_element_t
-        {
-            return static_cast<const_rvalue_element_t>(flux::move_at(self.base_, cur));
-        }
-
-        static constexpr auto move_at_unchecked(auto& self, cursor_t<Base> const& cur)
-            -> const_rvalue_element_t
-        {
-            return static_cast<const_rvalue_element_t>(flux::move_at_unchecked(self.base_, cur));
-        }
-
-        static constexpr auto last(auto& self) -> cursor_t<Base>
-            requires bounded_sequence<Base>
-        {
-            return flux::last(self.base_);
-        }
-
-        static constexpr auto dec(auto& self, cursor_t<Base>& cur)
-            requires bidirectional_sequence<Base>
-        {
-            return flux::dec(self.base_, cur);
-        }
-
-        static constexpr auto inc(auto& self, cursor_t<Base>& cur, distance_t o)
-            requires random_access_sequence<Base>
-        {
-            return flux::inc(self.base_, cur, o);
-        }
-
-        static constexpr auto distance(auto& self, cursor_t<Base> const& from,
-                                       cursor_t<Base> const& to) -> distance_t
-            requires random_access_sequence<Base>
-        {
-            return flux::distance(self.base_, from, to);
-        }
-
-        static constexpr auto size(auto& self) -> distance_t
-            requires sized_sequence<Base>
-        {
-            return flux::size(self.base_);
-        }
-
+    struct flux_sequence_traits : map::flux_sequence_traits {
         static constexpr auto data(auto& self)
             requires contiguous_sequence<Base>
         {
             using P = std::add_pointer_t<std::remove_reference_t<const_element_t<Base>>>;
-            return static_cast<P>(flux::data(self.base_));
-        }
-
-        static constexpr auto for_each_while(auto& self, auto&& pred)
-        {
-            return flux::for_each_while(self.base_, [&pred](auto&& elem) {
-                return std::invoke(pred, static_cast<const_element_t<Base>>(FLUX_FWD(elem)));
-            });
+            return static_cast<P>(flux::data(self.base()));
         }
     };
-
-
 };
 
 struct read_only_fn {

--- a/test/test_read_only.cpp
+++ b/test/test_read_only.cpp
@@ -19,7 +19,7 @@ constexpr bool test_read_only() {
     {
         std::array arr{1, 2, 3, 4, 5};
 
-        auto seq = flux::read_only(flux::ref(arr));
+        auto seq = flux::read_only(flux::mut_ref(arr));
         using S = decltype(seq);
 
         static_assert(flux::contiguous_sequence<S>);


### PR DESCRIPTION
* Fix broken `read_only()` test
* Implement `read_only_adaptor` by inheriting from `map_adaptor` and adding `data()` in the case where `Base` is a `contiguous_sequence`

Fixes #96  