### PR TITLE
Fix multidim benchmark CI failure

### DIFF
--- a/benchmark/multidimensional_memset_benchmark_kernels.cpp
+++ b/benchmark/multidimensional_memset_benchmark_kernels.cpp
@@ -9,7 +9,11 @@
 #include <flux/op/for_each.hpp>
 #include <flux/op/filter.hpp>
 
+#if __cpp_lib_ranges_cartesian_product >= 202207L
+#include <ranges>
+#else
 #include "ranges_cartesian_product.hpp"
+#endif
 
 #include <ranges>
 #include <algorithm>


### PR DESCRIPTION
It looks like MSVC's STL now provides C++23 std::views::cartesian_product, which clashes with the polyfill version we use for the multidim benchmark.

Fortunately, there's a feature test macro we can use to detect whether the std version exists, so we'll use that to select the std version if possible or otherwise fall back to our version.