### PR TITLE
Fix out-of-bounds inc() in detail::advance

### DIFF
--- a/include/flux/op/stride.hpp
+++ b/include/flux/op/stride.hpp
@@ -18,12 +18,12 @@ inline constexpr struct advance_fn {
     constexpr auto operator()(Seq& seq, cursor_t<Seq>& cur, distance_t offset) const -> distance_t
     {
         if (offset > 0) {
-            while (--offset >= 0)  {
-                if (flux::is_last(seq, flux::inc(seq, cur))) {
-                    break;
-                }
+            distance_t counter = 0;
+            while (offset-- > 0 && !flux::is_last(seq, cur))  {
+                flux::inc(seq, cur);
+                ++counter;
             }
-            return offset;
+            return counter;
         } else if (offset < 0) {
             if constexpr (bidirectional_sequence<Seq>) {
                 auto const fst = flux::first(seq);

--- a/test/test_drop.cpp
+++ b/test/test_drop.cpp
@@ -11,6 +11,10 @@
 
 #include <array>
 #include <list>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace {
 


### PR DESCRIPTION
If we passed a positive offset to the non-RA version of advance(), we were performing an initial inc() on the passed-in cursor without first checking whether it was at the end.

So let's not do that.

Fixes #132