### PR TITLE
Fix flatten optional assignment

### DIFF
--- a/include/flux/core/optional.hpp
+++ b/include/flux/core/optional.hpp
@@ -106,11 +106,16 @@ public:
     constexpr optional& operator=(optional const& other)
         noexcept(std::is_nothrow_copy_assignable_v<T> &&
                  std::is_nothrow_copy_constructible_v<T>)
-        requires std::copyable<T>
+        requires std::copy_constructible<T>
     {
         if (engaged_) {
             if (other.engaged_) {
-                item_ = other.item_;
+                if constexpr (std::is_copy_assignable_v<T>) {
+                    item_ = other.item_;
+                } else {
+                    reset();
+                    construct(other.item_);
+                }
             } else {
                 reset();
             }
@@ -123,7 +128,8 @@ public:
     }
 
     optional& operator=(optional const&)
-        requires std::copyable<T> && std::is_trivially_copy_assignable_v<T>
+        requires std::copy_constructible<T> &&
+                 std::is_trivially_copy_assignable_v<T>
         = default;
 
     /*
@@ -149,11 +155,16 @@ public:
     constexpr optional& operator=(optional&& other)
         noexcept(std::is_nothrow_move_constructible_v<T> &&
                  std::is_nothrow_move_assignable_v<T>)
-        requires std::movable<T>
+        requires std::move_constructible<T>
     {
         if (engaged_) {
             if (other.engaged_) {
-                item_ = std::move(other.item_);
+                if constexpr (std::is_move_assignable_v<T>) {
+                    item_ = std::move(other).item_;
+                } else {
+                    reset();
+                    construct(std::move(other).item_);
+                }
             } else {
                 reset();
             }
@@ -166,7 +177,7 @@ public:
     }
 
     constexpr optional& operator=(optional&&)
-        requires std::movable<T> &&
+        requires std::move_constructible<T> &&
                  std::is_trivially_move_assignable_v<T>
         = default;
 

--- a/include/flux/core/optional.hpp
+++ b/include/flux/core/optional.hpp
@@ -456,6 +456,10 @@ public:
      */
     constexpr auto reset() -> void { ptr_ = nullptr; }
 
+    template <typename U = T>
+        requires requires(U& u) { test_fn(u); }
+    constexpr auto emplace(U& item) -> void { ptr_ = std::addressof(item); }
+
     /*
      * Monadic operations
      */

--- a/include/flux/op/flatten.hpp
+++ b/include/flux/op/flatten.hpp
@@ -45,8 +45,8 @@ public:
         static constexpr auto satisfy(auto& self, cursor_type& cur) -> void
         {
             while (!flux::is_last(self.base_, cur.outer_cur)) {
-                self.inner_ = optional<InnerSeq>(flux::read_at(self.base_, cur.outer_cur));
-                cur.inner_cur = optional(flux::first(*self.inner_));
+                self.inner_.emplace(flux::read_at(self.base_, cur.outer_cur));
+                cur.inner_cur.emplace(flux::first(*self.inner_));
                 if (!flux::is_last(*self.inner_, *cur.inner_cur)) {
                     return;
                 }

--- a/test/test_flatten.cpp
+++ b/test/test_flatten.cpp
@@ -135,6 +135,18 @@ constexpr bool test_flatten_single_pass()
     }
 #endif // NO_CONSTEXPR_VECTOR
 
+    // Test awkward single-pass flatten with a non-assignable inner sequence
+    {
+        int k = 0;
+        auto seq = flux::ints(0, 2)
+                    .map([&k](auto i) {
+                           return flux::ints(0, 2).map([i, &k](int j) { return i + j + k; });
+                       })
+                    .flatten();
+
+        STATIC_CHECK(check_equal(seq, {0, 1, 1, 2}));
+    }
+
     return true;
 }
 static_assert(test_flatten_single_pass());


### PR DESCRIPTION
The single-pass version of `flatten_adaptor` currently does a move-assignment of an optional, which doesn't work if the inner sequence is not move-assignable -- for example if it involves a capturing lambda.

This is rare, but I ran into it today doing Advent of code...

This PR fixes it in two ways. Firstly, in our `optional<T>` implementation, if `T` is copy-constructible but not copy-assignable, we destroy + construct in the assignment operator (and likewise for move). This allows `optional<T>` to be copy/move-assignable even when `T` is not, for example if it's a capturing lambda.

Secondly, we actually remove the problem by using `optional::emplace` in `flatten_adaptor`, which results in fewer total operations anyway, but does require adding `optional<T&>::emplace` so things don't break.