### PR TITLE
Attempt to work around Clang 18 ICE

### DIFF
--- a/include/flux/op/adjacent.hpp
+++ b/include/flux/op/adjacent.hpp
@@ -49,7 +49,7 @@ public:
     {
         cursor_type out{flux::first(self.base_), };
 
-        for (auto i : flux::iota(std::size_t{1}, std::size_t{N})) {
+        FLUX_FOR(auto i, flux::iota(std::size_t{1}, std::size_t{N})) {
             out.arr[i] = out.arr[i - 1];
             if (!flux::is_last(self.base_, out.arr[i])) {
                 flux::inc(self.base_, out.arr[i]);
@@ -76,7 +76,7 @@ public:
         cursor_type out{};
         out.arr.back() = flux::last(self.base_);
         auto const first = flux::first(self.base_);
-        for (auto i : flux::iota(std::size_t{0}, std::size_t{N}-1).reverse()) {
+        FLUX_FOR(auto i, flux::iota(std::size_t{0}, std::size_t{N}-1).reverse()) {
             out.arr[i] = out.arr[i + 1];
             if (out.arr[i] != first) {
                 flux::dec(self.base_, out.arr[i]);


### PR DESCRIPTION
This is a wild stab in the dark which attempts to solve the Clang 18 internal compiler error reported in #174.

Homebrew doesn't have LLVM 18 yet (https://github.com/Homebrew/homebrew-core/pull/165206) so I don't have a local install of the latest Clang, and we can't add it to CI either. This PR just slightly simplifies the code that Clang appears to dislike (based on the backtrace supplies in #174), but unfortunately I don't have any way of testing it yet.

So let's see what happens...