### PR TITLE
Add Clang 17 on MacOS to CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,9 @@ jobs:
     strategy:
       matrix:
         build_type: [Debug, Release]
-        cxx: [g++-12, g++-13, /usr/local/opt/llvm/bin/clang++]
+        cxx: [g++-12, g++-13,
+              /usr/local/opt/llvm@16/bin/clang++,
+              /usr/local/opt/llvm@17/bin/clang++]
         include:
           - cxx: g++-12
             install: brew install gcc@12 ninja
@@ -23,9 +25,12 @@ jobs:
             install: |
               brew update
               brew install gcc@13 ninja
-          - cxx: /usr/local/opt/llvm/bin/clang++
+          - cxx: /usr/local/opt/llvm@16/bin/clang++
             install: |
               brew install llvm@16 ninja
+          - cxx: /usr/local/opt/llvm@17/bin/clang++
+            install: |
+              brew install llvm@17 ninja
 
     steps:
     - uses: actions/checkout@v3

--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -29,8 +29,8 @@ constexpr auto max_weeks_in_month = 6;
 constexpr auto col_sep = "  ";
 constexpr auto row_sep = ' ';
 
-// Workaround: libc++16 does not support C++20 chrono::time_point::operator++
-#if defined _LIBCPP_VERSION and _LIBCPP_VERSION < 170000
+// Workaround: libc++17 does not support C++20 chrono::time_point::operator++
+#if defined _LIBCPP_VERSION and _LIBCPP_VERSION < 180000
 namespace std::chrono {
     sys_days& operator++(sys_days& d) {
         return d += days{1};


### PR DESCRIPTION
Our Mac CI script was mistakenly mixing up the Homebrew names "LLVM" and "LLVM@16", meaning it broken when Homebrew updated the default version.

We'll take this opportunity to not only fix it, but test with both Clang 16 and 17