### PR TITLE
Fix MSVC warnings

### DIFF
--- a/include/flux/core/assert.hpp
+++ b/include/flux/core/assert.hpp
@@ -52,9 +52,9 @@ struct assert_fn {
     constexpr void operator()(bool cond, char const* msg,
                               std::source_location loc = std::source_location::current()) const
     {
-        if (cond) [[likely]] {
+        if (cond) {
             return;
-        } else [[unlikely]] {
+        } else {
             runtime_error(msg, std::move(loc));
         }
     }

--- a/include/flux/op/set_adaptors.hpp
+++ b/include/flux/op/set_adaptors.hpp
@@ -298,8 +298,7 @@ public:
                                           flux::read_at(self.base2_, cur.base2_cursor))) {
                     cur.state_ = cursor_type::first;
                     return;
-                }
-                else {
+                } else {
                     if(std::invoke(self.cmp_, flux::read_at(self.base2_, cur.base2_cursor), 
                                               flux::read_at(self.base1_, cur.base1_cursor))) {
                         cur.state_ = cursor_type::second;
@@ -366,9 +365,13 @@ public:
             -> std::common_reference_t<decltype(flux::read_at(self.base1_, cur.base1_cursor)),
                                        decltype(flux::read_at(self.base2_, cur.base2_cursor))>
         {
-            if (cur.state_ == cursor_type::first || cur.state_ == cursor_type::second_done)
-                return flux::read_at(self.base1_, cur.base1_cursor);
-            return flux::read_at(self.base2_, cur.base2_cursor);
+            using R = std::common_reference_t<decltype(flux::read_at(self.base1_, cur.base1_cursor)),
+                                              decltype(flux::read_at(self.base2_, cur.base2_cursor))>;
+            if (cur.state_ == cursor_type::first || cur.state_ == cursor_type::second_done) {
+                return static_cast<R>(flux::read_at(self.base1_, cur.base1_cursor));
+            } else {
+                return static_cast<R>(flux::read_at(self.base2_, cur.base2_cursor));
+            }
         }
 
         template <typename Self>
@@ -384,11 +387,14 @@ public:
             -> std::common_reference_t<decltype(flux::move_at(self.base1_, cur.base1_cursor)),
                                        decltype(flux::move_at(self.base2_, cur.base2_cursor))>
         {
-            if (cur.state_ == cursor_type::first || cur.state_ == cursor_type::second_done)
-                return flux::move_at(self.base1_, cur.base1_cursor);
-            return flux::move_at(self.base2_, cur.base2_cursor);
+            using R = std::common_reference_t<decltype(flux::move_at(self.base1_, cur.base1_cursor)),
+                                              decltype(flux::move_at(self.base2_, cur.base2_cursor))>;
+            if (cur.state_ == cursor_type::first || cur.state_ == cursor_type::second_done) {
+                return static_cast<R>(flux::move_at(self.base1_, cur.base1_cursor));
+            } else {
+                return static_cast<R>(flux::move_at(self.base2_, cur.base2_cursor));
+            }
         }
-        
     };
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,7 @@ endif()
 if(MSVC)
     target_compile_options(test-libflux PRIVATE /W4
         /wd4459 # local variable name hides global variable
+        /wd4702 # unreachable code
     )
 endif()
 

--- a/test/test_repeat.cpp
+++ b/test/test_repeat.cpp
@@ -53,9 +53,9 @@ constexpr bool test_repeat()
         // Check that internal iteration works as expected
         {
             auto counter = 0;
-            auto cur =
+            auto inner_cur =
                 flux::for_each_while(seq, [&](int) { return counter++ < 5; });
-            STATIC_CHECK(cur == 5);
+            STATIC_CHECK(inner_cur == 5);
         }
     }
 


### PR DESCRIPTION
A couple of warnings have slipped in when compiling with MSVC, so let's squish 'em.

We'll also disable C4702 "unreachable code" as we get a ton of these when compiling the tests with optimisation and they all seem like false positives.