### PR TITLE
Add const_iterable_sequence concept

### DIFF
--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -301,7 +301,9 @@ concept const_iterable_sequence =
     std::same_as<cursor_t<Seq>, cursor_t<Seq const>> &&
     std::same_as<value_t<Seq>, value_t<Seq const>> &&
     // Seq and Seq const must have the same const_element type
+#ifdef FLUX_HAVE_CPP23_TUPLE_COMMON_REF
     std::same_as<const_element_t<Seq>, const_element_t<Seq const>> &&
+#endif
     // Seq and Seq const must model the same extended sequence concepts
     (multipass_sequence<Seq> == multipass_sequence<Seq const>) &&
     (bidirectional_sequence<Seq> == bidirectional_sequence<Seq const>) &&

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -292,6 +292,27 @@ concept read_only_sequence =
     sequence<Seq> &&
     std::same_as<element_t<Seq>, const_element_t<Seq>>;
 
+FLUX_EXPORT
+template <typename Seq>
+concept const_iterable_sequence =
+    // Seq and Seq const must both be sequences
+    sequence<Seq> && sequence<Seq const> &&
+    // Seq and Seq const must have the same cursor and value types
+    std::same_as<cursor_t<Seq>, cursor_t<Seq const>> &&
+    std::same_as<value_t<Seq>, value_t<Seq const>> &&
+    // Seq and Seq const must have the same const_element type
+    std::same_as<const_element_t<Seq>, const_element_t<Seq const>> &&
+    // Seq and Seq const must model the same extended sequence concepts
+    (multipass_sequence<Seq> == multipass_sequence<Seq const>) &&
+    (bidirectional_sequence<Seq> == bidirectional_sequence<Seq const>) &&
+    (random_access_sequence<Seq> == random_access_sequence<Seq const>) &&
+    (contiguous_sequence<Seq> == contiguous_sequence<Seq const>) &&
+    (bounded_sequence<Seq> == bounded_sequence<Seq const>) &&
+    (sized_sequence<Seq> == sized_sequence<Seq const>) &&
+    (infinite_sequence<Seq> == infinite_sequence<Seq const>) &&
+    // If Seq is read-only, Seq const must be read-only as well
+    (!read_only_sequence<Seq> || read_only_sequence<Seq const>);
+
 namespace detail {
 
 template <typename T, typename R = std::remove_cvref_t<T>>

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -193,7 +193,7 @@ public:
         return std::invoke(FLUX_FWD(func), std::move(derived()), FLUX_FWD(args)...);
     }
 
-    constexpr auto ref() const& requires sequence<Derived const>;
+    constexpr auto ref() const& requires const_iterable_sequence<Derived>;
 
     auto ref() const&& -> void = delete;
 

--- a/include/flux/op/ref.hpp
+++ b/include/flux/op/ref.hpp
@@ -191,16 +191,15 @@ struct mut_ref_fn {
 };
 
 struct ref_fn {
-    template <typename Seq>
-        requires (!is_ref_adaptor<Seq> && sequence<Seq const>)
+    template <const_iterable_sequence Seq>
+        requires (!is_ref_adaptor<Seq>)
     [[nodiscard]]
     constexpr auto operator()(Seq const& seq) const
     {
         return ref_adaptor<Seq const>(seq);
     }
 
-    template <typename Seq>
-        requires sequence<Seq const>
+    template <const_iterable_sequence Seq>
     [[nodiscard]]
     constexpr auto operator()(ref_adaptor<Seq> ref) const
     {
@@ -218,7 +217,7 @@ FLUX_EXPORT inline constexpr auto ref = detail::ref_fn{};
 
 template <typename D>
 constexpr auto inline_sequence_base<D>::ref() const&
-    requires sequence<D const>
+    requires const_iterable_sequence<D>
 {
     return flux::ref(derived());
 }

--- a/test/test_bitset.cpp
+++ b/test/test_bitset.cpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <iostream>
+#include <utility>
 
 #include "test_utils.hpp"
 

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -6,7 +6,7 @@
 #include "catch.hpp"
 
 #include <array>
-#include <iostream>
+#include <utility>
 
 #include "test_utils.hpp"
 

--- a/test/test_from_range.cpp
+++ b/test/test_from_range.cpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <ranges>
 #include <sstream>
+#include <utility>
 
 #include "test_utils.hpp"
 

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -5,6 +5,8 @@
 
 #include "catch.hpp"
 
+#include <utility> // std::as_const
+
 #include "test_utils.hpp"
 
 // Silence warnings about unneeded comparison functions: in fact they are

--- a/test/test_output_to.cpp
+++ b/test/test_output_to.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <array>
+#include <iterator>
 #include <list>
 #include <sstream>
 #include <vector>

--- a/test/test_zip_algorithms.cpp
+++ b/test/test_zip_algorithms.cpp
@@ -5,6 +5,7 @@
 
 #include "catch.hpp"
 
+#include <algorithm>
 #include <array>
 #include <string_view>
 


### PR DESCRIPTION
For a sequence S, `const_iterable_sequence<S>` means we can use `S const` as a sequence with the expected semantics.

Specifically, we require that:

* `S const` is a sequence
* `S` and `S const` have the same cursor type and the same value type
* `S` and `S const` have the same `const_element_type`
* For every extended sequence concept (`multipass`, `bidirectional` etc), excluding `read_only_sequence`, both `S` and `S const` must satisfy the concept or both must not satisfy the concept. For example, if `S` is bidirectional then `S const` must be bidirectional and vice versa
* If `S` models `read_only_sequence` then `S const` must model `read_only_sequence` -- that is, `S const` may strengthen the const-qualification of elements but not weaken it
* Semantic requirement: iterating over `S const` yields "the same elements" as iterating over `S` (but let's gloss over exactly how we define "same"...)

We've previously assumed all of these things are true (except possibly the `const_element_t` requirement), but it's good to have them checked by the compiler where we can.