### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+---
+BasedOnStyle: WebKit
+AlignAfterOpenBracket: Align
+AlignEscapedNewlines: Left
+#AllowBreakBeforeNoexceptSpecifier: OnlyWithParen
+AllowShortCaseLabelsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - FLUX_NO_UNIQUE_ADDRESS
+BreakBeforeConceptDeclarations: Always
+BreakConstructorInitializers: BeforeColon
+ColumnLimit: 100
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+ForEachMacros:
+  - FLUX_FOR
+IndentPPDirectives: AfterHash
+InsertBraces: true
+NamespaceIndentation: None
+PackConstructorInitializers: CurrentLine
+SortIncludes: Never
+TabWidth: 4


### PR DESCRIPTION
After a lot of messing about, I've think I've finally come up with a clang-format config that I don't hate. It still messes up the concept definitions in `core/concepts.hpp`, but other that that it seems to do a pretty good job of matching the current layout.

I'm not planning on reformatting the whole codebase or anything like that but this should hopefully be useful for new contributors.

Supercedes #110