### PR TITLE
Add flatten_with adaptor

### DIFF
--- a/include/flux.hpp
+++ b/include/flux.hpp
@@ -36,6 +36,7 @@
 #include <flux/op/find.hpp>
 #include <flux/op/find_min_max.hpp>
 #include <flux/op/flatten.hpp>
+#include <flux/op/flatten_with.hpp>
 #include <flux/op/fold.hpp>
 #include <flux/op/for_each.hpp>
 #include <flux/op/for_each_while.hpp>

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -283,6 +283,20 @@ public:
     [[nodiscard]]
     constexpr auto flatten() && requires sequence<element_t<Derived>>;
 
+    template <adaptable_sequence Pattern>
+        requires sequence<element_t<Derived>> &&
+                 multipass_sequence<Pattern> &&
+                 detail::flatten_with_compatible<element_t<Derived>, Pattern>
+    [[nodiscard]]
+    constexpr auto flatten_with(Pattern&& pattern) &&;
+
+
+    template <typename Value>
+        requires sequence<element_t<Derived>> &&
+                 std::constructible_from<value_t<element_t<Derived>>, Value&&>
+    [[nodiscard]]
+    constexpr auto flatten_with(Value value) &&;
+
     template <typename Func>
         requires std::invocable<Func&, element_t<Derived>>
     [[nodiscard]]

--- a/include/flux/op/flatten_with.hpp
+++ b/include/flux/op/flatten_with.hpp
@@ -1,0 +1,201 @@
+
+// Copyright (c) 2024 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef FLUX_OP_FLATTEN_WITH_HPP_INCLUDED
+#define FLUX_OP_FLATTEN_WITH_HPP_INCLUDED
+
+#include <flux/core.hpp>
+
+#include <flux/source/single.hpp>
+
+namespace flux {
+
+namespace detail {
+
+// Workaround for std::variant::emplace<N> not being constexpr in libc++
+// See P2231 (C++20 DR)
+template <std::size_t N>
+inline constexpr auto variant_emplace =
+[]<typename... Types>(std::variant<Types...>& variant, auto&&... args) {
+    if constexpr (__cpp_lib_variant >= 202106L) {
+        variant.template emplace<N>(FLUX_FWD(args)...);
+    } else {
+        if (std::is_constant_evaluated()) {
+            variant = std::variant<Types...>(std::in_place_index<N>, FLUX_FWD(args)...);
+        } else {
+            variant.template emplace<N>(FLUX_FWD(args)...);
+        }
+    }
+};
+
+template <sequence Base, multipass_sequence Pattern>
+struct flatten_with_adaptor : inline_sequence_base<flatten_with_adaptor<Base, Pattern>>
+{
+private:
+    using InnerSeq = element_t<Base>;
+
+    FLUX_NO_UNIQUE_ADDRESS Base base_;
+    FLUX_NO_UNIQUE_ADDRESS Pattern pattern_;
+    optional<InnerSeq> inner_ = nullopt;
+
+public:
+    constexpr flatten_with_adaptor(decays_to<Base> auto&& base,
+                                   decays_to<Pattern> auto&& pattern)
+        : base_(FLUX_FWD(base)),
+          pattern_(FLUX_FWD(pattern))
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        using self_t = flatten_with_adaptor;
+        using element_type =
+            std::common_reference_t<element_t<InnerSeq>, element_t<Pattern>>;
+        using rvalue_element_type =
+            std::common_reference_t<rvalue_element_t<InnerSeq>, rvalue_element_t<Pattern>>;
+
+        struct cursor_type {
+            cursor_t<Base> outer_cur;
+            std::variant<cursor_t<Pattern>, cursor_t<InnerSeq>> inner_cur{};
+        };
+
+        static constexpr auto satisfy(self_t& self, cursor_type& cur) -> void
+        {
+            while (true) {
+                if (cur.inner_cur.index() == 0) {
+                    if (!flux::is_last(self.pattern_, std::get<0>(cur.inner_cur))) {
+                        break;
+                    }
+
+                    self.inner_.emplace(flux::read_at(self.base_, cur.outer_cur));
+                    variant_emplace<1>(cur.inner_cur, flux::first(*self.inner_));
+                } else {
+                    FLUX_ASSERT(self.inner_.has_value());
+                    if (!flux::is_last(*self.inner_, std::get<1>(cur.inner_cur))) {
+                        break;
+                    }
+
+                    flux::inc(self.base_, cur.outer_cur);
+                    if (!flux::is_last(self.base_, cur.outer_cur)) {
+                        variant_emplace<0>(cur.inner_cur, flux::first(self.pattern_));
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+    public:
+        using value_type = std::common_type_t<value_t<InnerSeq>, value_t<Pattern>>;
+
+        static constexpr auto first(self_t& self) -> cursor_type
+        {
+            cursor_type cur{.outer_cur = flux::first(self.base_)};
+            if (!flux::is_last(self.base_, cur.outer_cur)) {
+                self.inner_.emplace(flux::read_at(self.base_, cur.outer_cur));
+                variant_emplace<1>(cur.inner_cur, flux::first(*self.inner_));
+                satisfy(self, cur);
+            }
+            return cur;
+        }
+
+        static constexpr auto is_last(self_t& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.outer_cur);
+        }
+
+        static constexpr auto inc(self_t& self, cursor_type& cur) -> void
+        {
+            if (cur.inner_cur.index() == 0) {
+                flux::inc(self.pattern_, std::get<0>(cur.inner_cur));
+            } else {
+                FLUX_ASSERT(self.inner_.has_value());
+                flux::inc(*self.inner_, std::get<1>(cur.inner_cur));
+            }
+            satisfy(self, cur);
+        }
+
+        static constexpr auto read_at(self_t& self, cursor_type const& cur)
+            -> element_type
+        {
+            if (cur.inner_cur.index() == 0) {
+                return static_cast<element_type>(
+                    flux::read_at(self.pattern_, std::get<0>(cur.inner_cur)));
+            } else {
+                FLUX_ASSERT(self.inner_.has_value());
+                return static_cast<element_type>(
+                    flux::read_at(*self.inner_, std::get<1>(cur.inner_cur)));
+            }
+        }
+
+        static constexpr auto move_at(self_t& self, cursor_type const& cur)
+            -> rvalue_element_type
+        {
+            if (cur.inner_cur.index() == 0) {
+                return static_cast<rvalue_element_type>(
+                    flux::move_at(self.pattern_, std::get<0>(cur.inner_cur)));
+            } else {
+                FLUX_ASSERT(self.inner_.has_value());
+                return static_cast<rvalue_element_type>(
+                    flux::move_at(*self.inner_, std::get<1>(cur.inner_cur)));
+            }
+        }
+
+        static constexpr auto last(self_t& self) -> cursor_type
+            requires bounded_sequence<Base>
+        {
+            return cursor_type{.outer_cur = flux::last(self)};
+        }
+    };
+};
+
+struct flatten_with_fn {
+
+    template <adaptable_sequence Seq, adaptable_sequence Pattern>
+        requires sequence<element_t<Seq>> &&
+                 multipass_sequence<Pattern> &&
+                 flatten_with_compatible<element_t<Seq>, Pattern>
+    constexpr auto operator()(Seq&& seq, Pattern&& pattern) const
+        -> sequence auto
+    {
+        return flatten_with_adaptor<std::decay_t<Seq>, std::decay_t<Pattern>>(
+            FLUX_FWD(seq), FLUX_FWD(pattern));
+    }
+
+    template <adaptable_sequence Seq>
+        requires sequence<element_t<Seq>> &&
+                 std::movable<value_t<element_t<Seq>>>
+    constexpr auto operator()(Seq&& seq, value_t<element_t<Seq>> value) const
+        -> sequence auto
+    {
+        return (*this)(FLUX_FWD(seq), flux::single(std::move(value)));
+    }
+};
+
+} // namespace detail
+
+FLUX_EXPORT inline constexpr auto flatten_with = detail::flatten_with_fn{};
+
+template <typename Derived>
+template <adaptable_sequence Pattern>
+    requires sequence<element_t<Derived>> &&
+             multipass_sequence<Pattern> &&
+             detail::flatten_with_compatible<element_t<Derived>, Pattern>
+constexpr auto inline_sequence_base<Derived>::flatten_with(Pattern&& pattern) &&
+{
+    return flux::flatten_with(std::move(derived()), FLUX_FWD(pattern));
+}
+
+template <typename Derived>
+template <typename Value>
+    requires sequence<element_t<Derived>> &&
+             std::constructible_from<value_t<element_t<Derived>>, Value&&>
+constexpr auto inline_sequence_base<Derived>::flatten_with(Value value) &&
+{
+    return flux::flatten_with(std::move(derived()), std::move(value));
+}
+
+} // namespace flux
+
+#endif // FLUX_OP_FLATTEN_WITH_HPP_INCLUDED

--- a/include/flux/op/flatten_with.hpp
+++ b/include/flux/op/flatten_with.hpp
@@ -150,6 +150,192 @@ public:
     };
 };
 
+template <multipass_sequence Base, multipass_sequence Pattern>
+    requires std::is_lvalue_reference_v<element_t<Base>> &&
+             multipass_sequence<element_t<Base>>
+struct flatten_with_adaptor<Base, Pattern>
+    : inline_sequence_base<flatten_with_adaptor<Base, Pattern>> {
+private:
+    FLUX_NO_UNIQUE_ADDRESS Base base_;
+    FLUX_NO_UNIQUE_ADDRESS Pattern pattern_;
+
+public:
+    constexpr flatten_with_adaptor(decays_to<Base> auto&& base,
+                                   decays_to<Pattern> auto&& pattern)
+        : base_(FLUX_FWD(base)),
+          pattern_(FLUX_FWD(pattern))
+    {}
+
+    struct flux_sequence_traits {
+    private:
+        using InnerSeq = element_t<Base>;
+
+        template <typename Self>
+        static constexpr bool can_flatten = [] () consteval {
+            if constexpr (std::is_const_v<Self>) {
+                return multipass_sequence<Base const> &&
+                       std::same_as<element_t<Base const>, std::remove_reference_t<InnerSeq> const&> &&
+                       multipass_sequence<InnerSeq const> &&
+                       multipass_sequence<Pattern const>;
+            } else {
+                return true;
+            }
+        }();
+
+        struct cursor_type {
+            cursor_t<Base> outer_cur;
+            std::variant<cursor_t<Pattern>, cursor_t<InnerSeq>> inner_cur{};
+
+            friend auto operator==(cursor_type const&, cursor_type const&) -> bool = default;
+        };
+
+        static constexpr auto satisfy(auto& self, cursor_type& cur) -> void
+        {
+            while (true) {
+                if (cur.inner_cur.index() == 0) {
+                    if (!flux::is_last(self.pattern_, std::get<0>(cur.inner_cur))) {
+                        break;
+                    }
+
+                    auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                    variant_emplace<1>(cur.inner_cur, flux::first(inner));
+                } else {
+                    auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                    if (!flux::is_last(inner, std::get<1>(cur.inner_cur))) {
+                        break;
+                    }
+
+                    flux::inc(self.base_, cur.outer_cur);
+                    variant_emplace<0>(cur.inner_cur, flux::first(self.pattern_));
+                    if (flux::is_last(self.base_, cur.outer_cur)) {
+                        break;
+                    }
+                }
+            }
+        }
+
+    public:
+        using value_type = value_t<InnerSeq>;
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto first(Self& self) -> cursor_type
+        {
+            cursor_type cur{.outer_cur = flux::first(self.base_)};
+            if (!flux::is_last(self.base_, cur.outer_cur)) {
+                auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                variant_emplace<1>(cur.inner_cur, flux::first(inner));
+            }
+            satisfy(self, cur);
+            return cur;
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto is_last(Self& self, cursor_type const& cur) -> bool
+        {
+            return flux::is_last(self.base_, cur.outer_cur);
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto read_at(Self& self, cursor_type const& cur)
+            -> decltype(auto)
+        {
+            using R = std::common_reference_t<
+                element_t<element_t<decltype((self.base_))>>,
+                element_t<decltype((self.pattern_))>>;
+
+            if (cur.inner_cur.index() == 0) {
+                return static_cast<R>(flux::read_at(self.pattern_, std::get<0>(cur.inner_cur)));
+            } else {
+                auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                return static_cast<R>(flux::read_at(inner, std::get<1>(cur.inner_cur)));
+            }
+        }
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto move_at(Self& self, cursor_type const& cur)
+            -> decltype(auto)
+        {
+            using R = std::common_reference_t<
+                      rvalue_element_t<element_t<decltype((self.base_))>>,
+                      rvalue_element_t<decltype((self.pattern_))>>;
+
+            if (cur.inner_cur.index() == 0) {
+                return static_cast<R>(flux::move_at(self.pattern_, std::get<0>(cur.inner_cur)));
+            } else {
+                auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                return static_cast<R>(flux::move_at(inner, std::get<1>(cur.inner_cur)));
+            }
+        }
+
+
+        template <typename Self>
+            requires can_flatten<Self>
+        static constexpr auto inc(Self& self, cursor_type& cur) -> void
+        {
+            if (cur.inner_cur.index() == 0) {
+                flux::inc(self.pattern_, std::get<0>(cur.inner_cur));
+            } else {
+                auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                flux::inc(inner, std::get<1>(cur.inner_cur));
+            }
+            satisfy(self, cur);
+        }
+
+        template <typename Self>
+            requires can_flatten<Self> && bounded_sequence<Base>
+        static constexpr auto last(Self& self) -> cursor_type
+        {
+            return cursor_type{.outer_cur = flux::last(self.base_)};
+        }
+
+        template <typename Self>
+            requires can_flatten<Self> &&
+                     bidirectional_sequence<Base> &&
+                     bidirectional_sequence<InnerSeq> &&
+                     bounded_sequence<InnerSeq> &&
+                     bidirectional_sequence<Pattern> &&
+                     bounded_sequence<Pattern>
+        static constexpr auto dec(Self& self, cursor_type& cur) -> void
+        {
+            if (flux::is_last(self.base_, cur.outer_cur)) {
+                flux::dec(self.base_, cur.outer_cur);
+                auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                variant_emplace<1>(cur.inner_cur, flux::last(inner));
+            }
+
+            while (true) {
+                if (cur.inner_cur.index() == 0) {
+                    if (std::get<0>(cur.inner_cur) == flux::first(self.pattern_)) {
+                        flux::dec(self.base_, cur.outer_cur);
+                        auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                        variant_emplace<1>(cur.inner_cur, flux::last(inner));
+                    } else {
+                        break;
+                    }
+                } else {
+                    auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                    if (std::get<1>(cur.inner_cur) == flux::first(inner)) {
+                        variant_emplace<0>(cur.inner_cur, flux::last(self.pattern_));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            if (cur.inner_cur.index() == 0) {
+                flux::dec(self.pattern_, std::get<0>(cur.inner_cur));
+            } else {
+                auto& inner = flux::read_at(self.base_, cur.outer_cur);
+                flux::dec(inner, std::get<1>(cur.inner_cur));
+            }
+        }
+    };
+};
+
 struct flatten_with_fn {
 
     template <adaptable_sequence Seq, adaptable_sequence Pattern>

--- a/include/flux/op/requirements.hpp
+++ b/include/flux/op/requirements.hpp
@@ -40,6 +40,12 @@ struct repeated_invocable_helper {
 template <typename Func, typename E, distance_t N>
 concept repeated_invocable = repeated_invocable_helper<Func, E, N>::value;
 
+template <typename InnerSeq, typename Pattern>
+concept flatten_with_compatible =
+    std::common_reference_with<element_t<InnerSeq>, element_t<Pattern>> &&
+    std::common_reference_with<rvalue_element_t<InnerSeq>, rvalue_element_t<Pattern>> &&
+    std::common_with<value_t<InnerSeq>, value_t<Pattern>>;
+
 } // namespace detail
 
 FLUX_EXPORT

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(test-flux
     test_find.cpp
     test_find_min_max.cpp
     test_flatten.cpp
+    test_flatten_with.cpp
     test_for_each.cpp
     test_fold.cpp
     test_front_back.cpp

--- a/test/test_flatten_with.cpp
+++ b/test/test_flatten_with.cpp
@@ -60,8 +60,7 @@ constexpr bool test_flatten_with_single_pass()
     // flatten_with with an empty pattern is the same as flatten()
     {
         std::array<std::string_view, 3> arr{"111", "222", "333"};
-        auto seq = flux::flatten_with(single_pass_only(std::move(arr)),
-                                      flux::empty<char const&>);
+        auto seq = flux::flatten_with(single_pass_only(std::move(arr)), ""sv);
 
         using S = decltype(seq);
         static_assert(flux::sequence<S>);

--- a/test/test_flatten_with.cpp
+++ b/test/test_flatten_with.cpp
@@ -1,0 +1,118 @@
+
+// Copyright (c) 2024 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <array>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <iostream>
+
+#include "test_utils.hpp"
+
+namespace {
+
+using namespace std::string_view_literals;
+
+constexpr bool test_flatten_with_single_pass()
+{
+    // Single-pass outer, multipass inner, sequence pattern
+    {
+        std::array<std::string_view, 3> arr{"111", "222", "333"};
+        auto seq = flux::flatten_with(single_pass_only(std::move(arr)), "-"sv);
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+        static_assert(std::same_as<flux::element_t<S>, char const&>);
+        static_assert(std::same_as<flux::value_t<S>, char>);
+        static_assert(std::same_as<flux::rvalue_element_t<S>, char const&&>);
+
+        STATIC_CHECK(check_equal(seq, "111-222-333"sv));
+    }
+
+    // Single-pass outer, multipass inner, value pattern
+    {
+        std::array<std::string_view, 3> arr{"111", "222", "333"};
+        auto seq = flux::flatten_with(single_pass_only(std::move(arr)), '-');
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(check_equal(seq, "111-222-333"sv));
+    }
+
+    // Multipass outer, prvalue inner
+    {
+        std::array<std::string_view, 3> arr{"111", "222", "333"};
+        auto seq = flux::map(arr, [](auto sv) { return sv; }).flatten_with('-');
+
+        STATIC_CHECK(check_equal(seq, "111-222-333"sv));
+    }
+
+    // flatten_with with an empty pattern is the same as flatten()
+    {
+        std::array<std::string_view, 3> arr{"111", "222", "333"};
+        auto seq = flux::flatten_with(single_pass_only(std::move(arr)),
+                                      flux::empty<char const&>);
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(check_equal(seq, "111222333"sv));
+    }
+
+    // Empty inner sequence is handled correctly, with delims on both sides
+    {
+        std::array<std::string_view, 6> arr{
+            "123"sv, ""sv, "456"sv, ""sv, "7"sv, "89"sv
+        };
+        
+        auto seq = single_pass_only(std::move(arr)).flatten_with('-');
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(check_equal(seq, "123--456--7-89"sv));
+    }
+
+    // Empty outer sequence is handled correctly
+    {
+        auto arr = std::array<std::array<int, 3>, 0>{};
+
+        auto seq = flux::flatten_with(single_pass_only(std::move(arr)), 999);
+
+        using S = decltype(seq);
+        static_assert(flux::sequence<S>);
+        static_assert(not flux::multipass_sequence<S>);
+        static_assert(not flux::sized_sequence<S>);
+        static_assert(flux::bounded_sequence<S>);
+
+        STATIC_CHECK(seq.count() == 0);
+    }
+
+
+    return true;
+}
+static_assert(test_flatten_with_single_pass());
+
+}
+
+TEST_CASE("flatten_with")
+{
+    bool res = test_flatten_with_single_pass();
+    REQUIRE(res);
+}


### PR DESCRIPTION
This PR adds a flatten_with adaptor. This takes a sequence-of-sequences and a multipass pattern sequence, and produces the sequences interspersed with all of the elements from the pattern.

Fixes #124