### PR TITLE
Add cmp::min cmp::max

### DIFF
--- a/include/flux/core/functional.hpp
+++ b/include/flux/core/functional.hpp
@@ -253,6 +253,39 @@ FLUX_EXPORT inline constexpr auto odd = detail::predicate([](auto const& val) ->
 
 } // namespace pred
 
+namespace cmp {
+
+namespace detail {
+
+struct min_fn {
+    template <typename T, typename U, typename Cmp = std::ranges::less>
+        requires std::strict_weak_order<Cmp&, T&, U&>
+    [[nodiscard]]
+    constexpr auto operator()(T&& t, U&& u, Cmp cmp = Cmp{}) const
+        -> std::common_reference_t<T, U>
+    {
+        return std::invoke(cmp, u, t) ? FLUX_FWD(u) : FLUX_FWD(t);
+    }
+};
+
+struct max_fn {
+    template <typename T, typename U, typename Cmp = std::ranges::less>
+        requires std::strict_weak_order<Cmp&, T&, U&>
+    [[nodiscard]]
+    constexpr auto operator()(T&& t, U&& u, Cmp cmp = Cmp{}) const
+        -> std::common_reference_t<T, U>
+    {
+        return !std::invoke(cmp, u, t) ? FLUX_FWD(u) : FLUX_FWD(t);
+    }
+};
+
+} // namespace detail
+
+FLUX_EXPORT inline constexpr auto min = detail::min_fn{};
+FLUX_EXPORT inline constexpr auto max = detail::max_fn{};
+
+} // namespace cmp
+
 } // namespace flux
 
 #endif


### PR DESCRIPTION
Because they're ordinary function templates, `std::min` and `std::max` can't be passed as arguments to functions without wrapping them in lambdas (or doing a horrible function pointer cast). This makes me sad.

`std::ranges::min` and `std::ranges::max` **are** function objects and so can be passed as function arguments -- except with MSVC, which annoyingly goes out of its way to prevent you doing this very useful thing. This also makes me sad.

To improve matters, we'll add `flux::cmp::min` and `flux::cmp::max` which take two arguments and an optional comparator and return the lesser and greater respectively.

As an added bonus, `max()` now correctly returns the second argument if both are equal, and our versions of these functions should be less likely than the standard versions to cause dangling when used with rvalues.