### PR TITLE
Fix bug in reverse_adaptor::for_each_while

### DIFF
--- a/include/flux/op/reverse.hpp
+++ b/include/flux/op/reverse.hpp
@@ -128,11 +128,12 @@ public:
             while (cur != end) {
                 flux::dec(self.base_, cur);
                 if (!std::invoke(pred, flux::read_at(self.base_, cur))) {
+                    flux::inc(self.base_, cur);
                     break;
                 }
             }
 
-            return cursor_type(flux::inc(self.base_, cur));
+            return cursor_type(cur);
         }
     };
 };

--- a/test/test_reverse.cpp
+++ b/test/test_reverse.cpp
@@ -126,6 +126,19 @@ constexpr bool issue_143()
 }
 static_assert(issue_143());
 
+// Regression test for #182
+// https://github.com/tcbrindle/flux/issues/182
+constexpr bool issue_182()
+{
+    auto seq = flux::iota(1,4)
+                   .drop(2)
+                   .reverse().drop(5).reverse()
+                   .filter([](int i) { return i&1; })
+                   .chunk(4);
+
+    return seq.is_empty();
+}
+static_assert(issue_182());
 
 }
 
@@ -135,6 +148,12 @@ TEST_CASE("reverse")
     REQUIRE(result);
 
     result = issue_52();
+    REQUIRE(result);
+
+    result = issue_143();
+    REQUIRE(result);
+
+    result = issue_182();
     REQUIRE(result);
 
     {


### PR DESCRIPTION
We only need to increment the base cursor if we break out the loop early

Fixes #182 
