### PR TITLE
Add default_sequence_traits

### DIFF
--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -18,6 +18,11 @@
 
 // clang-format off
 
+// Workaround GCC11/12 ICE in sequence concept definition below
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 13)
+#define FLUX_COMPILER_IS_GCC12
+#endif
+
 #if defined(__cpp_lib_ranges_zip) && (__cpp_lib_ranges_zip >= 202110L)
 #define FLUX_HAVE_CPP23_TUPLE_COMMON_REF
 #endif
@@ -139,9 +144,11 @@ concept sequence_concept =
         { Traits::move_at(seq, cur) } -> can_reference;
         { Traits::move_at_unchecked(seq, cur) } -> std::same_as<rvalue_element_t<Seq>>;
     } &&
+#ifndef FLUX_COMPILER_IS_GCC12
     requires (Seq& seq, bool (*pred)(element_t<Seq>)) {
         { Traits::for_each_while(seq, pred) } -> std::same_as<cursor_t<Seq>>;
     } &&
+#endif
 #ifdef FLUX_HAVE_CPP23_TUPLE_COMMON_REF
     std::common_reference_with<element_t<Seq>&&, value_t<Seq>&> &&
     std::common_reference_with<rvalue_element_t<Seq>&&, value_t<Seq> const&> &&

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -16,6 +16,8 @@
 #include <tuple>
 #include <type_traits>
 
+// clang-format off
+
 #if defined(__cpp_lib_ranges_zip) && (__cpp_lib_ranges_zip >= 202110L)
 #define FLUX_HAVE_CPP23_TUPLE_COMMON_REF
 #endif
@@ -77,11 +79,6 @@ template <has_element_type T>
     requires requires { typename traits_t<T>::value_type; }
 struct value_type<T> { using type = typename traits_t<T>::value_type; };
 
-template <has_element_type T>
-    requires requires { traits_t<T>::using_primary_template; } &&
-             requires { typename T::value_type; }
-struct value_type<T> { using type = typename T::value_type; };
-
 } // namespace detail
 
 FLUX_EXPORT
@@ -133,8 +130,6 @@ concept sequence_requirements =
     requires (Seq& seq, cursor_t<Seq>& cur) {
         { Traits::inc(seq, cur) };
     };
-
-// clang-format off
 
 template <typename Seq, typename Traits = sequence_traits<std::remove_cvref_t<Seq>>>
 concept sequence_concept =

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -81,24 +81,6 @@ template <has_element_type T>
              requires { typename T::value_type; }
 struct value_type<T> { using type = typename T::value_type; };
 
-template <has_element_type T>
-struct rvalue_element_type {
-    using type = std::conditional_t<std::is_lvalue_reference_v<element_t<T>>,
-                                    std::add_rvalue_reference_t<std::remove_reference_t<element_t<T>>>,
-                                    element_t<T>>;
-};
-
-template <typename Seq>
-concept has_move_at = requires (Seq& seq, cursor_t<Seq> const& cur) {
-   { traits_t<Seq>::move_at(seq, cur) };
-};
-
-template <has_element_type T>
-    requires has_move_at<T>
-struct rvalue_element_type<T> {
-    using type = decltype(traits_t<T>::move_at(FLUX_DECLVAL(T&), FLUX_DECLVAL(cursor_t<T> const&)));
-};
-
 } // namespace detail
 
 FLUX_EXPORT
@@ -113,7 +95,7 @@ using index_t = flux::config::int_type;
 
 FLUX_EXPORT
 template <typename Seq>
-using rvalue_element_t = typename detail::rvalue_element_type<Seq>::type;
+using rvalue_element_t = decltype(detail::traits_t<Seq>::move_at(FLUX_DECLVAL(Seq&), FLUX_DECLVAL(cursor_t<Seq> const&)));
 
 FLUX_EXPORT
 template <typename Seq>

--- a/include/flux/core/default_impls.hpp
+++ b/include/flux/core/default_impls.hpp
@@ -18,7 +18,7 @@ namespace flux {
  * Default implementation for C arrays of known bound
  */
 template <typename T, index_t N>
-struct sequence_traits<T[N]> {
+struct sequence_traits<T[N]> : default_sequence_traits {
 
     static constexpr auto first(auto const&) -> index_t { return index_t{0}; }
 
@@ -82,7 +82,7 @@ struct sequence_traits<T[N]> {
  * Default implementation for std::reference_wrapper<T>
  */
 template <sequence Seq>
-struct sequence_traits<std::reference_wrapper<Seq>> {
+struct sequence_traits<std::reference_wrapper<Seq>> : default_sequence_traits {
 
     using self_t = std::reference_wrapper<Seq>;
 
@@ -172,7 +172,7 @@ template <typename R>
              std::ranges::sized_range<R> &&
              std::ranges::contiguous_range<R const> &&
              std::ranges::sized_range<R const>)
-struct sequence_traits<R> {
+struct sequence_traits<R> : default_sequence_traits {
 
     using value_type = std::ranges::range_value_t<R>;
 

--- a/include/flux/core/sequence_access.hpp
+++ b/include/flux/core/sequence_access.hpp
@@ -117,12 +117,7 @@ struct size_fn {
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq) const -> distance_t
     {
-        if constexpr (requires { traits_t<Seq>::size(seq); }) {
-            return traits_t<Seq>::size(seq);
-        } else {
-            static_assert(bounded_sequence<Seq> && random_access_sequence<Seq>);
-            return distance_fn{}(seq, first_fn{}(seq), last_fn{}(seq));
-        }
+        return traits_t<Seq>::size(seq);
     }
 };
 

--- a/include/flux/core/sequence_access.hpp
+++ b/include/flux/core/sequence_access.hpp
@@ -135,37 +135,15 @@ struct usize_fn {
     }
 };
 
-template <typename Seq>
-concept has_custom_move_at =
-    sequence<Seq> &&
-    requires (Seq& seq, cursor_t<Seq> const& cur) {
-        { traits_t<Seq>::move_at(seq, cur) };
-    };
-
 struct move_at_fn {
     template <sequence Seq>
     [[nodiscard]]
     constexpr auto operator()(Seq& seq, cursor_t<Seq> const& cur) const
         -> rvalue_element_t<Seq>
     {
-        if constexpr (has_custom_move_at<Seq>) {
-            return traits_t<Seq>::move_at(seq, cur);
-        } else {
-            if constexpr (std::is_lvalue_reference_v<element_t<Seq>>) {
-                return std::move(read_at_fn{}(seq, cur));
-            } else {
-                return read_at_fn{}(seq, cur);
-            }
-        }
+        return traits_t<Seq>::move_at(seq, cur);
     }
 };
-
-template <typename Seq>
-concept has_custom_read_at_unchecked =
-    sequence<Seq> &&
-    requires (Seq& seq, cursor_t<Seq> const& cur) {
-        { traits_t<Seq>::read_at_unchecked(seq, cur) } -> std::same_as<element_t<Seq>>;
-    };
 
 struct read_at_unchecked_fn {
     template <sequence Seq>
@@ -173,19 +151,8 @@ struct read_at_unchecked_fn {
     constexpr auto operator()(Seq& seq, cursor_t<Seq> const& cur) const
         -> element_t<Seq>
     {
-        if constexpr (has_custom_read_at_unchecked<Seq>) {
-            return traits_t<Seq>::read_at_unchecked(seq, cur);
-        } else {
-            return read_at_fn{}(seq, cur);
-        }
+        return traits_t<Seq>::read_at_unchecked(seq, cur);
     }
-};
-
-template <typename Seq>
-concept has_custom_move_at_unchecked =
-    sequence<Seq> &&
-    requires (Seq& seq, cursor_t<Seq> const& cur) {
-        { traits_t<Seq>::move_at_unchecked(seq, cur) } -> std::same_as<rvalue_element_t<Seq>>;
 };
 
 struct move_at_unchecked_fn {
@@ -194,15 +161,7 @@ struct move_at_unchecked_fn {
     constexpr auto operator()(Seq& seq, cursor_t<Seq> const& cur) const
         -> rvalue_element_t<Seq>
     {
-        if constexpr (has_custom_move_at_unchecked<Seq>) {
-            return traits_t<Seq>::move_at_unchecked(seq, cur);
-        } else if constexpr (has_custom_move_at<Seq>) {
-            return move_at_fn{}(seq, cur);
-        } else if constexpr (std::is_lvalue_reference_v<element_t<Seq>>){
-            return std::move(read_at_unchecked_fn{}(seq, cur));
-        } else {
-            return read_at_unchecked_fn{}(seq, cur);
-        }
+        return traits_t<Seq>::move_at_unchecked(seq, cur);
     }
 };
 

--- a/include/flux/op/adjacent.hpp
+++ b/include/flux/op/adjacent.hpp
@@ -22,7 +22,7 @@ namespace flux {
 namespace detail {
 
 template <typename Base, distance_t N>
-struct adjacent_sequence_traits_base {
+struct adjacent_sequence_traits_base : default_sequence_traits {
 protected:
     struct cursor_type {
         std::array<cursor_t<Base>, N> arr{};

--- a/include/flux/op/adjacent_filter.hpp
+++ b/include/flux/op/adjacent_filter.hpp
@@ -25,7 +25,7 @@ public:
           pred_(std::move(pred))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/op/adjacent_filter.hpp
+++ b/include/flux/op/adjacent_filter.hpp
@@ -59,6 +59,18 @@ public:
             return flux::read_at_unchecked(self.base_, cur.base_cur);
         }
 
+        static constexpr auto move_at(auto& self, cursor_type const& cur)
+            -> decltype(flux::move_at(self.base_, cur.base_cur))
+        {
+            return flux::move_at(self.base_, cur.base_cur);
+        }
+
+        static constexpr auto move_at_unchecked(auto& self, cursor_type const& cur)
+            -> decltype(flux::move_at_unchecked(self.base_, cur.base_cur))
+        {
+            return flux::move_at_unchecked(self.base_, cur.base_cur);
+        }
+
         static constexpr auto inc(auto& self, cursor_type& cur) -> void
         {
             auto temp = cur.base_cur;

--- a/include/flux/op/cartesian_base.hpp
+++ b/include/flux/op/cartesian_base.hpp
@@ -328,11 +328,7 @@ public:
         -> decltype(auto)
         requires (ReadKind == read_kind::map)
     {
-        if constexpr (std::is_lvalue_reference_v<decltype(read_at(self, cur))>) {
-            return std::move(read_at(self, cur));
-        } else {
-            return read_at(self, cur);
-        }
+        return default_sequence_traits::move_at(self, cur);
     }
 
     template <typename Self>
@@ -340,11 +336,7 @@ public:
         -> decltype(auto)
         requires (ReadKind == read_kind::map)
     {
-        if constexpr (std::is_lvalue_reference_v<decltype(read_at_unchecked(self, cur))>) {
-            return std::move(read_at_unchecked(self, cur));
-        } else {
-            return read_at_unchecked(self, cur);
-        }
+        return default_sequence_traits::move_at_unchecked(self, cur);
     }
 
     template <typename Self>

--- a/include/flux/op/cartesian_base.hpp
+++ b/include/flux/op/cartesian_base.hpp
@@ -383,14 +383,7 @@ public:
     static constexpr auto for_each_while(Self& self, Function&& func) -> cursor_t<Self>
         requires (ReadKind == read_kind::map)
     {
-        auto cur = first(self);
-        while (!is_last(self, cur)) {
-            if (!std::invoke(func, read_at(self, cur))) {
-                break;
-            }
-            inc(self, cur);
-        }
-        return cur;
+        return default_sequence_traits::for_each_while(self, FLUX_FWD(func));
     }
 
 };

--- a/include/flux/op/cartesian_base.hpp
+++ b/include/flux/op/cartesian_base.hpp
@@ -379,6 +379,20 @@ public:
         return cur;
     }
 
+    template <typename Self, typename Function>
+    static constexpr auto for_each_while(Self& self, Function&& func) -> cursor_t<Self>
+        requires (ReadKind == read_kind::map)
+    {
+        auto cur = first(self);
+        while (!is_last(self, cur)) {
+            if (!std::invoke(func, read_at(self, cur))) {
+                break;
+            }
+            inc(self, cur);
+        }
+        return cur;
+    }
+
 };
 
 template <std::size_t Arity, cartesian_kind CartesianKind, read_kind ReadKind, typename... Bases>

--- a/include/flux/op/chain.hpp
+++ b/include/flux/op/chain.hpp
@@ -57,7 +57,7 @@ struct chain_fn {
 } // namespace detail
 
 template <typename... Bases>
-struct sequence_traits<detail::chain_adaptor<Bases...>> {
+struct sequence_traits<detail::chain_adaptor<Bases...>> : default_sequence_traits {
 
     using value_type = std::common_type_t<value_t<Bases>...>;
 

--- a/include/flux/op/chunk.hpp
+++ b/include/flux/op/chunk.hpp
@@ -33,7 +33,7 @@ public:
     chunk_adaptor(chunk_adaptor&&) = default;
     chunk_adaptor& operator=(chunk_adaptor&&) = default;
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct outer_cursor {
             outer_cursor(outer_cursor&&) = default;
@@ -61,7 +61,7 @@ public:
             value_type(value_type&&) = default;
             value_type& operator=(value_type&&) = default;
 
-            struct flux_sequence_traits {
+            struct flux_sequence_traits : default_sequence_traits {
             private:
                 struct inner_cursor {
                     inner_cursor(inner_cursor&&) = default;
@@ -146,7 +146,7 @@ public:
           chunk_sz_(chunk_sz)
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
         static inline constexpr bool is_infinite = infinite_sequence<Base>;
 
         static constexpr auto first(auto& self) -> cursor_t<Base>
@@ -198,7 +198,7 @@ public:
           chunk_sz_(chunk_sz)
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> cur{};

--- a/include/flux/op/chunk_by.hpp
+++ b/include/flux/op/chunk_by.hpp
@@ -25,7 +25,7 @@ public:
           pred_(std::move(pred))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> from;

--- a/include/flux/op/cursors.hpp
+++ b/include/flux/op/cursors.hpp
@@ -22,7 +22,7 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
 
         static inline constexpr bool is_infinite = infinite_sequence<Base>;
 

--- a/include/flux/op/drop.hpp
+++ b/include/flux/op/drop.hpp
@@ -54,7 +54,10 @@ public:
             return flux::data(self.base()) + (cmp::min)(self.count_, flux::size(self.base_));
         }
 
-        using default_sequence_traits::for_each_while;
+        static constexpr auto for_each_while(auto& self, auto&& pred) -> cursor_t<Base>
+        {
+            return default_sequence_traits::for_each_while(self, FLUX_FWD(pred));
+        }
     };
 };
 

--- a/include/flux/op/drop.hpp
+++ b/include/flux/op/drop.hpp
@@ -54,7 +54,7 @@ public:
             return flux::data(self.base()) + (cmp::min)(self.count_, flux::size(self.base_));
         }
 
-        void for_each_while(...) = delete;
+        using default_sequence_traits::for_each_while;
     };
 };
 

--- a/include/flux/op/drop_while.hpp
+++ b/include/flux/op/drop_while.hpp
@@ -47,8 +47,8 @@ public:
                    flux::distance(self.base_, flux::first(self.base_), first(self));
         }
 
-        void size(...) = delete;
-        void for_each_while(...) = delete;
+        using default_sequence_traits::size;
+        using default_sequence_traits::for_each_while;
     };
 };
 

--- a/include/flux/op/flatten.hpp
+++ b/include/flux/op/flatten.hpp
@@ -25,7 +25,7 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         using self_t = flatten_adaptor;
 
@@ -105,7 +105,7 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         using InnerSeq = element_t<Base>;
 

--- a/include/flux/op/flatten_with.hpp
+++ b/include/flux/op/flatten_with.hpp
@@ -47,7 +47,7 @@ public:
           pattern_(FLUX_FWD(pattern))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         using self_t = flatten_with_adaptor;
         using element_type =
@@ -173,7 +173,7 @@ public:
           pattern_(FLUX_FWD(pattern))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         using InnerSeq = element_t<Base>;
 

--- a/include/flux/op/for_each_while.hpp
+++ b/include/flux/op/for_each_while.hpp
@@ -18,26 +18,7 @@ struct for_each_while_fn {
                  boolean_testable<std::invoke_result_t<Pred&, element_t<Seq>>>
     constexpr auto operator()(Seq&& seq, Pred pred) const -> cursor_t<Seq>
     {
-        if constexpr (requires { traits_t<Seq>::for_each_while(seq, std::move(pred)); }) {
-            return traits_t<Seq>::for_each_while(seq, std::move(pred));
-        } else {
-            if constexpr (multipass_sequence<Seq> && bounded_sequence<Seq>) {
-                auto cur = first(seq);
-                auto end = last(seq);
-                while (cur != end) {
-                    if (!std::invoke(pred, read_at(seq, cur))) { break; }
-                    inc(seq, cur);
-                }
-                return cur;
-            } else {
-                auto cur = first(seq);
-                while (!is_last(seq, cur)) {
-                    if (!std::invoke(pred, read_at(seq, cur))) { break; }
-                    inc(seq, cur);
-                }
-                return cur;
-            }
-        }
+        return traits_t<Seq>::for_each_while(seq, std::move(pred));
     }
 };
 

--- a/include/flux/op/map.hpp
+++ b/include/flux/op/map.hpp
@@ -63,7 +63,6 @@ public:
             });
         }
 
-        using default_sequence_traits::read_at_unchecked;
         using default_sequence_traits::move_at;
         using default_sequence_traits::move_at_unchecked;
 

--- a/include/flux/op/map.hpp
+++ b/include/flux/op/map.hpp
@@ -63,7 +63,10 @@ public:
             });
         }
 
-        static void move_at() = delete; // Use the base version of move_at
+        using default_sequence_traits::read_at_unchecked;
+        using default_sequence_traits::move_at;
+        using default_sequence_traits::move_at_unchecked;
+
         static void data() = delete; // we're not a contiguous sequence
     };
 };

--- a/include/flux/op/mask.hpp
+++ b/include/flux/op/mask.hpp
@@ -25,7 +25,7 @@ public:
           mask_(FLUX_FWD(mask))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;
@@ -103,7 +103,7 @@ public:
 
         template <typename Self>
             requires maybe_const_iterable<Self>
-        static constexpr auto move_at(auto& self, cursor_type const& cur) -> decltype(auto)
+        static constexpr auto move_at(Self& self, cursor_type const& cur) -> decltype(auto)
         {
             return flux::move_at(self.base_, cur.base_cur);
         }

--- a/include/flux/op/ref.hpp
+++ b/include/flux/op/ref.hpp
@@ -15,7 +15,7 @@ namespace flux {
 namespace detail {
 
 template <typename Base>
-struct passthrough_traits_base {
+struct passthrough_traits_base : default_sequence_traits {
 
     static constexpr auto first(auto& self)
         -> decltype(flux::first(self.base()))

--- a/include/flux/op/scan.hpp
+++ b/include/flux/op/scan.hpp
@@ -45,7 +45,7 @@ public:
     scan_adaptor(scan_adaptor&&) = default;
     scan_adaptor& operator=(scan_adaptor&&) = default;
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
 
         struct cursor_type : private scan_cursor_base<Mode> {

--- a/include/flux/op/scan.hpp
+++ b/include/flux/op/scan.hpp
@@ -146,6 +146,8 @@ public:
                 return std::invoke(pred, std::as_const(self.accum_));
             }));
         }
+
+        using default_sequence_traits::for_each_while; // when Mode == exclusive
     };
 };
 

--- a/include/flux/op/scan_first.hpp
+++ b/include/flux/op/scan_first.hpp
@@ -28,7 +28,7 @@ public:
           func_(std::move(func))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_type(cursor_type&&) = default;

--- a/include/flux/op/set_adaptors.hpp
+++ b/include/flux/op/set_adaptors.hpp
@@ -29,7 +29,7 @@ public:
           cmp_(cmp)
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
 
         struct cursor_type {
@@ -162,7 +162,7 @@ public:
           cmp_(cmp)
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
 
         struct cursor_type {
@@ -265,7 +265,7 @@ public:
           cmp_(cmp)
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
 
         struct cursor_type {
@@ -410,7 +410,7 @@ public:
           cmp_(cmp)
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
 
         struct cursor_type {

--- a/include/flux/op/slice.hpp
+++ b/include/flux/op/slice.hpp
@@ -134,8 +134,8 @@ struct sequence_traits<subsequence<Base, Bounded>>
                flux::distance(*self.base_, flux::first(*self.base_), self.data_.first);
     }
 
-    void size() = delete;
-    void for_each_while() = delete;
+    using default_sequence_traits::size;
+    using default_sequence_traits::for_each_while;
 };
 
 FLUX_EXPORT inline constexpr auto slice = detail::slice_fn{};

--- a/include/flux/op/slide.hpp
+++ b/include/flux/op/slide.hpp
@@ -26,7 +26,7 @@ public:
           win_sz_(win_sz)
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> from;

--- a/include/flux/op/split.hpp
+++ b/include/flux/op/split.hpp
@@ -34,7 +34,7 @@ public:
           splitter_(FLUX_FWD(splitter))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> cur{};

--- a/include/flux/op/stride.hpp
+++ b/include/flux/op/stride.hpp
@@ -124,7 +124,7 @@ public:
           stride_(stride)
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> cur{};

--- a/include/flux/op/zip.hpp
+++ b/include/flux/op/zip.hpp
@@ -247,7 +247,8 @@ public:
 };
 
 template <typename Func, typename... Bases>
-struct sequence_traits<detail::zip_map_adaptor<Func, Bases...>> : zip_traits_base<Bases...>
+struct sequence_traits<detail::zip_map_adaptor<Func, Bases...>>
+    : zip_traits_base<Bases...>, default_sequence_traits
 {
 private:
     using base = zip_traits_base<Bases...>;
@@ -280,6 +281,9 @@ public:
     {
         return read_(flux::read_at_unchecked, self, cur);
     }
+
+    using default_sequence_traits::move_at;
+    using default_sequence_traits::move_at_unchecked;
 };
 
 FLUX_EXPORT inline constexpr auto zip = detail::zip_fn{};

--- a/include/flux/op/zip.hpp
+++ b/include/flux/op/zip.hpp
@@ -31,7 +31,7 @@ using pair_or_tuple_t = typename pair_or_tuple<Ts...>::type;
 }
 
 template <typename... Bases>
-struct zip_traits_base {
+struct zip_traits_base : default_sequence_traits {
 private:
     template <typename From, typename To>
     using const_like_t = std::conditional_t<std::is_const_v<From>, To const, To>;
@@ -247,8 +247,7 @@ public:
 };
 
 template <typename Func, typename... Bases>
-struct sequence_traits<detail::zip_map_adaptor<Func, Bases...>>
-    : zip_traits_base<Bases...>, default_sequence_traits
+struct sequence_traits<detail::zip_map_adaptor<Func, Bases...>> : zip_traits_base<Bases...>
 {
 private:
     using base = zip_traits_base<Bases...>;

--- a/include/flux/source/array_ptr.hpp
+++ b/include/flux/source/array_ptr.hpp
@@ -78,7 +78,7 @@ public:
         return std::ranges::equal_to{}(lhs.data_, rhs.data_) && lhs.sz_ == rhs.sz_;
     }
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
 
         static constexpr auto first(array_ptr const&) -> index_t { return 0; }
 

--- a/include/flux/source/bitset.hpp
+++ b/include/flux/source/bitset.hpp
@@ -13,7 +13,7 @@
 namespace flux {
 
 template <std::size_t N>
-struct sequence_traits<std::bitset<N>> {
+struct sequence_traits<std::bitset<N>> : default_sequence_traits {
 
     using value_type = bool;
 

--- a/include/flux/source/empty.hpp
+++ b/include/flux/source/empty.hpp
@@ -14,7 +14,7 @@ namespace detail {
 
 template <typename T>
 struct empty_sequence : inline_sequence_base<empty_sequence<T>> {
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             friend auto operator==(cursor_type, cursor_type) -> bool = default;

--- a/include/flux/source/generator.hpp
+++ b/include/flux/source/generator.hpp
@@ -73,7 +73,7 @@ public:
 };
 
 template <typename T>
-struct sequence_traits<generator<T>>
+struct sequence_traits<generator<T>> : default_sequence_traits
 {
 private:
     struct cursor_type {

--- a/include/flux/source/getlines.hpp
+++ b/include/flux/source/getlines.hpp
@@ -37,7 +37,7 @@ public:
     getlines_sequence(getlines_sequence&&) = default;
     getlines_sequence& operator=(getlines_sequence&&) = default;
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             explicit cursor_type() = default;

--- a/include/flux/source/iota.hpp
+++ b/include/flux/source/iota.hpp
@@ -49,7 +49,7 @@ struct iota_traits {
 };
 
 template <incrementable T, iota_traits Traits>
-struct iota_sequence_traits {
+struct iota_sequence_traits : default_sequence_traits {
     using cursor_type = T;
 
     static constexpr bool is_infinite = !Traits.has_end;

--- a/include/flux/source/istream.hpp
+++ b/include/flux/source/istream.hpp
@@ -45,7 +45,7 @@ struct from_istream_fn {
 } // namespace detail
 
 template <typename T, typename CharT, typename Traits>
-struct sequence_traits<detail::istream_adaptor<T, CharT, Traits>>
+struct sequence_traits<detail::istream_adaptor<T, CharT, Traits>> : default_sequence_traits
 {
 private:
     struct cursor_type {

--- a/include/flux/source/istreambuf.hpp
+++ b/include/flux/source/istreambuf.hpp
@@ -42,7 +42,7 @@ struct from_istreambuf_fn {
 } // namespace detail
 
 template <detail::derives_from_streambuf Streambuf>
-struct sequence_traits<Streambuf>
+struct sequence_traits<Streambuf> : default_sequence_traits
 {
 private:
     struct cursor_type {

--- a/include/flux/source/range.hpp
+++ b/include/flux/source/range.hpp
@@ -27,7 +27,7 @@ private:
     using V = std::conditional_t<IsConst, R const, R>;
 
 public:
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         class cursor_type {
 

--- a/include/flux/source/repeat.hpp
+++ b/include/flux/source/repeat.hpp
@@ -37,7 +37,7 @@ public:
           data_{count}
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         using self_t = repeat_sequence;
 

--- a/include/flux/source/single.hpp
+++ b/include/flux/source/single.hpp
@@ -55,7 +55,7 @@ struct single_fn {
 } // namespace detail
 
 template <typename T>
-struct sequence_traits<detail::single_sequence<T>>
+struct sequence_traits<detail::single_sequence<T>> : default_sequence_traits
 {
 private:
     using self_t = detail::single_sequence<T>;

--- a/include/flux/source/unfold.hpp
+++ b/include/flux/source/unfold.hpp
@@ -26,7 +26,7 @@ public:
           func_(std::move(func))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             friend struct flux_sequence_traits;

--- a/test/test_cache_last.cpp
+++ b/test/test_cache_last.cpp
@@ -21,9 +21,8 @@ constexpr bool test_cache_last()
         static_assert(flux::sequence<C>);
         static_assert(flux::random_access_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>); // because RA and bounded
 
-        STATIC_CHECK(cached.size() == 5);
+        STATIC_CHECK(cached.count() == 5);
 
         static_assert(std::ranges::common_range<C>);
     }

--- a/test/test_chunk.cpp
+++ b/test/test_chunk.cpp
@@ -29,7 +29,7 @@ struct NotBidir : flux::inline_sequence_base<NotBidir<Base>> {
     constexpr Base& base() & { return base_; }
     constexpr Base const& base() const& { return base_; }
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : flux::default_sequence_traits {
         static constexpr auto first(auto& self) { return flux::first(self.base_); }
 
         static constexpr bool is_last(auto& self, auto const& cur) {

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -49,7 +49,7 @@ struct cant_instantiate {
 };
 
 template <typename T>
-struct dummy_impl {
+struct dummy_impl : flux::default_sequence_traits {
     static int first(T&);
     static bool is_last(T&, int);
     static int& inc(T&, int&);
@@ -58,7 +58,7 @@ struct dummy_impl {
 
 template <typename Elem>
 struct minimal_seq_of {
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : flux::default_sequence_traits {
         static int first(minimal_seq_of);
         static bool is_last(minimal_seq_of, int);
         static int& inc(minimal_seq_of, int&);
@@ -68,7 +68,7 @@ struct minimal_seq_of {
 
 template <typename Idx>
 struct minimal_with_idx {
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : flux::default_sequence_traits {
         static Idx first(minimal_with_idx);
         static bool is_last(minimal_with_idx, Idx const&);
         static Idx& inc(minimal_with_idx, Idx&);
@@ -194,7 +194,7 @@ static_assert(flux::sequence<Derived2>);
 // Adaptable sequence tests
 namespace {
     struct movable_seq {
-        struct flux_sequence_traits {
+        struct flux_sequence_traits : flux::default_sequence_traits {
             static int first(movable_seq);
             static bool is_last(movable_seq, int);
             static int& inc(movable_seq, int&);
@@ -207,7 +207,7 @@ namespace {
         move_only_seq(move_only_seq&&) = default;
         move_only_seq& operator=(move_only_seq&&) = default;
 
-        struct flux_sequence_traits {
+        struct flux_sequence_traits : flux::default_sequence_traits {
             static int first(move_only_seq const&);
             static bool is_last(move_only_seq const&, int);
             static int& inc(move_only_seq const&, int&);
@@ -220,7 +220,7 @@ namespace {
         unmovable_seq(unmovable_seq&&) = delete;
         unmovable_seq& operator=(unmovable_seq&&) = delete;
 
-        struct flux_sequence_traits {
+        struct flux_sequence_traits : flux::default_sequence_traits {
             static int first(unmovable_seq const&);
             static bool is_last(unmovable_seq const&, int);
             static int& inc(unmovable_seq const&, int&);
@@ -252,7 +252,7 @@ namespace {
 // const_iterable_sequence tests
 namespace {
     struct const_iter {
-        struct flux_sequence_traits {
+        struct flux_sequence_traits : flux::default_sequence_traits {
             static int first(const_iter const&);
             static bool is_last(const_iter const&, int);
             static void inc(const_iter const&, int&);
@@ -265,7 +265,7 @@ namespace {
 
     // read_at(S const&) is not defined
     struct not_const_iter1 {
-        struct flux_sequence_traits {
+        struct flux_sequence_traits : flux::default_sequence_traits {
             static int first(not_const_iter1 const&);
             static bool is_last(not_const_iter1 const&, int);
             static void inc(not_const_iter1 const&, int&);
@@ -276,7 +276,7 @@ namespace {
 
     // read_at(S) and read_at(S const) yield different types
     struct not_const_iter2 {
-        struct flux_sequence_traits {
+        struct flux_sequence_traits : flux::default_sequence_traits {
             static int first(not_const_iter2 const&);
             static bool is_last(not_const_iter2 const&, int);
             static void inc(not_const_iter2 const&, int&);
@@ -289,7 +289,7 @@ namespace {
 
     // read_at(S const) weakens const qualification
     struct not_const_iter3 {
-        struct flux_sequence_traits {
+        struct flux_sequence_traits : flux::default_sequence_traits {
             static int first(not_const_iter3 const&);
             static bool is_last(not_const_iter3 const&, int);
             static void inc(not_const_iter3 const&, int&);
@@ -302,7 +302,7 @@ namespace {
 
     // S is bounded but S const is not
     struct not_const_iter4 {
-        struct flux_sequence_traits {
+        struct flux_sequence_traits : flux::default_sequence_traits {
             static int first(not_const_iter4 const&);
             static bool is_last(not_const_iter4 const&, int);
             static void inc(not_const_iter4 const&, int&);
@@ -316,7 +316,7 @@ namespace {
 
     // S const is sized but S is not
     struct not_const_iter5 {
-        struct flux_sequence_traits {
+        struct flux_sequence_traits : flux::default_sequence_traits {
             static int first(not_const_iter5 const&);
             static bool is_last(not_const_iter5 const&, int);
             static void inc(not_const_iter5 const&, int&);

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -19,7 +19,7 @@ struct span_seq {
     T* ptr_;
     std::size_t sz_;
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : flux::default_sequence_traits {
         static constexpr std::size_t first(span_seq const&) { return 0; }
         static constexpr bool is_last(span_seq const& self, std::size_t i) { return i == self.sz_; }
         static constexpr std::size_t& inc(span_seq const&, std::size_t& i) { return ++i; }

--- a/test/test_stride.cpp
+++ b/test/test_stride.cpp
@@ -20,7 +20,7 @@ struct NotBidir : flux::inline_sequence_base<NotBidir<Base>> {
     constexpr Base& base() & { return base_; }
     constexpr Base const& base() const& { return base_; }
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : flux::default_sequence_traits {
         static constexpr auto first(auto& self) { return flux::first(self.base_); }
 
         static constexpr bool is_last(auto& self, auto const& cur) {

--- a/test/test_take_while.cpp
+++ b/test/test_take_while.cpp
@@ -12,7 +12,7 @@ namespace {
 struct ints {
     int from = 0;
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : flux::default_sequence_traits {
         static constexpr int first(ints) { return 0; }
         static constexpr bool is_last(ints, int) { return false; }
         static constexpr int read_at(ints self, int cur){ return self.from + cur; }

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -88,7 +88,7 @@ public:
 }
 
 template <typename Base>
-struct flux::sequence_traits<single_pass_only<Base>>
+struct flux::sequence_traits<single_pass_only<Base>> : flux::default_sequence_traits
 {
     using self_t = single_pass_only<Base>;
     using cursor_t = typename single_pass_only<Base>::cursor_type;


### PR DESCRIPTION
The `sequence` concept has several optional customisation points, for example `read_at_unchecked()` and `for_each_while()`, for which we can provide a reasonable default if the sequence implementation does not.

Previously this was handled by the wrapper functions (`flux::read_at_unchecked` etc) examining the `sequence_traits<T>` struct and  using the customised function if it existed, otherwise falling back to their default implementation.

This PR changes the arrangement somewhat. Rather than being strictly optional, the `sequence` concept now requires that **all** customisation points are implemented. We can still provide default implementations, but this is now handled by having `sequence_traits<T>` inherit from a new base class `default_sequence_traits`. (In principle using this base class is not required by the sequence concept, but in practise everyone will want to use it.)

This has the advantage that user-defined customisations can now be concept-checked; that is, if a user provides an incompatible signature for e.g. `for_each_while` in their `sequence_traits`, it will hide the default implementation, and result in a compile error; previously, the incompatible signature would just have been ignored and the default impl would silently have been used.

For complicated sequence implementations (e.g. the `zip` and `cartesian_product` families), this means that we also need to be explicit about when we're using the default impls vs using customised versions. This is a good thing.

