### PR TITLE
Low level optimizations for contiguous sequences

### DIFF
--- a/include/flux/core/utils.hpp
+++ b/include/flux/core/utils.hpp
@@ -70,6 +70,13 @@ FLUX_EXPORT
 template <std::integral To>
 inline constexpr auto checked_cast = detail::checked_cast_fn<To>{};
 
+namespace detail {
+
+template <typename T, typename... U>
+concept any_of = (std::same_as<T, U> || ...);
+
+} // namespace detail
+
 } // namespace flux
 
 #endif

--- a/include/flux/op/compare.hpp
+++ b/include/flux/op/compare.hpp
@@ -73,8 +73,13 @@ public:
                 auto const seq1_size = flux::usize(seq1);
                 auto const seq2_size = flux::usize(seq2);
                 auto min_size = std::min(seq1_size, seq2_size);
+            
+                FLUX_ASSERT(flux::data(seq1) != nullptr);
+                FLUX_ASSERT(flux::data(seq2) != nullptr);
+            
                 auto cmp_result =
                     std::memcmp(flux::data(seq1), flux::data(seq2), min_size);
+            
                 if (cmp_result == 0) {
                     if (seq1_size == seq2_size) {
                         return std::strong_ordering::equal;

--- a/include/flux/op/compare.hpp
+++ b/include/flux/op/compare.hpp
@@ -25,7 +25,7 @@ concept is_comparison_category =
 struct compare_fn {
 private:
     template <typename Seq1, typename Seq2, typename Cmp>
-    static constexpr auto impl(Seq1 &&seq1, Seq2 &&seq2, Cmp cmp = {})
+    static constexpr auto impl(Seq1& seq1, Seq2& seq2, Cmp& cmp)
         -> std::decay_t<
             std::invoke_result_t<Cmp &, element_t<Seq1>, element_t<Seq2>>>
     {
@@ -58,12 +58,13 @@ public:
     {
         constexpr bool can_memcmp = 
             std::same_as<Cmp, std::compare_three_way> &&
-            contiguous_sequence<Seq1> && contiguous_sequence<Seq2> &&
-            sized_sequence<Seq1> && sized_sequence<Seq2> &&
+            contiguous_sequence<Seq1> && 
+            contiguous_sequence<Seq2> &&
+            sized_sequence<Seq1> && 
+            sized_sequence<Seq2> &&
             std::same_as<value_t<Seq1>, value_t<Seq2>> &&
             std::unsigned_integral<value_t<Seq1>> &&
-            ((sizeof(value_t<Seq1>) == 1) ||
-                (std::endian::native == std::endian::big));
+            ((sizeof(value_t<Seq1>) == 1) || (std::endian::native == std::endian::big));
 
         if constexpr (can_memcmp) {
             if (std::is_constant_evaluated()) {

--- a/include/flux/op/compare.hpp
+++ b/include/flux/op/compare.hpp
@@ -73,13 +73,18 @@ public:
                 auto const seq1_size = flux::usize(seq1);
                 auto const seq2_size = flux::usize(seq2);
                 auto min_size = std::min(seq1_size, seq2_size);
-            
-                FLUX_ASSERT(flux::data(seq1) != nullptr);
-                FLUX_ASSERT(flux::data(seq2) != nullptr);
-            
-                auto cmp_result =
-                    std::memcmp(flux::data(seq1), flux::data(seq2), min_size);
-            
+
+                int cmp_result = 0;
+                if(min_size > 0)
+                {
+                    auto data1 = flux::data(seq1);
+                    FLUX_ASSERT(data1 != nullptr);
+                    auto data2 = flux::data(seq2);
+                    FLUX_ASSERT(data2 != nullptr);
+
+                    cmp_result = std::memcmp(data1, data2, min_size);
+                }
+
                 if (cmp_result == 0) {
                     if (seq1_size == seq2_size) {
                         return std::strong_ordering::equal;

--- a/include/flux/op/compare.hpp
+++ b/include/flux/op/compare.hpp
@@ -75,8 +75,7 @@ public:
                 auto min_size = std::min(seq1_size, seq2_size);
 
                 int cmp_result = 0;
-                if(min_size > 0)
-                {
+                if(min_size > 0) {
                     auto data1 = flux::data(seq1);
                     FLUX_ASSERT(data1 != nullptr);
                     auto data2 = flux::data(seq2);

--- a/include/flux/op/equal.hpp
+++ b/include/flux/op/equal.hpp
@@ -45,12 +45,13 @@ public:
             }
         }
 
-        constexpr bool can_memcmp = contiguous_sequence<Seq1> &&
-            contiguous_sequence<Seq2> && sized_sequence<Seq1> &&
-            sized_sequence<Seq2> &&
-            std::is_trivially_copyable_v<value_t<Seq1>> &&
-            std::is_trivially_copyable_v<value_t<Seq2>> &&
-            std::same_as<value_t<Seq1>, value_t<Seq2>>;
+        constexpr bool can_memcmp = 
+            std::same_as<Cmp, std::ranges::equal_to> &&
+            contiguous_sequence<Seq1> && contiguous_sequence<Seq2> &&
+            sized_sequence<Seq1> && sized_sequence<Seq2> &&
+            std::same_as<value_t<Seq1>, value_t<Seq2>> &&
+            (std::integral<value_t<Seq1>> || std::is_pointer_v<value_t<Seq1>>) &&
+            std::has_unique_object_representations_v<value_t<Seq1>>;
 
         if constexpr (can_memcmp) {
             if (std::is_constant_evaluated()) {

--- a/include/flux/op/equal.hpp
+++ b/include/flux/op/equal.hpp
@@ -57,21 +57,17 @@ public:
             if (std::is_constant_evaluated()) {
                 return impl(seq1, seq2, cmp);
             } else {
-                auto size1 = flux::usize(seq1);
-                auto size2 = flux::usize(seq2);
-                if(size1 == 0 && size2 == 0) 
-                {
+                auto size = flux::usize(seq1);
+                if(size == 0) {
                     return true;
                 }
-                else if(size1 != size2 && (size1 == 0 || size2 == 0)) {
-                    return false;
-                }
 
-                FLUX_ASSERT(flux::data(seq1) != nullptr);
-                FLUX_ASSERT(flux::data(seq2) != nullptr);
+                auto data1 = flux::data(seq1);
+                auto data2 = flux::data(seq2);
+                FLUX_ASSERT(data1 != nullptr);
+                FLUX_ASSERT(data2 != nullptr);
 
-                auto result = std::memcmp(flux::data(seq1), flux::data(seq2),
-                    flux::usize(seq1) * sizeof(value_t<Seq1>));
+                auto result = std::memcmp(data1, data2, size * sizeof(value_t<Seq1>));
                 return result == 0;
             }
         } else {

--- a/include/flux/op/equal.hpp
+++ b/include/flux/op/equal.hpp
@@ -7,22 +7,18 @@
 #define FLUX_OP_EQUAL_HPP_INCLUDED
 
 #include <flux/core.hpp>
+#include <type_traits>
+#include <cstring>
 
 namespace flux {
 
 namespace detail {
 
 struct equal_fn {
-    template <sequence Seq1, sequence Seq2, typename Cmp = std::ranges::equal_to>
-        requires std::predicate<Cmp&, element_t<Seq1>, element_t<Seq2>>
-    constexpr auto operator()(Seq1&& seq1, Seq2&& seq2, Cmp cmp = {}) const -> bool
+private:
+    template <typename Seq1, typename Seq2, typename Cmp>
+    static constexpr auto impl(Seq1& seq1, Seq2& seq2, Cmp cmp)
     {
-        if constexpr (sized_sequence<Seq1> && sized_sequence<Seq2>) {
-            if (flux::size(seq1) != flux::size(seq2)) {
-                return false;
-            }
-        }
-
         auto cur1 = flux::first(seq1);
         auto cur2 = flux::first(seq2);
 
@@ -37,6 +33,37 @@ struct equal_fn {
         return flux::is_last(seq1, cur1) == flux::is_last(seq2, cur2);
     }
 
+public:
+    template <sequence Seq1, sequence Seq2, typename Cmp = std::ranges::equal_to>
+        requires std::predicate<Cmp&, element_t<Seq1>, element_t<Seq2>>
+    constexpr auto operator()(Seq1&& seq1, Seq2&& seq2, Cmp cmp = {}) const
+        -> bool
+    {
+        if constexpr (sized_sequence<Seq1> && sized_sequence<Seq2>) {
+            if (flux::size(seq1) != flux::size(seq2)) {
+                return false;
+            }
+        }
+
+        constexpr bool cam_memcmp = contiguous_sequence<Seq1> &&
+            contiguous_sequence<Seq2> && sized_sequence<Seq1> &&
+            sized_sequence<Seq2> &&
+            std::is_trivially_copyable_v<value_t<Seq1>> &&
+            std::is_trivially_copyable_v<value_t<Seq2>> &&
+            std::same_as<value_t<Seq1>, value_t<Seq2>>;
+
+        if constexpr (cam_memcmp) {
+            if (std::is_constant_evaluated()) {
+                return impl(seq1, seq2, cmp);
+            } else {
+                auto result = std::memcmp(flux::data(seq1), flux::data(seq2),
+                    flux::usize(seq1) * sizeof(value_t<Seq1>));
+                return result == 0;
+            }
+        } else {
+            return impl(seq1, seq2, cmp);
+        }
+    }
 };
 
 } // namespace detail

--- a/include/flux/op/equal.hpp
+++ b/include/flux/op/equal.hpp
@@ -57,7 +57,16 @@ public:
             if (std::is_constant_evaluated()) {
                 return impl(seq1, seq2, cmp);
             } else {
-                
+                auto size1 = flux::usize(seq1);
+                auto size2 = flux::usize(seq2);
+                if(size1 == 0 && size2 == 0) 
+                {
+                    return true;
+                }
+                else if(size1 != size2 && (size1 == 0 || size2 == 0)) {
+                    return false;
+                }
+
                 FLUX_ASSERT(flux::data(seq1) != nullptr);
                 FLUX_ASSERT(flux::data(seq2) != nullptr);
 

--- a/include/flux/op/equal.hpp
+++ b/include/flux/op/equal.hpp
@@ -45,14 +45,14 @@ public:
             }
         }
 
-        constexpr bool cam_memcmp = contiguous_sequence<Seq1> &&
+        constexpr bool can_memcmp = contiguous_sequence<Seq1> &&
             contiguous_sequence<Seq2> && sized_sequence<Seq1> &&
             sized_sequence<Seq2> &&
             std::is_trivially_copyable_v<value_t<Seq1>> &&
             std::is_trivially_copyable_v<value_t<Seq2>> &&
             std::same_as<value_t<Seq1>, value_t<Seq2>>;
 
-        if constexpr (cam_memcmp) {
+        if constexpr (can_memcmp) {
             if (std::is_constant_evaluated()) {
                 return impl(seq1, seq2, cmp);
             } else {

--- a/include/flux/op/equal.hpp
+++ b/include/flux/op/equal.hpp
@@ -57,6 +57,10 @@ public:
             if (std::is_constant_evaluated()) {
                 return impl(seq1, seq2, cmp);
             } else {
+                
+                FLUX_ASSERT(flux::data(seq1) != nullptr);
+                FLUX_ASSERT(flux::data(seq2) != nullptr);
+
                 auto result = std::memcmp(flux::data(seq1), flux::data(seq2),
                     flux::usize(seq1) * sizeof(value_t<Seq1>));
                 return result == 0;

--- a/include/flux/op/fill.hpp
+++ b/include/flux/op/fill.hpp
@@ -28,8 +28,9 @@ public:
         constexpr bool can_memset = 
             contiguous_sequence<Seq> &&
             sized_sequence<Seq> &&
+            std::same_as<Value, value_t<Seq>> &&
             // only allow memset on single byte types
-            sizeof(value) == sizeof(std::uint8_t) &&
+            sizeof(value_t<Seq>) == 1 &&
             std::is_trivially_copyable_v<value_t<Seq>>;
 
         if constexpr (can_memset) {

--- a/include/flux/op/fill.hpp
+++ b/include/flux/op/fill.hpp
@@ -38,14 +38,14 @@ public:
                 impl(seq, value);
             } else {
                 auto size = flux::usize(seq);
-                if(size == 0){
+                if(size == 0) {
                     return;
                 }
                 
                 FLUX_ASSERT(flux::data(seq) != nullptr);
                 
                 std::memset(flux::data(seq), value,
-                    flux::usize(seq) * sizeof(value_t<Seq>));
+                    size * sizeof(value_t<Seq>));
             }
         } else {
             impl(seq, value);

--- a/include/flux/op/fill.hpp
+++ b/include/flux/op/fill.hpp
@@ -6,18 +6,42 @@
 #define FLUX_OP_FILL_HPP_INCLUDED
 
 #include <flux/op/for_each.hpp>
+#include <type_traits>
+#include <cstring>
 
 namespace flux {
 
 namespace detail {
 
 struct fill_fn {
+private:
+    template <typename Seq, typename Value>
+    static constexpr auto impl(Seq& seq, Value& value)
+    {
+        flux::for_each(seq, [&value](auto&& elem) { FLUX_FWD(elem) = value; });
+    }
+
+public:
     template <typename Value, writable_sequence_of<Value> Seq>
     constexpr void operator()(Seq&& seq, Value const& value) const
     {
-        flux::for_each(seq, [&value](auto&& elem) {
-            FLUX_FWD(elem) = value;
-        });
+        constexpr bool can_memset = 
+            contiguous_sequence<Seq> &&
+            sized_sequence<Seq> &&
+            // only allow memset on single byte types
+            sizeof(value) == sizeof(std::uint8_t) &&
+            std::is_trivially_copyable_v<value_t<Seq>>;
+
+        if constexpr (can_memset) {
+            if (std::is_constant_evaluated()) {
+                impl(seq, value);
+            } else {
+                std::memset(flux::data(seq), value,
+                    flux::usize(seq) * sizeof(value_t<Seq>));
+            }
+        } else {
+            impl(seq, value);
+        }
     }
 };
 

--- a/include/flux/op/fill.hpp
+++ b/include/flux/op/fill.hpp
@@ -37,6 +37,9 @@ public:
             if (std::is_constant_evaluated()) {
                 impl(seq, value);
             } else {
+                auto size = flux::usize(seq);
+                if(size == 0) return;
+                
                 FLUX_ASSERT(flux::data(seq) != nullptr);
                 
                 std::memset(flux::data(seq), value,

--- a/include/flux/op/fill.hpp
+++ b/include/flux/op/fill.hpp
@@ -37,6 +37,8 @@ public:
             if (std::is_constant_evaluated()) {
                 impl(seq, value);
             } else {
+                FLUX_ASSERT(flux::data(seq) != nullptr);
+                
                 std::memset(flux::data(seq), value,
                     flux::usize(seq) * sizeof(value_t<Seq>));
             }

--- a/include/flux/op/fill.hpp
+++ b/include/flux/op/fill.hpp
@@ -38,7 +38,9 @@ public:
                 impl(seq, value);
             } else {
                 auto size = flux::usize(seq);
-                if(size == 0) return;
+                if(size == 0){
+                    return;
+                }
                 
                 FLUX_ASSERT(flux::data(seq) != nullptr);
                 

--- a/include/flux/op/fill.hpp
+++ b/include/flux/op/fill.hpp
@@ -16,7 +16,7 @@ namespace detail {
 struct fill_fn {
 private:
     template <typename Seq, typename Value>
-    static constexpr auto impl(Seq& seq, Value& value)
+    static constexpr auto impl(Seq& seq, Value const& value)
     {
         flux::for_each(seq, [&value](auto&& elem) { FLUX_FWD(elem) = value; });
     }

--- a/include/flux/op/find.hpp
+++ b/include/flux/op/find.hpp
@@ -43,7 +43,7 @@ public:
             auto location = std::memchr(flux::data(seq), static_cast<unsigned char>(value),
                 flux::usize(seq) * sizeof(value_t<Seq>));
             if (location == nullptr) {
-                return flux::usize(seq);
+                return flux::last(seq);
             } else {
                 auto offset = static_cast<value_t<Seq> const*>(location) - flux::data(seq);
                 return flux::next(seq, flux::first(seq), offset);

--- a/include/flux/op/find.hpp
+++ b/include/flux/op/find.hpp
@@ -41,12 +41,12 @@ public:
                 return impl(seq, value);
             } else {
                 auto size = flux::usize(seq);
-                if(size == 0) {
+                if (size == 0) {
                     return flux::last(seq);
                 }
                 FLUX_ASSERT(flux::data(seq) != nullptr);
                 auto location = std::memchr(flux::data(seq), static_cast<unsigned char>(value),
-                    flux::usize(seq) * sizeof(value_t<Seq>));
+                    size * sizeof(value_t<Seq>));
                 if (location == nullptr) {
                     return flux::last(seq);
                 } else {

--- a/include/flux/op/find.hpp
+++ b/include/flux/op/find.hpp
@@ -39,16 +39,17 @@ public:
         if constexpr (can_memchr) {
             if (std::is_constant_evaluated()) {
                 return impl(seq, value);
-            }
-            auto location = std::memchr(flux::data(seq), static_cast<unsigned char>(value),
-                flux::usize(seq) * sizeof(value_t<Seq>));
-            if (location == nullptr) {
-                return flux::last(seq);
             } else {
-                auto offset = static_cast<value_t<Seq> const*>(location) - flux::data(seq);
-                return flux::next(seq, flux::first(seq), offset);
+                FLUX_ASSERT(flux::data(seq) != nullptr);
+                auto location = std::memchr(flux::data(seq), static_cast<unsigned char>(value),
+                    flux::usize(seq) * sizeof(value_t<Seq>));
+                if (location == nullptr) {
+                    return flux::last(seq);
+                } else {
+                    auto offset = static_cast<value_t<Seq> const*>(location) - flux::data(seq);
+                    return flux::next(seq, flux::first(seq), offset);
+                }
             }
-
         } else {
             return impl(seq, value);
         }

--- a/include/flux/op/find.hpp
+++ b/include/flux/op/find.hpp
@@ -40,6 +40,8 @@ public:
             if (std::is_constant_evaluated()) {
                 return impl(seq, value);
             } else {
+                auto size = flux::usize(seq);
+                if(size == 0) return flux::last(seq);
                 FLUX_ASSERT(flux::data(seq) != nullptr);
                 auto location = std::memchr(flux::data(seq), static_cast<unsigned char>(value),
                     flux::usize(seq) * sizeof(value_t<Seq>));

--- a/include/flux/op/find.hpp
+++ b/include/flux/op/find.hpp
@@ -6,20 +6,52 @@
 #ifndef FLUX_OP_FIND_HPP_INCLUDED
 #define FLUX_OP_FIND_HPP_INCLUDED
 
+#include <flux/core/utils.hpp>
 #include <flux/op/for_each_while.hpp>
+
+#include <cstring>
+#include <type_traits>
 
 namespace flux {
 
 namespace detail {
 
 struct find_fn {
-    template <sequence Seq, typename Value>
-        requires std::equality_comparable_with<element_t<Seq>, Value const&>
-    constexpr auto operator()(Seq&& seq, Value const& value) const -> cursor_t<Seq>
+private:
+    template <typename Seq, typename Value>
+    static constexpr auto impl(Seq&& seq, Value const& value) -> cursor_t<Seq>
     {
         return for_each_while(seq, [&](auto&& elem) {
             return FLUX_FWD(elem) != value;
         });
+    }
+
+public:
+    template <sequence Seq, typename Value>
+        requires std::equality_comparable_with<element_t<Seq>, Value const&>
+    constexpr auto operator()(Seq&& seq, Value const& value) const -> cursor_t<Seq>
+    {
+        constexpr auto can_memchr = 
+            contiguous_sequence<Seq> && sized_sequence<Seq> && 
+            std::same_as<Value, value_t<Seq>> &&
+            flux::detail::any_of<value_t<Seq>, char, signed char, unsigned char, char8_t, std::byte>;
+
+        if constexpr (can_memchr) {
+            if (std::is_constant_evaluated()) {
+                return impl(seq, value);
+            }
+            auto location = std::memchr(flux::data(seq), static_cast<unsigned char>(value),
+                flux::usize(seq) * sizeof(value_t<Seq>));
+            if (location == nullptr) {
+                return flux::usize(seq);
+            } else {
+                auto offset = static_cast<value_t<Seq> const*>(location) - flux::data(seq);
+                return flux::next(seq, flux::first(seq), offset);
+            }
+
+        } else {
+            return impl(seq, value);
+        }
     }
 };
 

--- a/include/flux/op/find.hpp
+++ b/include/flux/op/find.hpp
@@ -41,7 +41,9 @@ public:
                 return impl(seq, value);
             } else {
                 auto size = flux::usize(seq);
-                if(size == 0) return flux::last(seq);
+                if(size == 0) {
+                    return flux::last(seq);
+                }
                 FLUX_ASSERT(flux::data(seq) != nullptr);
                 auto location = std::memchr(flux::data(seq), static_cast<unsigned char>(value),
                     flux::usize(seq) * sizeof(value_t<Seq>));

--- a/include/flux/op/output_to.hpp
+++ b/include/flux/op/output_to.hpp
@@ -42,6 +42,7 @@ public:
             if (std::is_constant_evaluated()) {
                 return impl(seq, iter);
             } else {
+                FLUX_ASSERT(flux::data(seq) != nullptr);
                 std::memmove(std::to_address(iter), flux::data(seq),
                              flux::usize(seq) * sizeof(value_t<Seq>));
                 return iter + checked_cast<std::iter_difference_t<Iter>>(flux::size(seq));

--- a/include/flux/op/output_to.hpp
+++ b/include/flux/op/output_to.hpp
@@ -43,12 +43,12 @@ public:
                 return impl(seq, iter);
             } else {
                 auto size = flux::usize(seq);
-                if(size == 0) {
+                if (size == 0) {
                     return iter;
                 }
                 FLUX_ASSERT(flux::data(seq) != nullptr);
                 std::memmove(std::to_address(iter), flux::data(seq),
-                             flux::usize(seq) * sizeof(value_t<Seq>));
+                             size * sizeof(value_t<Seq>));
                 return iter + checked_cast<std::iter_difference_t<Iter>>(flux::size(seq));
             }
         } else {

--- a/include/flux/op/output_to.hpp
+++ b/include/flux/op/output_to.hpp
@@ -42,6 +42,10 @@ public:
             if (std::is_constant_evaluated()) {
                 return impl(seq, iter);
             } else {
+                auto size = flux::usize(seq);
+                if(size == 0) {
+                    return iter;
+                }
                 FLUX_ASSERT(flux::data(seq) != nullptr);
                 std::memmove(std::to_address(iter), flux::data(seq),
                              flux::usize(seq) * sizeof(value_t<Seq>));

--- a/include/flux/op/split_string.hpp
+++ b/include/flux/op/split_string.hpp
@@ -7,15 +7,13 @@
 #define FLUX_STRING_SPLIT_HPP_INCLUDED
 
 #include <flux/op/split.hpp>
+#include <flux/core/utils.hpp>
 
 #include <string_view>
 
 namespace flux {
 
 namespace detail {
-
-template <typename T, typename... U>
-concept any_of = (std::same_as<T, U> || ...);
 
 template <typename C>
 concept character = any_of<C, char, wchar_t, char8_t, char16_t, char32_t>;

--- a/single_include/flux.hpp
+++ b/single_include/flux.hpp
@@ -11079,7 +11079,6 @@ public:
             if (std::is_constant_evaluated()) {
                 return impl(seq, iter);
             } else {
-                FLUX_ASSERT(flux::data(seq) != nullptr);
                 std::memmove(std::to_address(iter), flux::data(seq),
                              flux::usize(seq) * sizeof(value_t<Seq>));
                 return iter + checked_cast<std::iter_difference_t<Iter>>(flux::size(seq));

--- a/single_include/flux.hpp
+++ b/single_include/flux.hpp
@@ -11079,6 +11079,7 @@ public:
             if (std::is_constant_evaluated()) {
                 return impl(seq, iter);
             } else {
+                FLUX_ASSERT(flux::data(seq) != nullptr);
                 std::memmove(std::to_address(iter), flux::data(seq),
                              flux::usize(seq) * sizeof(value_t<Seq>));
                 return iter + checked_cast<std::iter_difference_t<Iter>>(flux::size(seq));

--- a/test/test_compare.cpp
+++ b/test/test_compare.cpp
@@ -117,6 +117,24 @@ constexpr bool test_compare()
         STATIC_CHECK(r == std::strong_ordering::equal);
     }
 
+    {
+        std::array<std::uint8_t, 3> arr1{1, 2, 3};
+        std::array<std::uint8_t, 3> arr2{1, 2, 3};
+        auto r = flux::compare(arr1, arr2);
+
+        static_assert(std::same_as<decltype(r), std::strong_ordering>);
+        STATIC_CHECK(r == std::strong_ordering::equal);
+    }
+
+    {
+        std::array<std::uint8_t, 3> arr1{1, 2, 3};
+        std::array<std::uint8_t, 0> arr2{};
+        auto r = flux::compare(arr1, arr2);
+
+        static_assert(std::same_as<decltype(r), std::strong_ordering>);
+        STATIC_CHECK(r == std::strong_ordering::greater);
+    }
+
     return true;
 }
 static_assert(test_compare());

--- a/test/test_compare.cpp
+++ b/test/test_compare.cpp
@@ -130,9 +130,24 @@ constexpr bool test_compare()
         std::array<std::uint8_t, 3> arr1{1, 2, 3};
         std::array<std::uint8_t, 0> arr2{};
         auto r = flux::compare(arr1, arr2);
-
         static_assert(std::same_as<decltype(r), std::strong_ordering>);
         STATIC_CHECK(r == std::strong_ordering::greater);
+        
+        auto r2 = flux::compare(arr2, arr1);
+        STATIC_CHECK(r2 == std::strong_ordering::less);
+    }
+
+    {
+        std::array<std::uint8_t, 3> arr1{1, 2, 3};
+        std::array<std::uint8_t, 3> arr2{1, 2, 4};
+        
+        auto r1 = flux::compare(arr1, arr2);
+        
+        static_assert(std::same_as<decltype(r1), std::strong_ordering>);
+        STATIC_CHECK(r1 == std::strong_ordering::less);
+        
+        auto r2 = flux::compare(arr2, arr1);
+        STATIC_CHECK(r2 == std::strong_ordering::greater);
     }
 
     return true;

--- a/test/test_equal.cpp
+++ b/test/test_equal.cpp
@@ -97,6 +97,11 @@ constexpr bool test_equal()
         static_assert(flux::equal(flux::empty<int>, flux::empty<float>));
     }
 
+    {
+        std::array<int, 0> arr;
+        STATIC_CHECK(flux::equal(arr, arr) == true);
+    }
+
     return true;
 }
 static_assert(test_equal());

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -68,6 +68,13 @@ constexpr bool test_fill()
         STATIC_CHECK(check_equal(arr, {5, 5, 5, 5, 5}));
     }
 
+    // fill empty sequence with char
+    {
+        std::array<std::uint8_t, 0> arr{};
+        std::uint8_t c = 5;
+        flux::fill(arr, c);
+    }
+
     return true;
 }
 

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -53,15 +53,24 @@ constexpr bool test_fill()
 
     // single sequences can be filled
     {
-        auto s= flux::single(0);
+        auto s = flux::single(0);
 
         flux::fill(s, short{1});
 
         STATIC_CHECK(s.value() == 1);
     }
 
+    // string fill with char
+    {
+        std::array<std::uint8_t, 5> arr{};
+        std::uint8_t c = 5;
+        flux::fill(arr, c);
+        STATIC_CHECK(check_equal(arr, {5, 5, 5, 5, 5}));
+    }
+
     return true;
 }
+
 static_assert(test_fill());
 
 }

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -78,4 +78,9 @@ TEST_CASE("find")
         REQUIRE(idx == std::ssize(vec));
     }
 
+    {
+        std::string_view str = "abcdefg";
+        auto idx = flux::find(str, 'd');
+        REQUIRE(idx == 3);
+    }
 }

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -83,4 +83,10 @@ TEST_CASE("find")
         auto idx = flux::find(str, 'd');
         REQUIRE(idx == 3);
     }
+
+    {
+        std::string str = "";
+        auto idx = flux::find(str, 'a');
+        REQUIRE(idx == flux::last(str));
+    }
 }

--- a/test/test_output_to.cpp
+++ b/test/test_output_to.cpp
@@ -82,4 +82,15 @@ TEST_CASE("output to")
 
         REQUIRE(oss.str() == " hello world!! ");
     }
+    
+    SECTION("...with empty input sequences")
+    {
+        std::vector<int> const in;
+        std::vector<int> out;
+
+        auto iter = flux::output_to(in, out.begin());
+
+        REQUIRE(iter == out.begin());
+        REQUIRE(out.empty());
+    }
 }


### PR DESCRIPTION
## Description

Adds low level optimizations to address #57 

**Optimizations**

- [x] `std::memset` with `fill()`
- [x] `std::memcmp` with `equal()`
- [x] `std::memcmp` with `compare()`
- [x] `std::memchr` with `find()`
- ~~`std::memmem` with `search()`~~
