### PR TITLE
Add adjacent_filter adaptor

### DIFF
--- a/docs/reference/adaptors.rst
+++ b/docs/reference/adaptors.rst
@@ -46,6 +46,36 @@ Adaptors
         * :func:`flux::pairwise`
         * :func:`flux::slide`
 
+``adjacent_filter``
+^^^^^^^^^^^^^^^^^^^
+
+..  function::
+    template <multipass_sequence Seq, typename Pred> \
+        requires std::predicate<Pred&, element_t<Seq>, element_t<Seq>> \
+    auto adjacent_filter(Seq seq, Pred pred) -> multipass_sequence auto;
+
+    Applies the given binary predicate :var:`pred` to each pair of adjacent elements of :var:`seq`. If the predicate returns ``false``, the second element of the pair does not appear in the resulting sequence. The first element of :var:`seq` is always included in the output.
+
+    The resulting sequence is always multipass; it is also a :concept:`bidirectional_sequence` if :var:`Seq` is bidirectional, and a :concept:`bounded_sequence` if :var:`Seq` is bounded.
+
+    A common use for :func:`adjacent_filter` is to remove adjacent equal elements from a sequence, which can be achieved by passing :expr:`std::not_equal_to{}` as the predicate. The :func:`dedup` function is a handy alias for :expr:`adjacent_filter(not_equal_to{})`.
+
+    :param seq: A multipass sequence
+    :param pred: A binary predicate to compare sequence elements
+
+    :returns: The filtered sequence
+
+    :example:
+
+    ..  literalinclude:: ../../example/docs/adjacent_filter.cpp
+        :language: cpp
+        :dedent:
+        :lines: 15-34
+
+    :see also:
+       * :func:`flux::dedup`
+       * :func:`flux::filter`
+
 
 ``adjacent_map``
 ^^^^^^^^^^^^^^^^
@@ -164,6 +194,18 @@ Adaptors
 
     :see also:
 
+``dedup``
+^^^^^^^^^
+
+..  function::
+    template <multipass_sequence Seq> \
+        requires std::equality_comparable<element_t<Seq>> \
+    auto dedup(Seq seq) -> multipass_sequence auto;
+
+    An alias for :expr:`adjacent_filter(seq, std::ranges::not_equal_to{})`. This can be used to remove adjacent elements from a sequence.
+
+    :see also:
+        * :func:`flux::adjacent_filter`
 
 ``drop``
 ^^^^^^^^

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -18,6 +18,7 @@ add_example(example-shortest-path shortest_path.cpp)
 add_example(example-moving-average moving_average.cpp)
 
 add_example(example-docs-adjacent docs/adjacent.cpp)
+add_example(example-docs-adjacent-filter docs/adjacent_filter.cpp)
 add_example(example-docs-all docs/all.cpp)
 add_example(example-docs-any docs/any.cpp)
 add_example(example-docs-compare docs/compare.cpp)

--- a/example/docs/adjacent_filter.cpp
+++ b/example/docs/adjacent_filter.cpp
@@ -1,0 +1,35 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <flux.hpp>
+
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+int main()
+{
+    std::array nums{1, 1, 2, 3, 3, 2, 2};
+
+    // The adjacent_filter adaptor applies the given predicate to each pair
+    // of elements in the sequence, and if the predicate returns false then
+    // the second element of the pair is discarded
+    auto filtered1 = flux::adjacent_filter(nums, std::less{});
+    assert(flux::equal(filtered1, std::array{1, 2, 3}));
+
+    // For the common case of removing adjacent equal elements, Flux provides
+    // the dedup() function as shorthand for adjacent_filter(std::not_equal_to{})
+    auto filtered2 = flux::dedup(nums);
+    assert(flux::equal(filtered2, std::array{1, 2, 3, 2}));
+
+    // We can use adjacent_filter with a custom comparator as well
+    auto compare = [](auto p1, auto p2) { return p1.first != p2.first; };
+    std::pair<int, int> pairs[] = {{1, 2}, {1, 3}, {1, 4}, {2, 5}, {2, 6}};
+
+    auto filtered3 = flux::adjacent_filter(flux::ref(pairs), compare);
+    assert(flux::equal(filtered3,
+                       std::array{std::pair{1, 2}, std::pair{2, 5}}));
+}

--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -9,6 +9,7 @@
 #include <flux/core.hpp>
 
 #include <flux/op/adjacent.hpp>
+#include <flux/op/adjacent_filter.hpp>
 #include <flux/op/all_any_none.hpp>
 #include <flux/op/begin_end.hpp>
 #include <flux/op/cache_last.hpp>

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -218,6 +218,12 @@ public:
     [[nodiscard]]
     constexpr auto adjacent() && requires multipass_sequence<Derived>;
 
+    template <typename Pred>
+        requires multipass_sequence<Derived> &&
+                 std::predicate<Pred&, element_t<Derived>, element_t<Derived>>
+    [[nodiscard]]
+    constexpr auto adjacent_filter(Pred pred) &&;
+
     template <distance_t N, typename Func>
         requires multipass_sequence<Derived>
     [[nodiscard]]
@@ -246,6 +252,11 @@ public:
 
     [[nodiscard]]
     constexpr auto cycle(std::integral auto count) && requires multipass_sequence<Derived>;
+
+    [[nodiscard]]
+    constexpr auto dedup() &&
+        requires multipass_sequence<Derived> &&
+                 std::equality_comparable<element_t<Derived>>;
 
     [[nodiscard]]
     constexpr auto drop(std::integral auto count) &&;

--- a/include/flux/op/adjacent_filter.hpp
+++ b/include/flux/op/adjacent_filter.hpp
@@ -1,0 +1,151 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_ADJACENT_FILTER_HPP_INCLUDED
+#define FLUX_OP_ADJACENT_FILTER_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+namespace flux {
+
+namespace detail {
+
+template <multipass_sequence Base, typename Pred>
+struct adjacent_filter_adaptor
+    : inline_sequence_base<adjacent_filter_adaptor<Base, Pred>> {
+private:
+    FLUX_NO_UNIQUE_ADDRESS Base base_;
+    FLUX_NO_UNIQUE_ADDRESS Pred pred_;
+
+public:
+    constexpr adjacent_filter_adaptor(decays_to<Base> auto&& base, Pred pred)
+        : base_(FLUX_FWD(base)),
+          pred_(std::move(pred))
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        struct cursor_type {
+            cursor_t<Base> base_cur;
+
+            friend auto operator==(cursor_type const&, cursor_type const&) -> bool
+                = default;
+        };
+
+    public:
+        using value_type = value_t<Base>;
+
+        static constexpr auto first(auto& self) -> cursor_type
+        {
+            return cursor_type{flux::first(self.base_)};
+        }
+
+        static constexpr auto is_last(auto& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.base_cur);
+        }
+
+        static constexpr auto read_at(auto& self, cursor_type const& cur)
+            -> decltype(flux::read_at(self.base_, cur.base_cur))
+        {
+            return flux::read_at(self.base_, cur.base_cur);
+        }
+
+        static constexpr auto read_at_unchecked(auto& self, cursor_type const& cur)
+            -> decltype(flux::read_at_unchecked(self.base_, cur.base_cur))
+        {
+            return flux::read_at_unchecked(self.base_, cur.base_cur);
+        }
+
+        static constexpr auto inc(auto& self, cursor_type& cur) -> void
+        {
+            auto temp = cur.base_cur;
+            flux::inc(self.base_, cur.base_cur);
+
+            while (!flux::is_last(self.base_, cur.base_cur)) {
+                if (std::invoke(self.pred_,
+                                flux::read_at(self.base_, temp),
+                                flux::read_at(self.base_, cur.base_cur))) {
+                    break;
+                }
+                flux::inc(self.base_, cur.base_cur);
+            }
+        }
+
+        static constexpr auto dec(auto& self, cursor_type& cur) -> void
+            requires bidirectional_sequence<Base>
+        {
+            auto first = flux::first(self.base_);
+            FLUX_DEBUG_ASSERT(cur.base_cur != first);
+
+            flux::dec(self.base_, cur.base_cur);
+
+            while (cur.base_cur != first) {
+                auto temp = flux::prev(self.base_, cur.base_cur);
+
+                if (std::invoke(self.pred_, flux::read_at(self.base_, temp),
+                                flux::read_at(self.base_, cur.base_cur))) {
+                    break;
+                }
+                cur.base_cur = std::move(temp);
+            }
+        }
+
+        static constexpr auto last(auto& self) -> cursor_type
+            requires bounded_sequence<Base>
+        {
+            return cursor_type{flux::last(self.base_)};
+        }
+    };
+};
+
+struct adjacent_filter_fn {
+    template <adaptable_sequence Seq, typename Pred>
+        requires multipass_sequence<Seq> &&
+                 std::predicate<Pred&, element_t<Seq>, element_t<Seq>>
+    [[nodiscard]]
+    constexpr auto operator()(Seq&& seq, Pred pred) const -> multipass_sequence auto
+    {
+        return adjacent_filter_adaptor<std::decay_t<Seq>, Pred>(
+            FLUX_FWD(seq), std::move(pred));
+    }
+};
+
+struct dedup_fn {
+    template <adaptable_sequence Seq>
+        requires multipass_sequence<Seq> &&
+                 std::equality_comparable<element_t<Seq>>
+    [[nodiscard]]
+    constexpr auto operator()(Seq&& seq) const -> multipass_sequence auto
+    {
+        return adjacent_filter_fn{}(FLUX_FWD(seq), std::ranges::not_equal_to{});
+    }
+};
+
+} // namespace detail
+
+FLUX_EXPORT inline constexpr auto adjacent_filter = detail::adjacent_filter_fn{};
+FLUX_EXPORT inline constexpr auto dedup = detail::dedup_fn{};
+
+template <typename D>
+template <typename Pred>
+    requires multipass_sequence<D> &&
+             std::predicate<Pred&, element_t<D>, element_t<D>>
+constexpr auto inline_sequence_base<D>::adjacent_filter(Pred pred) &&
+{
+    return flux::adjacent_filter(std::move(derived()), std::move(pred));
+}
+
+template <typename D>
+constexpr auto inline_sequence_base<D>::dedup() &&
+    requires multipass_sequence<D> &&
+             std::equality_comparable<element_t<D>>
+{
+    return flux::dedup(std::move(derived()));
+}
+
+} // namespace flux
+
+#endif // FLUX_OP_ADJACENT_FILTER_HPP_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(test-libflux
     test_apply.cpp
 
     test_adjacent.cpp
+    test_adjacent_filter.cpp
     test_adjacent_map.cpp
     test_all_any_none.cpp
     test_bounds_checked.cpp

--- a/test/test_adjacent_filter.cpp
+++ b/test/test_adjacent_filter.cpp
@@ -1,0 +1,235 @@
+
+// Copyright (c) 2023 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "catch.hpp"
+
+#include <flux.hpp>
+
+#include "test_utils.hpp"
+
+#include <array>
+
+namespace {
+
+constexpr bool test_adjacent_filter()
+{
+    // Basic adjacent_filter
+    {
+        std::array arr{1, 1, 1, 2, 2, 3, 4, 4, 4, 5};
+
+        auto filtered = flux::adjacent_filter(arr, std::not_equal_to{});
+
+        using F = decltype(filtered);
+        static_assert(flux::sequence<F>);
+        static_assert(flux::multipass_sequence<F>);
+        static_assert(flux::bidirectional_sequence<F>);
+        static_assert(not flux::random_access_sequence<F>);
+        static_assert(flux::bounded_sequence<F>);
+        static_assert(not flux::sized_sequence<F>);
+
+        static_assert(std::same_as<flux::element_t<F>, int&>);
+
+        STATIC_CHECK(filtered.count() == 5);
+        STATIC_CHECK(check_equal(filtered, {1, 2, 3, 4, 5}));
+        STATIC_CHECK(filtered.is_last(filtered.last()));
+    }
+
+    // adjacent_filter is const-iterable when the base is
+    {
+        std::array arr{1, 1, 1, 2, 2, 3, 4, 4, 4, 5};
+
+        auto const filtered = flux::adjacent_filter(arr, std::not_equal_to{});
+
+        using F = decltype(filtered);
+        static_assert(flux::sequence<F>);
+        static_assert(flux::multipass_sequence<F>);
+        static_assert(flux::bidirectional_sequence<F>);
+        static_assert(not flux::random_access_sequence<F>);
+        static_assert(flux::bounded_sequence<F>);
+        static_assert(not flux::sized_sequence<F>);
+
+        static_assert(std::same_as<flux::element_t<F>, int const&>);
+
+        STATIC_CHECK(flux::count(filtered) == 5);
+        STATIC_CHECK(check_equal(filtered, {1, 2, 3, 4, 5}));
+        STATIC_CHECK(flux::is_last(filtered, flux::last(filtered)));
+    }
+
+    // adj_filt of an empty sequence is empty
+    {
+        auto f = flux::adjacent_filter(flux::empty<int>, std::not_equal_to{});
+
+        STATIC_CHECK(f.is_empty());
+    }
+
+    // adj_filt with a sequence of size 1 is just that element
+    {
+        auto f = flux::single(99).adjacent_filter(std::not_equal_to{});
+
+        STATIC_CHECK(f.count() == 1);
+        STATIC_CHECK(f.front().value() == 99);
+    }
+
+    // adj_filt with a repeated sequence contains one element
+    {
+        auto f = flux::adjacent_filter(flux::repeat(99, 1000), std::not_equal_to{});
+
+        STATIC_CHECK(f.count() == 1);
+        STATIC_CHECK(f.front().value() == 99);
+    }
+
+    // adj_filt picks the first of a run of identical elements
+    {
+        struct Pair { int i, j; bool operator==(const Pair&) const = default; };
+
+        Pair arr[] = { {1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}};
+
+        auto filtered = flux::ref(arr).adjacent_filter(
+            flux::proj{std::not_equal_to{}, &Pair::i});
+
+        STATIC_CHECK(filtered.count() == 2);
+        STATIC_CHECK(check_equal(filtered, {Pair{1, 1}, Pair{2, 4}}));
+    }
+
+    // ...and again, slightly differently
+    {
+        int arr[] = {1, 1, 1, 2, 2, 2, 3, 3, 3};
+
+        auto filtered = flux::ref(arr).adjacent_filter(std::not_equal_to{});
+
+        STATIC_CHECK(filtered.count() == 3);
+
+        auto cur = filtered.first();
+
+        STATIC_CHECK(&filtered[cur] == arr);
+        STATIC_CHECK(&filtered[filtered.inc(cur)] == arr + 3);
+        STATIC_CHECK(&filtered[filtered.inc(cur)] == arr + 6);
+    }
+
+    // adj_filter of a bidir sequence is bidir
+    {
+        int arr[] = {1, 1, 1, 3, 3, 3, 2, 2, 2};
+
+        auto seq = flux::ref(arr).adjacent_filter(std::not_equal_to{}).reverse();
+
+        STATIC_CHECK(check_equal(seq, {2, 3, 1}));
+
+        auto cur = seq.first();
+        STATIC_CHECK(&seq[cur] == arr + 6);
+        STATIC_CHECK(&seq[seq.inc(cur)] == arr + 3);
+        STATIC_CHECK(&seq[seq.inc(cur)] == arr);
+    }
+
+    return true;
+}
+static_assert(test_adjacent_filter());
+
+constexpr bool test_dedup()
+{
+    // Basic dedup
+    {
+        std::array arr{1, 1, 1, 2, 2, 3, 4, 4, 4, 5};
+
+        auto filtered = flux::dedup(arr);
+
+        using F = decltype(filtered);
+        static_assert(flux::sequence<F>);
+        static_assert(flux::multipass_sequence<F>);
+        static_assert(flux::bidirectional_sequence<F>);
+        static_assert(not flux::random_access_sequence<F>);
+        static_assert(flux::bounded_sequence<F>);
+        static_assert(not flux::sized_sequence<F>);
+
+        static_assert(std::same_as<flux::element_t<F>, int&>);
+
+        STATIC_CHECK(filtered.count() == 5);
+        STATIC_CHECK(check_equal(filtered, {1, 2, 3, 4, 5}));
+        STATIC_CHECK(filtered.is_last(filtered.last()));
+    }
+
+    // dedup is const-iterable when the base is
+    {
+        std::array arr{1, 1, 1, 2, 2, 3, 4, 4, 4, 5};
+
+        auto const filtered = flux::dedup(arr);
+
+        using F = decltype(filtered);
+        static_assert(flux::sequence<F>);
+        static_assert(flux::multipass_sequence<F>);
+        static_assert(flux::bidirectional_sequence<F>);
+        static_assert(not flux::random_access_sequence<F>);
+        static_assert(flux::bounded_sequence<F>);
+        static_assert(not flux::sized_sequence<F>);
+
+        static_assert(std::same_as<flux::element_t<F>, int const&>);
+
+        STATIC_CHECK(flux::count(filtered) == 5);
+        STATIC_CHECK(check_equal(filtered, {1, 2, 3, 4, 5}));
+        STATIC_CHECK(flux::is_last(filtered, flux::last(filtered)));
+    }
+
+    // dedup of an empty sequence is empty
+    {
+        auto f = flux::dedup(flux::empty<int>);
+
+        STATIC_CHECK(f.is_empty());
+    }
+
+    // dedup with a sequence of size 1 is just that element
+    {
+        auto f = flux::single(99).dedup();
+
+        STATIC_CHECK(f.count() == 1);
+        STATIC_CHECK(f.front().value() == 99);
+    }
+
+    // dedup with a repeated sequence contains one element
+    {
+        auto f = flux::repeat(99, 1000).dedup();
+
+        STATIC_CHECK(f.count() == 1);
+        STATIC_CHECK(f.front().value() == 99);
+    }
+
+    // dedup picks the first of a run of equal elements
+    {
+        int arr[] = {1, 1, 1, 2, 2, 2, 3, 3, 3};
+
+        auto filtered = flux::ref(arr).dedup();
+
+        STATIC_CHECK(filtered.count() == 3);
+
+        auto cur = filtered.first();
+
+        STATIC_CHECK(&filtered[cur] == arr);
+        STATIC_CHECK(&filtered[filtered.inc(cur)] == arr + 3);
+        STATIC_CHECK(&filtered[filtered.inc(cur)] == arr + 6);
+    }
+
+    // dedup of a bidir sequence is bidir
+    {
+        int arr[] = {1, 1, 1, 3, 3, 3, 2, 2, 2};
+
+        auto seq = flux::ref(arr).dedup().reverse();
+
+        STATIC_CHECK(check_equal(seq, {2, 3, 1}));
+
+        auto cur = seq.first();
+        STATIC_CHECK(&seq[cur] == arr + 6);
+        STATIC_CHECK(&seq[seq.inc(cur)] == arr + 3);
+        STATIC_CHECK(&seq[seq.inc(cur)] == arr);
+    }
+
+    return true;
+}
+static_assert(test_dedup());
+
+}
+
+TEST_CASE("adjacent_filter")
+{
+    bool res = test_adjacent_filter();
+    REQUIRE(res);
+}


### PR DESCRIPTION
`adjacent_filter()` takes a binary predicate and has the same semantics as Range-V3's views::adjacent_filter: elements are tested pair-wise, and if the predicate returns `false` then the second element of the pair is discarded.

This also adds `dedup()` as a shortcut for `adjacent_filter(std::not_equal_to{})`, because that's what people are probably going to want most of the time.

Fixes #116