### PR TITLE
Update the internal iteration protocol

### DIFF
--- a/include/flux/op/filter.hpp
+++ b/include/flux/op/filter.hpp
@@ -97,15 +97,30 @@ public:
             return flux::last(self.base_);
         }
 
-        static constexpr auto for_each_while(self_t& self, auto&& func) -> cursor_t<Base>
+        static constexpr auto iterate_while(self_t& self, cursor_t<Base> from,
+                                            auto&& func) -> cursor_t<Base>
         {
-            return flux::for_each_while(self.base_, [&](auto&& elem) {
+            return flux::iterate_while(self.base_, std::move(from), [&](auto&& elem) {
                 if (std::invoke(self.pred_, elem)) {
                     return std::invoke(func, FLUX_FWD(elem));
                 } else {
                     return true;
                 }
             });
+        }
+
+        static constexpr auto iterate_while(self_t& self, cursor_t<Base> from,
+                                            cursor_t<Base> to, auto&& func)
+            -> cursor_t<Base>
+        {
+            return flux::iterate_while(self.base_, std::move(from), std::move(to),
+                                       [&](auto&& elem) {
+                    if (std::invoke(self.pred_, elem)) {
+                        return std::invoke(func, FLUX_FWD(elem));
+                    } else {
+                        return true;
+                    }
+                });
         }
     };
 };

--- a/include/flux/op/for_each_while.hpp
+++ b/include/flux/op/for_each_while.hpp
@@ -18,16 +18,7 @@ struct for_each_while_fn {
                  boolean_testable<std::invoke_result_t<Pred&, element_t<Seq>>>
     constexpr auto operator()(Seq&& seq, Pred pred) const -> cursor_t<Seq>
     {
-        if constexpr (requires { traits_t<Seq>::for_each_while(seq, std::move(pred)); }) {
-            return traits_t<Seq>::for_each_while(seq, std::move(pred));
-        } else {
-            auto cur = first(seq);
-            while (!is_last(seq, cur)) {
-                if (!std::invoke(pred, read_at(seq, cur))) { break; }
-                inc(seq, cur);
-            }
-            return cur;
-        }
+        return iterate_while(seq, FLUX_FWD(pred), flux::first(seq));
     }
 };
 

--- a/include/flux/op/for_each_while.hpp
+++ b/include/flux/op/for_each_while.hpp
@@ -18,7 +18,7 @@ struct for_each_while_fn {
                  boolean_testable<std::invoke_result_t<Pred&, element_t<Seq>>>
     constexpr auto operator()(Seq&& seq, Pred pred) const -> cursor_t<Seq>
     {
-        return iterate_while(seq, FLUX_FWD(pred), flux::first(seq));
+        return iterate_while(seq, flux::first(seq), FLUX_FWD(pred));
     }
 };
 

--- a/include/flux/op/map.hpp
+++ b/include/flux/op/map.hpp
@@ -49,11 +49,23 @@ public:
             return std::invoke(self.func_, flux::read_at(self.base_, cur));
         }
 
-        static constexpr auto for_each_while(auto& self, auto&& pred)
+        static constexpr auto iterate_while(auto& self, cursor_t<Base> from,
+                                            auto&& pred)
+            -> cursor_t<Base>
         {
-            return flux::for_each_while(self.base_, [&](auto&& elem) {
+            return flux::iterate_while(self.base_, std::move(from), [&](auto&& elem) {
                 return std::invoke(pred, std::invoke(self.func_, FLUX_FWD(elem)));
             });
+        }
+
+        static constexpr auto iterate_while(auto& self, cursor_t<Base> from,
+                                            cursor_t<Base> to, auto&& pred)
+            -> cursor_t<Base>
+        {
+            return flux::iterate_while(self.base_, std::move(from),
+                                       std::move(to), [&](auto&& elem) {
+                    return std::invoke(pred, std::invoke(self.func_, FLUX_FWD(elem)));
+                });
         }
 
         static void move_at() = delete; // Use the base version of move_at


### PR DESCRIPTION
This is an experimental PR to try out the ideas in #99, namely replacing the existing `for_each_while(seq, pred) -> cursor_t` customisation point with a new pair of customisation points:

```cpp
auto iterate_while(auto& seq, auto pred, cursor_t from) -> cursor_t;
auto iterate_while(auto& seq, auto pred, cursor_t from, cursor_t to) -> cursor_t;
```

The idea being that this will allow us to use internal iteration in more places.

A rough plan of action:

* [x] Add `flux::iterate_while` wrapper functions
* [x] Implement `flux::for_each_while` using `iterate_while`
* [ ] Replace existing `for_each_while` custom implementations with `iterate_while` customisations:
    - [x] `T[N]`
    - [x] `std::reference_wrapper`
    - [x] `ranges::contiguous_range`
    - [ ]  `simple_sequence_base`
    - [ ] `chain_adaptor`
    - [ ] `cycle_adaptor`
    - [x] `filter_adaptor`
    - [ ] (multipass) `flatten_adaptor` 
    - [x] `map_adaptor`
    - [ ] `passthrough_traits_base`
    - [ ] `reverse_adaptor`
    - [ ] `scan_adaptor`
    - [ ] `scan_first_adaptor`
    - [ ] `take_adaptor`
    - [ ] `take_while_adaptor`
    - [ ] `array_ptr`
    - [ ] `range_sequence`
    - [ ] `repeat_sequence`
    - [ ] `single_sequence`
    - [ ] `unfold_sequence`
* [ ] Verify that we're again getting internal iteration happening in all the places it did before
* [ ] Update `fold_first` to use `iterate_while`
* [ ] Implement `iterate_while` for `subsequence`
* [ ] Add a benchmark to verify that we're now getting improved performance with the new changes
* [ ] Add documentation for `iterate_while`


