### PR TITLE
Remove caching from filter, drop and drop_while

### DIFF
--- a/include/flux/op/drop.hpp
+++ b/include/flux/op/drop.hpp
@@ -19,7 +19,6 @@ struct drop_adaptor : inline_sequence_base<drop_adaptor<Base>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     distance_t count_;
-    flux::optional<cursor_t<Base>> cached_first_;
 
 public:
     constexpr drop_adaptor(decays_to<Base> auto&& base, distance_t count)
@@ -37,31 +36,22 @@ public:
 
         static constexpr auto first(drop_adaptor& self) -> cursor_t<Base>
         {
-            if constexpr (std::copy_constructible<cursor_t<Base>>) {
-                if (!self.cached_first_) {
-                    auto cur = flux::first(self.base_);
-                    detail::advance(self.base_, cur, self.count_);
-                    self.cached_first_ = flux::optional(std::move(cur));
-                }
-
-                return self.cached_first_.value_unchecked();
-            } else {
-                auto cur = flux::first(self.base_);
-                detail::advance(self.base_, cur, self.count_);
-                return cur;
-            }
+            auto cur = flux::first(self.base_);
+            detail::advance(self.base_, cur, self.count_);
+            return cur;
         }
 
         static constexpr auto size(drop_adaptor& self)
             requires sized_sequence<Base>
         {
-            return (std::max)(flux::size(self.base()) - self.count_, distance_t{0});
+            return (cmp::max)(num::checked_sub(flux::size(self.base()), self.count_),
+                              distance_t{0});
         }
 
         static constexpr auto data(drop_adaptor& self)
             requires contiguous_sequence<Base> && sized_sequence<Base>
         {
-            return flux::data(self.base()) + (std::min)(self.count_, flux::size(self.base_));
+            return flux::data(self.base()) + (cmp::min)(self.count_, flux::size(self.base_));
         }
 
         void for_each_while(...) = delete;

--- a/include/flux/op/drop.hpp
+++ b/include/flux/op/drop.hpp
@@ -34,21 +34,21 @@ public:
 
         static constexpr bool disable_multipass = !multipass_sequence<Base>;
 
-        static constexpr auto first(drop_adaptor& self) -> cursor_t<Base>
+        static constexpr auto first(auto& self) -> cursor_t<Base>
         {
             auto cur = flux::first(self.base_);
             detail::advance(self.base_, cur, self.count_);
             return cur;
         }
 
-        static constexpr auto size(drop_adaptor& self)
+        static constexpr auto size(auto& self)
             requires sized_sequence<Base>
         {
             return (cmp::max)(num::checked_sub(flux::size(self.base()), self.count_),
                               distance_t{0});
         }
 
-        static constexpr auto data(drop_adaptor& self)
+        static constexpr auto data(auto& self)
             requires contiguous_sequence<Base> && sized_sequence<Base>
         {
             return flux::data(self.base()) + (cmp::min)(self.count_, flux::size(self.base_));

--- a/include/flux/op/filter.hpp
+++ b/include/flux/op/filter.hpp
@@ -62,6 +62,24 @@ public:
             return flux::read_at(self.base_, cur.base_cur);
         }
 
+        static constexpr auto read_at_unchecked(auto& self, cursor_type const& cur)
+            -> decltype(flux::read_at_unchecked(self.base_, cur.base_cur))
+        {
+            return flux::read_at_unchecked(self.base_, cur.base_cur);
+        }
+
+        static constexpr auto move_at(auto& self, cursor_type const& cur)
+            -> decltype(flux::move_at(self.base_, cur.base_cur))
+        {
+            return flux::move_at(self.base_, cur.base_cur);
+        }
+
+        static constexpr auto move_at_unchecked(auto& self, cursor_type const& cur)
+            -> decltype(flux::move_at_unchecked(self.base_, cur.base_cur))
+        {
+            return flux::move_at_unchecked(self.base_, cur.base_cur);
+        }
+
         static constexpr auto inc(auto& self, cursor_type& cur) -> void
         {
             flux::inc(self.base_, cur.base_cur);
@@ -96,7 +114,6 @@ public:
         }
     };
 };
-
 
 struct filter_fn {
     template <adaptable_sequence Seq, std::move_constructible Pred>

--- a/include/flux/op/filter.hpp
+++ b/include/flux/op/filter.hpp
@@ -9,6 +9,7 @@
 #include <flux/core.hpp>
 #include <flux/op/find.hpp>
 #include <flux/op/for_each_while.hpp>
+#include <flux/op/slice.hpp>
 
 namespace flux {
 

--- a/include/flux/op/filter.hpp
+++ b/include/flux/op/filter.hpp
@@ -32,33 +32,34 @@ public:
     constexpr auto base() && -> Base { return std::move(base_); }
 
     struct flux_sequence_traits {
-        using self_t = filter_adaptor;
+
+        using value_type = value_t<Base>;
 
         static constexpr bool disable_multipass = !multipass_sequence<Base>;
 
-        static constexpr auto first(self_t& self) -> cursor_t<Base>
+        static constexpr auto first(auto& self) -> cursor_t<Base>
         {
             return flux::find_if(self.base_, self.pred_);
         }
 
-        static constexpr auto is_last(self_t& self, cursor_t<Base> const& cur) -> bool
+        static constexpr auto is_last(auto& self, cursor_t<Base> const& cur) -> bool
         {
             return flux::is_last(self.base_, cur);
         }
 
-        static constexpr auto read_at(self_t& self, cursor_t<Base> const& cur)
-            -> element_t<Base>
+        static constexpr auto read_at(auto& self, cursor_t<Base> const& cur)
+            -> decltype(flux::read_at(self.base_, cur))
         {
             return flux::read_at(self.base_, cur);
         }
 
-        static constexpr auto inc(self_t& self, cursor_t<Base>& cur) -> void
+        static constexpr auto inc(auto& self, cursor_t<Base>& cur) -> void
         {
             flux::inc(self.base_, cur);
             cur = flux::slice(self.base_, std::move(cur), flux::last).find_if(self.pred_);
         }
 
-        static constexpr auto dec(self_t& self, cursor_t<Base>& cur) -> void
+        static constexpr auto dec(auto& self, cursor_t<Base>& cur) -> void
             requires bidirectional_sequence<Base>
         {
             do {
@@ -66,13 +67,13 @@ public:
             } while(!std::invoke(self.pred_, flux::read_at(self.base_, cur)));
         }
 
-        static constexpr auto last(self_t& self) -> cursor_t<Base>
+        static constexpr auto last(auto& self) -> cursor_t<Base>
             requires bounded_sequence<Base>
         {
             return flux::last(self.base_);
         }
 
-        static constexpr auto for_each_while(self_t& self, auto&& func) -> cursor_t<Base>
+        static constexpr auto for_each_while(auto& self, auto&& func) -> cursor_t<Base>
         {
             return flux::for_each_while(self.base_, [&](auto&& elem) {
                 if (std::invoke(self.pred_, elem)) {

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -106,7 +106,6 @@ constexpr bool test_chain()
         using S = decltype(seq);
 
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::sequence<S const>);
 
         STATIC_CHECK(check_equal(seq, {0, 1, 2, 3, 4, 5}));
     }

--- a/test/test_cursors.cpp
+++ b/test/test_cursors.cpp
@@ -70,7 +70,8 @@ constexpr bool test_cursors()
         auto const arr = std::array{101, 102, 103, 104, 105, 106, 107, 108, 109, 110};
 
         auto evens = flux::filter(arr, flux::pred::even);
-        auto indices_of_evens = std::move(evens).cursors();
+        auto indices_of_evens = std::move(evens).cursors()
+                                    .map([](auto cur) { return cur.base_cur; });
 
         STATIC_CHECK(flux::count(indices_of_evens) == 5);
         STATIC_CHECK(check_equal(indices_of_evens, {1, 3, 5, 7, 9}));

--- a/test/test_drop.cpp
+++ b/test/test_drop.cpp
@@ -27,9 +27,18 @@ constexpr bool test_drop() {
         static_assert(flux::sized_sequence<D>);
         static_assert(flux::bounded_sequence<D>);
 
+        static_assert(flux::contiguous_sequence<D const>);
+        static_assert(flux::sized_sequence<D const>);
+        static_assert(flux::bounded_sequence<D const>);
+
         STATIC_CHECK(flux::size(dropped) == 5);
         STATIC_CHECK(flux::data(dropped) == arr + 5);
         STATIC_CHECK(check_equal(dropped, {5, 6, 7, 8, 9}));
+
+        auto const& c_dropped = dropped;
+        STATIC_CHECK(flux::size(c_dropped) == 5);
+        STATIC_CHECK(flux::data(c_dropped) == arr + 5);
+        STATIC_CHECK(check_equal(c_dropped, {5, 6, 7, 8, 9}));
     }
 
     {
@@ -42,8 +51,16 @@ constexpr bool test_drop() {
         static_assert(flux::sized_sequence<D>);
         static_assert(flux::bounded_sequence<D>);
 
+        static_assert(flux::contiguous_sequence<D const>);
+        static_assert(flux::sized_sequence<D const>);
+        static_assert(flux::bounded_sequence<D const>);
+
         STATIC_CHECK(flux::size(dropped) == 5);
         STATIC_CHECK(check_equal(dropped, {5, 6, 7, 8, 9}));
+
+        auto const& c_dropped = dropped;
+        STATIC_CHECK(flux::size(c_dropped) == 5);
+        STATIC_CHECK(check_equal(c_dropped, {5, 6, 7, 8, 9}));
     }
 
     {

--- a/test/test_drop_while.cpp
+++ b/test/test_drop_while.cpp
@@ -26,8 +26,17 @@ constexpr bool test_drop_while()
         static_assert(flux::bounded_sequence<S>);
         static_assert(flux::sized_sequence<S>); // because bounded + RA
 
+        static_assert(flux::contiguous_sequence<S const>);
+        static_assert(flux::bounded_sequence<S const>);
+        static_assert(flux::sized_sequence<S const>);
+
         STATIC_CHECK(seq.size() == 5);
         STATIC_CHECK(seq.data() == arr + 5);
+        STATIC_CHECK(check_equal(seq, {5, 6, 7, 8, 9}));
+
+        auto const& c_seq = seq;
+        STATIC_CHECK(c_seq.size() == 5);
+        STATIC_CHECK(c_seq.data() == arr + 5);
         STATIC_CHECK(check_equal(seq, {5, 6, 7, 8, 9}));
     }
 

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -51,11 +51,14 @@ constexpr bool test_filter()
         static_assert(not flux::ordered_cursor<F>);
         static_assert(not flux::sized_sequence<F>);
 
-        static_assert(not flux::sequence<F const>);
+        static_assert(flux::sequence<F const>);
+        static_assert(flux::bidirectional_sequence<F const>);
+        static_assert(flux::bounded_sequence<F const>);
+        static_assert(not flux::ordered_cursor<F const>);
+        static_assert(not flux::sized_sequence<F const>);
 
-        if (!check_equal(filtered, {0, 2, 4, 6, 8})) {
-            return false;
-        }
+        STATIC_CHECK(check_equal(filtered, {0, 2, 4, 6, 8}));
+        STATIC_CHECK(check_equal(std::as_const(filtered), {0, 2, 4, 6, 8}));
     }
 
     // Filtering single-pass sequences works okay


### PR DESCRIPTION
This might be a bit controversial...

The `filter`, `drop` and `drop_while` adaptors, when operating on multipass sequences, cache the first cursor: that is, the first call to `first()` does a (potentially) `O(N)` pass over the data, but subsequent calls to `first()`returns the cached cursor. I originally did this for the same reason that Ranges does it: I wanted `first()` to always be (amortised?) `O(1)`.

As time goes on though, I'm less certain that this was the right choice. We definitely need `is_last()` to be `O(1)`; I'm very sure we also want `last()` to be `O(1)` for bounded sequences. But I'm less convinced about `first()`. After all, getting the second element with `inc()` can never be constant-time, so why do we special-case getting the first one?

Various later Flux adaptors don't do caching where the Ranges versions do, and there seems to be little ill effect. Also, the internal iteration implementation of `filter` has never used the cache, and I don't think anyone has ever noticed.

Getting rid of caching allows const-iteration, which is useful for such fundamental adaptors, and stops people needing to reach for `mut_ref`. It also makes life easier for the optimiser.



