### PR TITLE
Fixes for GCC 14

### DIFF
--- a/include/flux/op/zip.hpp
+++ b/include/flux/op/zip.hpp
@@ -9,6 +9,8 @@
 #include <flux/core.hpp>
 #include <flux/source/empty.hpp>
 
+#include <algorithm> // for std::min({ilist...})
+
 namespace flux {
 
 namespace detail {

--- a/module/flux.cpp
+++ b/module/flux.cpp
@@ -1,6 +1,7 @@
 
 module;
 
+#include <algorithm>
 #include <array>
 #include <bitset>
 #include <compare>

--- a/test/test_flatten.cpp
+++ b/test/test_flatten.cpp
@@ -249,7 +249,7 @@ constexpr
 #endif
 bool issue_150()
 {
-    const std::vector<std::string> vec{"a", "b", "c"};
+    const std::vector<std::string_view> vec{"a", "b", "c"};
 
     auto str = flux::ref(vec).flatten().to<std::string>();
 


### PR DESCRIPTION
* Work around constexpr test failure in test_flatten.cpp
* Add missing #include <algorithm> in zip.hpp