### PR TITLE
[OUTDATED] Add iterable concept

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,4 +19,5 @@ InsertBraces: true
 NamespaceIndentation: None
 PackConstructorInitializers: CurrentLine
 SortIncludes: Never
+SpaceBeforeCpp11BracedList: false
 TabWidth: 4

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ CMakeLists.txt.user
 cmake-build*/
 
 # VS Code
+.cache/
 .vscode/
 
 # VS

--- a/example/docs/read_only.cpp
+++ b/example/docs/read_only.cpp
@@ -11,7 +11,7 @@
 
 // We can use the read_only_sequence concept to statically require a sequence
 // whose elements are immutable
-bool contains_a_two(flux::read_only_sequence auto&& seq)
+bool contains_a_two(flux::read_only_iterable auto&& seq)
 {
     for (auto&& elem : seq) {
         if (elem == 2) { // What if we wrote `elem = 2` (assignment) by mistake?

--- a/example/top10/08_three_consecutive_odds.cpp
+++ b/example/top10/08_three_consecutive_odds.cpp
@@ -16,8 +16,7 @@ namespace version1 {
 
 auto const tco = [](std::initializer_list<int> nums)
 {
-    int odd_count = 0;
-    auto idx = flux::for_each_while(nums, [&](int i) {
+    return !flux::iterate(nums, [odd_count = 0](int i) mutable {
         if (i % 2 != 0) {
             ++odd_count;
         } else {
@@ -25,7 +24,6 @@ auto const tco = [](std::initializer_list<int> nums)
         }
         return odd_count < 3; // true => keep iterating
     });
-    return !flux::is_last(nums, idx);
 };
 
 static_assert(tco({}) == false);

--- a/include/flux/adaptor/adjacent.hpp
+++ b/include/flux/adaptor/adjacent.hpp
@@ -107,7 +107,7 @@ public:
     }
 
     static constexpr auto size(auto& self) -> distance_t
-        requires sized_sequence<Base>
+        requires sized_iterable<Base>
     {
         auto s = (flux::size(self.base_) - N) + 1;
         return (cmp::max)(s, distance_t{0});

--- a/include/flux/adaptor/adjacent.hpp
+++ b/include/flux/adaptor/adjacent.hpp
@@ -115,7 +115,7 @@ public:
 };
 
 template <typename Base, distance_t N>
-struct adjacent_adaptor : inline_sequence_base<adjacent_adaptor<Base, N>> {
+struct adjacent_adaptor : inline_iter_base<adjacent_adaptor<Base, N>> {
 private:
     Base base_;
 
@@ -176,7 +176,7 @@ public:
 };
 
 template <typename Base, distance_t N, typename Func>
-struct adjacent_map_adaptor : inline_sequence_base<adjacent_map_adaptor<Base, N, Func>> {
+struct adjacent_map_adaptor : inline_iter_base<adjacent_map_adaptor<Base, N, Func>> {
 private:
     Base base_;
     Func func_;
@@ -244,14 +244,14 @@ FLUX_EXPORT inline constexpr auto pairwise_map = adjacent_map<2>;
 
 template <typename D>
 template <distance_t N>
-constexpr auto inline_sequence_base<D>::adjacent() &&
+constexpr auto inline_iter_base<D>::adjacent() &&
     requires multipass_sequence<D>
 {
     return flux::adjacent<N>(std::move(derived()));
 }
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::pairwise() &&
+constexpr auto inline_iter_base<D>::pairwise() &&
     requires multipass_sequence<D>
 {
     return flux::pairwise(std::move(derived()));
@@ -260,7 +260,7 @@ constexpr auto inline_sequence_base<D>::pairwise() &&
 template <typename D>
 template <distance_t N, typename Func>
     requires multipass_sequence<D>
-constexpr auto inline_sequence_base<D>::adjacent_map(Func func) &&
+constexpr auto inline_iter_base<D>::adjacent_map(Func func) &&
 {
     return flux::adjacent_map<N>(std::move(derived()), std::move(func));
 }
@@ -268,7 +268,7 @@ constexpr auto inline_sequence_base<D>::adjacent_map(Func func) &&
 template <typename D>
 template <typename Func>
     requires multipass_sequence<D>
-constexpr auto inline_sequence_base<D>::pairwise_map(Func func) &&
+constexpr auto inline_iter_base<D>::pairwise_map(Func func) &&
 {
     return flux::pairwise_map(std::move(derived()), std::move(func));
 }

--- a/include/flux/adaptor/adjacent.hpp
+++ b/include/flux/adaptor/adjacent.hpp
@@ -20,7 +20,7 @@ namespace flux {
 namespace detail {
 
 template <typename Base, distance_t N>
-struct adjacent_sequence_traits_base : default_sequence_traits {
+struct adjacent_sequence_traits_base : default_iter_traits {
 protected:
     struct cursor_type {
         std::array<cursor_t<Base>, N> arr{};
@@ -126,7 +126,7 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    struct flux_sequence_traits : adjacent_sequence_traits_base<Base, N> {
+    struct flux_iter_traits : adjacent_sequence_traits_base<Base, N> {
     private:
 
         using cursor_type = adjacent_sequence_traits_base<Base, N>::cursor_type;
@@ -189,7 +189,7 @@ public:
           func_(std::move(func))
     {}
 
-    struct flux_sequence_traits : adjacent_sequence_traits_base<Base, N> {
+    struct flux_iter_traits : adjacent_sequence_traits_base<Base, N> {
         template <typename Self>
         static constexpr auto read_at(Self& self, cursor_t<Self> const& cur)
             -> decltype(auto)

--- a/include/flux/adaptor/adjacent_filter.hpp
+++ b/include/flux/adaptor/adjacent_filter.hpp
@@ -14,7 +14,7 @@ namespace detail {
 
 template <multipass_sequence Base, typename Pred>
 struct adjacent_filter_adaptor
-    : inline_sequence_base<adjacent_filter_adaptor<Base, Pred>> {
+    : inline_iter_base<adjacent_filter_adaptor<Base, Pred>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Pred pred_;
@@ -145,13 +145,13 @@ template <typename D>
 template <typename Pred>
     requires multipass_sequence<D> &&
              std::predicate<Pred&, element_t<D>, element_t<D>>
-constexpr auto inline_sequence_base<D>::adjacent_filter(Pred pred) &&
+constexpr auto inline_iter_base<D>::adjacent_filter(Pred pred) &&
 {
     return flux::adjacent_filter(std::move(derived()), std::move(pred));
 }
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::dedup() &&
+constexpr auto inline_iter_base<D>::dedup() &&
     requires multipass_sequence<D> &&
              std::equality_comparable<element_t<D>>
 {

--- a/include/flux/adaptor/adjacent_filter.hpp
+++ b/include/flux/adaptor/adjacent_filter.hpp
@@ -25,7 +25,7 @@ public:
           pred_(std::move(pred))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/cache_last.hpp
+++ b/include/flux/adaptor/cache_last.hpp
@@ -28,7 +28,7 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    struct flux_sequence_traits : detail::passthrough_traits_base {
+    struct flux_iter_traits : detail::passthrough_traits_base {
 
         using value_type = value_t<Base>;
         using self_t = cache_last_adaptor;

--- a/include/flux/adaptor/cache_last.hpp
+++ b/include/flux/adaptor/cache_last.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <sequence Base>
-struct cache_last_adaptor : inline_sequence_base<cache_last_adaptor<Base>>
+struct cache_last_adaptor : inline_iter_base<cache_last_adaptor<Base>>
 {
 private:
     Base base_;
@@ -79,7 +79,7 @@ struct cache_last_fn {
 FLUX_EXPORT inline constexpr auto cache_last = detail::cache_last_fn{};
 
 template <typename Derived>
-constexpr auto inline_sequence_base<Derived>::cache_last() &&
+constexpr auto inline_iter_base<Derived>::cache_last() &&
     requires bounded_sequence<Derived> ||
         (multipass_sequence<Derived> && not infinite_sequence<Derived>)
 {

--- a/include/flux/adaptor/cartesian_base.hpp
+++ b/include/flux/adaptor/cartesian_base.hpp
@@ -59,7 +59,7 @@ struct cartesian_traits_types<Arity, cartesian_kind::product, read_kind::tuple, 
 };
 
 template <std::size_t Arity, cartesian_kind CartesianKind, read_kind ReadKind, typename... Bases>
-struct cartesian_traits_base_impl : default_sequence_traits {
+struct cartesian_traits_base_impl : default_iter_traits {
 private:
 
     template<std::size_t I, typename Self>
@@ -368,7 +368,7 @@ public:
         -> decltype(auto)
         requires (ReadKind == read_kind::map)
     {
-        return default_sequence_traits::move_at(self, cur);
+        return default_iter_traits::move_at(self, cur);
     }
 
     template <typename Self>
@@ -376,7 +376,7 @@ public:
         -> decltype(auto)
         requires (ReadKind == read_kind::map)
     {
-        return default_sequence_traits::move_at_unchecked(self, cur);
+        return default_iter_traits::move_at_unchecked(self, cur);
     }
 
     template <typename Self>
@@ -415,7 +415,7 @@ public:
     static constexpr auto for_each_while(Self& self, Function&& func) -> cursor_t<Self>
         requires (ReadKind == read_kind::map)
     {
-        return default_sequence_traits::for_each_while(self, FLUX_FWD(func));
+        return default_iter_traits::for_each_while(self, FLUX_FWD(func));
     }
 
 };

--- a/include/flux/adaptor/cartesian_base.hpp
+++ b/include/flux/adaptor/cartesian_base.hpp
@@ -233,7 +233,7 @@ public:
     template <typename Self>
     static constexpr auto size(Self& self) -> distance_t
         requires (CartesianKind == cartesian_kind::product
-                  && (sized_sequence<Bases> && ...))
+                  && (sized_iterable<Bases> && ...))
     {
         return std::apply([](auto& base0, auto&... bases) {
             distance_t sz = flux::size(base0);
@@ -245,7 +245,7 @@ public:
     template <typename Self>
     static constexpr auto size(Self& self) -> distance_t
         requires (CartesianKind == cartesian_kind::power
-                  && (sized_sequence<Bases> && ...))
+                  && (sized_iterable<Bases> && ...))
     {
         return checked_pow(flux::size(self.base_), Arity);
     }
@@ -269,7 +269,7 @@ public:
     template <typename Self>
     static constexpr auto inc(Self& self, cursor_t<Self>& cur, distance_t offset) -> cursor_t<Self>&
         requires ((random_access_sequence<Bases> && ...) &&
-                  (sized_sequence<Bases> && ...))
+                  (sized_iterable<Bases> && ...))
     {
         return ra_inc_impl<Arity - 1>(self, cur, offset);
     }
@@ -305,7 +305,7 @@ public:
                                         cursor_t<Self> const& from,
                                         cursor_t<Self> const& to) -> distance_t
         requires ((random_access_sequence<Bases> && ...) &&
-                  (sized_sequence<Bases> && ...))
+                  (sized_iterable<Bases> && ...))
     {
         return distance_impl<Arity - 1>(self, from, to);
     }

--- a/include/flux/adaptor/cartesian_power.hpp
+++ b/include/flux/adaptor/cartesian_power.hpp
@@ -20,7 +20,7 @@ namespace detail {
 
 template <std::size_t PowN, sequence Base>
 struct cartesian_power_adaptor
-    : inline_sequence_base<cartesian_power_adaptor<PowN, Base>> {
+    : inline_iter_base<cartesian_power_adaptor<PowN, Base>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
 

--- a/include/flux/adaptor/cartesian_power.hpp
+++ b/include/flux/adaptor/cartesian_power.hpp
@@ -29,13 +29,13 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    using flux_sequence_traits = cartesian_traits_base<
+    using flux_iter_traits = cartesian_traits_base<
         PowN,
         cartesian_kind::power,
         read_kind::tuple,
         Base
     >;
-    friend flux_sequence_traits::impl;
+    friend flux_iter_traits::impl;
 };
 
 

--- a/include/flux/adaptor/cartesian_power_map.hpp
+++ b/include/flux/adaptor/cartesian_power_map.hpp
@@ -25,13 +25,13 @@ public:
           func_(FLUX_FWD(func))
     {}
 
-    using flux_sequence_traits = cartesian_traits_base<
+    using flux_iter_traits = cartesian_traits_base<
         PowN,
         cartesian_kind::power,
         read_kind::map,
         Base
     >;
-    friend flux_sequence_traits::impl;
+    friend flux_iter_traits::impl;
 };
 
 template <std::size_t PowN>

--- a/include/flux/adaptor/cartesian_power_map.hpp
+++ b/include/flux/adaptor/cartesian_power_map.hpp
@@ -14,7 +14,7 @@ namespace detail {
 
 template <sequence Base, std::size_t PowN, typename Func>
 struct cartesian_power_map_adaptor
-    : inline_sequence_base<cartesian_power_map_adaptor<Base, PowN, Func>> {
+    : inline_iter_base<cartesian_power_map_adaptor<Base, PowN, Func>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Func func_;

--- a/include/flux/adaptor/cartesian_product.hpp
+++ b/include/flux/adaptor/cartesian_product.hpp
@@ -20,7 +20,7 @@ namespace detail {
 
 template <sequence... Bases>
 struct cartesian_product_adaptor
-    : inline_sequence_base<cartesian_product_adaptor<Bases...>> {
+    : inline_iter_base<cartesian_product_adaptor<Bases...>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS std::tuple<Bases...> bases_;
 

--- a/include/flux/adaptor/cartesian_product.hpp
+++ b/include/flux/adaptor/cartesian_product.hpp
@@ -29,13 +29,13 @@ public:
         : bases_(FLUX_FWD(bases)...)
     {}
     
-    using flux_sequence_traits = cartesian_traits_base<
+    using flux_iter_traits = cartesian_traits_base<
         sizeof...(Bases),
         cartesian_kind::product,
         read_kind::tuple,
         Bases...
     >;
-    friend flux_sequence_traits::impl;
+    friend flux_iter_traits::impl;
 };
 
 struct cartesian_product_fn {

--- a/include/flux/adaptor/cartesian_product_map.hpp
+++ b/include/flux/adaptor/cartesian_product_map.hpp
@@ -14,7 +14,7 @@ namespace detail {
 
 template <typename Func, sequence... Bases>
 struct cartesian_product_map_adaptor
-    : inline_sequence_base<cartesian_product_map_adaptor<Func, Bases...>> {
+    : inline_iter_base<cartesian_product_map_adaptor<Func, Bases...>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS std::tuple<Bases...> bases_;
     FLUX_NO_UNIQUE_ADDRESS Func func_;

--- a/include/flux/adaptor/cartesian_product_map.hpp
+++ b/include/flux/adaptor/cartesian_product_map.hpp
@@ -25,13 +25,13 @@ public:
           func_(FLUX_FWD(func))
     {}
 
-    using flux_sequence_traits = cartesian_traits_base<
+    using flux_iter_traits = cartesian_traits_base<
         sizeof...(Bases),
         cartesian_kind::product,
         read_kind::map,
         Bases...
     >;
-    friend flux_sequence_traits::impl;
+    friend flux_iter_traits::impl;
 };
 
 struct cartesian_product_map_fn

--- a/include/flux/adaptor/chain.hpp
+++ b/include/flux/adaptor/chain.hpp
@@ -15,57 +15,52 @@ namespace flux {
 
 namespace detail {
 
-template <sequence... Bases>
-struct chain_adaptor : inline_sequence_base<chain_adaptor<Bases...>> {
-private:
-    std::tuple<Bases...> bases_;
-
-    friend struct sequence_traits<chain_adaptor>;
-
-public:
-    explicit constexpr chain_adaptor(decays_to<Bases> auto&&... bases)
-        : bases_(FLUX_FWD(bases)...)
-    {}
-};
-
-template <typename... Ts>
-concept all_have_common_ref =
-    requires { typename std::common_reference_t<Ts...>; } &&
-    (std::convertible_to<Ts, std::common_reference_t<Ts...>> && ...);
-
-template <typename... Seqs>
-concept chainable =
-    all_have_common_ref<element_t<Seqs>...> &&
-    all_have_common_ref<rvalue_element_t<Seqs>...> &&
-    requires { typename std::common_type_t<value_t<Seqs>...>; };
-
-struct chain_fn {
-    template <adaptable_sequence... Seqs>
-        requires (sizeof...(Seqs) >= 1) &&
-                 chainable<Seqs...>
-    [[nodiscard]]
-    constexpr auto operator()(Seqs&&... seqs) const
-    {
-        if constexpr (sizeof...(Seqs) == 1) {
-            return std::forward<Seqs...>(seqs...);
-        } else {
-            return chain_adaptor<std::decay_t<Seqs>...>(FLUX_FWD(seqs)...);
-        }
-    }
-};
-
-} // namespace detail
-
 template <typename... Bases>
-struct sequence_traits<detail::chain_adaptor<Bases...>> : default_sequence_traits {
+struct chain_iterable_traits_base : default_sequence_traits {
 
     using value_type = std::common_type_t<value_t<Bases>...>;
 
+protected:
+    static constexpr std::size_t End = sizeof...(Bases) - 1;
+
+    template <typename From, typename To>
+    using const_like_t = std::conditional_t<std::is_const_v<From>, To const, To>;
+
+    template <std::size_t N>
+    static constexpr auto iterate_impl(auto& self, auto& pred) -> bool
+    {
+        if constexpr (N < End) {
+            if (flux::iterate(std::get<N>(self.bases_), pred)) {
+                return iterate_impl<N+1>(self, pred);
+            } else {
+                return false;
+            }
+        } else {
+            return flux::iterate(std::get<N>(self.bases_), pred);
+        }
+    }
+
+public:
+    template <typename Self>
+    static consteval auto element_type(Self&)
+        -> std::common_reference_t<element_t<const_like_t<Self, Bases>>...>;
+
+    template <typename Self, typename Pred>
+    static constexpr auto iterate(Self& self, Pred&& pred) -> bool
+    {
+        return iterate_impl<0>(self, pred);
+    }
+
+};
+
+template <typename... Bases>
+struct chain_sequence_traits_base : chain_iterable_traits_base<Bases...>
+{
     static constexpr bool disable_multipass = !(multipass_sequence<Bases> && ...);
     static constexpr bool is_infinite = (infinite_sequence<Bases> || ...);
 
 private:
-    static constexpr std::size_t End = sizeof...(Bases) - 1;
+    using chain_iterable_traits_base<Bases...>::End;
 
     template <typename From, typename To>
     using const_like_t = std::conditional_t<std::is_const_v<From>, To const, To>;
@@ -247,7 +242,7 @@ public:
     static constexpr auto is_last(Self& self, cursor_type const& cur) -> bool
     {
         return cur.index() == End &&
-               flux::is_last(std::get<End>(self.bases_), std::get<End>(cur));
+            flux::is_last(std::get<End>(self.bases_), std::get<End>(cur));
     }
 
     template <typename Self>
@@ -273,7 +268,7 @@ public:
     template <typename Self>
     static constexpr auto dec(Self& self, cursor_type& cur) -> void
         requires (bidirectional_sequence<const_like_t<Self, Bases>> && ...) &&
-                 (bounded_sequence<const_like_t<Self,Bases>> &&...)
+        (bounded_sequence<const_like_t<Self,Bases>> &&...)
     {
         dec_impl<End>(self, cur);
     }
@@ -304,7 +299,7 @@ public:
                                    cursor_type const& to)
         -> distance_t
         requires (random_access_sequence<const_like_t<Self, Bases>> && ...) &&
-                 (bounded_sequence<const_like_t<Self, Bases>> && ...)
+        (bounded_sequence<const_like_t<Self, Bases>> && ...)
     {
         if (from.index() <= to.index()) {
             return distance_impl<0>(self, from, to);
@@ -316,12 +311,58 @@ public:
     template <typename Self>
     static constexpr auto inc(Self& self, cursor_type& cur, distance_t offset)
         requires (random_access_sequence<const_like_t<Self, Bases>> && ...) &&
-                 (bounded_sequence<const_like_t<Self, Bases>> && ...)
+        (bounded_sequence<const_like_t<Self, Bases>> && ...)
     {
         inc_ra_impl<0>(self, cur, offset);
     }
 
 };
+
+template <iterable... Bases>
+struct chain_adaptor : inline_sequence_base<chain_adaptor<Bases...>> {
+private:
+    std::tuple<Bases...> bases_;
+
+    friend struct chain_iterable_traits_base<Bases...>;
+    friend struct chain_sequence_traits_base<Bases...>;
+
+public:
+    explicit constexpr chain_adaptor(decays_to<Bases> auto&&... bases)
+        : bases_(FLUX_FWD(bases)...)
+    {}
+
+    struct flux_sequence_traits
+        : std::conditional_t<(sequence<Bases> && ...),
+            chain_sequence_traits_base<Bases...>,
+            chain_iterable_traits_base<Bases...>>
+    {};
+};
+
+template <typename... Ts>
+concept all_have_common_ref =
+    requires { typename std::common_reference_t<Ts...>; } &&
+    (std::convertible_to<Ts, std::common_reference_t<Ts...>> && ...);
+
+template <typename... Seqs>
+concept chainable =
+    all_have_common_ref<element_t<Seqs>...> &&
+    requires { typename std::common_type_t<value_t<Seqs>...>; };
+
+struct chain_fn {
+    template <sink_iterable It0, sink_iterable... Its>
+        requires chainable<It0, Its...>
+    [[nodiscard]]
+    constexpr auto operator()(It0&& it0, Its&&... its) const
+    {
+        if constexpr (sizeof...(Its) == 0) {
+            return FLUX_FWD(it0);
+        } else {
+            return chain_adaptor<std::decay_t<It0>, std::decay_t<Its>...>(FLUX_FWD(it0), FLUX_FWD(its)...);
+        }
+    }
+};
+
+} // namespace detail
 
 FLUX_EXPORT inline constexpr auto chain = detail::chain_fn{};
 

--- a/include/flux/adaptor/chain.hpp
+++ b/include/flux/adaptor/chain.hpp
@@ -319,7 +319,7 @@ public:
 };
 
 template <iterable... Bases>
-struct chain_adaptor : inline_sequence_base<chain_adaptor<Bases...>> {
+struct chain_adaptor : inline_iter_base<chain_adaptor<Bases...>> {
 private:
     std::tuple<Bases...> bases_;
 

--- a/include/flux/adaptor/chain.hpp
+++ b/include/flux/adaptor/chain.hpp
@@ -16,7 +16,7 @@ namespace flux {
 namespace detail {
 
 template <typename... Bases>
-struct chain_iterable_traits_base : default_sequence_traits {
+struct chain_iterable_traits_base : default_iter_traits {
 
     using value_type = std::common_type_t<value_t<Bases>...>;
 
@@ -331,7 +331,7 @@ public:
         : bases_(FLUX_FWD(bases)...)
     {}
 
-    struct flux_sequence_traits
+    struct flux_iter_traits
         : std::conditional_t<(sequence<Bases> && ...),
             chain_sequence_traits_base<Bases...>,
             chain_iterable_traits_base<Bases...>>

--- a/include/flux/adaptor/chain.hpp
+++ b/include/flux/adaptor/chain.hpp
@@ -287,7 +287,7 @@ public:
 
     template <typename Self>
     static constexpr auto size(Self& self)
-        requires (sized_sequence<const_like_t<Self, Bases>> && ...)
+        requires (sized_iterable<const_like_t<Self, Bases>> && ...)
     {
         return std::apply([](auto&... bases) { return (flux::size(bases) + ...); },
                           self.bases_);

--- a/include/flux/adaptor/chunk.hpp
+++ b/include/flux/adaptor/chunk.hpp
@@ -125,7 +125,7 @@ public:
         }
 
         static constexpr auto size(self_t& self) -> distance_t
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             auto s = flux::size(self.base_);
             return s/self.chunk_sz_ + (s % self.chunk_sz_ == 0 ? 0 : 1);
@@ -177,7 +177,7 @@ public:
         }
 
         static constexpr auto size(auto& self) -> distance_t
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             auto s = flux::size(self.base_);
             return s/self.chunk_sz_ + (s % self.chunk_sz_ == 0 ? 0 : 1);
@@ -257,7 +257,7 @@ public:
         }
 
         static constexpr auto last(auto& self) -> cursor_type
-            requires bounded_sequence<Base> && sized_sequence<Base>
+            requires bounded_sequence<Base> && sized_iterable<Base>
         {
             distance_t missing =
                 (self.chunk_sz_ - flux::size(self.base_) % self.chunk_sz_) % self.chunk_sz_;
@@ -268,7 +268,7 @@ public:
         }
 
         static constexpr auto size(auto& self) -> distance_t
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             auto s = flux::size(self.base_);
             return s/self.chunk_sz_ + (s % self.chunk_sz_ == 0 ? 0 : 1);

--- a/include/flux/adaptor/chunk.hpp
+++ b/include/flux/adaptor/chunk.hpp
@@ -312,6 +312,7 @@ FLUX_EXPORT inline constexpr auto chunk = detail::chunk_fn{};
 
 template <typename D>
 constexpr auto inline_iter_base<D>::chunk(num::integral auto chunk_sz) &&
+    requires sequence<D>
 {
     return flux::chunk(std::move(derived()), chunk_sz);
 }

--- a/include/flux/adaptor/chunk.hpp
+++ b/include/flux/adaptor/chunk.hpp
@@ -16,7 +16,7 @@ namespace flux {
 namespace detail {
 
 template <typename Base>
-struct chunk_adaptor : inline_sequence_base<chunk_adaptor<Base>> {
+struct chunk_adaptor : inline_iter_base<chunk_adaptor<Base>> {
 private:
     Base base_;
     distance_t chunk_sz_;
@@ -47,7 +47,7 @@ public:
         using self_t = chunk_adaptor;
 
     public:
-        struct value_type : inline_sequence_base<value_type> {
+        struct value_type : inline_iter_base<value_type> {
         private:
             chunk_adaptor* parent_;
             constexpr explicit value_type(chunk_adaptor& parent)
@@ -134,7 +134,7 @@ public:
 };
 
 template <multipass_sequence Base>
-struct chunk_adaptor<Base> : inline_sequence_base<chunk_adaptor<Base>> {
+struct chunk_adaptor<Base> : inline_iter_base<chunk_adaptor<Base>> {
 private:
     Base base_;
     distance_t chunk_sz_;
@@ -186,7 +186,7 @@ public:
 };
 
 template <bidirectional_sequence Base>
-struct chunk_adaptor<Base> : inline_sequence_base<chunk_adaptor<Base>> {
+struct chunk_adaptor<Base> : inline_iter_base<chunk_adaptor<Base>> {
 private:
     Base base_;
     distance_t chunk_sz_;
@@ -311,7 +311,7 @@ struct chunk_fn {
 FLUX_EXPORT inline constexpr auto chunk = detail::chunk_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::chunk(num::integral auto chunk_sz) &&
+constexpr auto inline_iter_base<D>::chunk(num::integral auto chunk_sz) &&
 {
     return flux::chunk(std::move(derived()), chunk_sz);
 }

--- a/include/flux/adaptor/chunk.hpp
+++ b/include/flux/adaptor/chunk.hpp
@@ -32,13 +32,13 @@ public:
     chunk_adaptor(chunk_adaptor&&) = default;
     chunk_adaptor& operator=(chunk_adaptor&&) = default;
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct outer_cursor {
             outer_cursor(outer_cursor&&) = default;
             outer_cursor& operator=(outer_cursor&&) = default;
 
-            friend struct flux_sequence_traits;
+            friend struct flux_iter_traits;
 
         private:
             explicit outer_cursor() = default;
@@ -54,19 +54,19 @@ public:
                 : parent_(std::addressof(parent))
             {}
 
-            friend struct self_t::flux_sequence_traits;
+            friend struct self_t::flux_iter_traits;
 
         public:
             value_type(value_type&&) = default;
             value_type& operator=(value_type&&) = default;
 
-            struct flux_sequence_traits : default_sequence_traits {
+            struct flux_iter_traits : default_iter_traits {
             private:
                 struct inner_cursor {
                     inner_cursor(inner_cursor&&) = default;
                     inner_cursor& operator=(inner_cursor&&) = default;
 
-                    friend struct value_type::flux_sequence_traits;
+                    friend struct value_type::flux_iter_traits;
 
                 private:
                     explicit inner_cursor() = default;
@@ -145,7 +145,7 @@ public:
           chunk_sz_(chunk_sz)
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
         static inline constexpr bool is_infinite = infinite_sequence<Base>;
 
         static constexpr auto first(auto& self) -> cursor_t<Base>
@@ -197,7 +197,7 @@ public:
           chunk_sz_(chunk_sz)
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> cur{};

--- a/include/flux/adaptor/chunk_by.hpp
+++ b/include/flux/adaptor/chunk_by.hpp
@@ -24,7 +24,7 @@ public:
           pred_(std::move(pred))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> from;

--- a/include/flux/adaptor/chunk_by.hpp
+++ b/include/flux/adaptor/chunk_by.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <multipass_sequence Base, typename Pred>
-struct chunk_by_adaptor : inline_sequence_base<chunk_by_adaptor<Base, Pred>> {
+struct chunk_by_adaptor : inline_iter_base<chunk_by_adaptor<Base, Pred>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Pred pred_;
@@ -138,7 +138,7 @@ template <typename Derived>
 template <typename Pred>
     requires multipass_sequence<Derived> &&
              std::predicate<Pred&, element_t<Derived>, element_t<Derived>>
-constexpr auto inline_sequence_base<Derived>::chunk_by(Pred pred) &&
+constexpr auto inline_iter_base<Derived>::chunk_by(Pred pred) &&
 {
     return flux::chunk_by(std::move(derived()), std::move(pred));
 }

--- a/include/flux/adaptor/cursors.hpp
+++ b/include/flux/adaptor/cursors.hpp
@@ -73,7 +73,7 @@ public:
         }
 
         static constexpr auto size(auto& self) -> distance_t
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             return flux::size(self.base_);
         }

--- a/include/flux/adaptor/cursors.hpp
+++ b/include/flux/adaptor/cursors.hpp
@@ -22,7 +22,7 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
 
         static inline constexpr bool is_infinite = infinite_sequence<Base>;
 

--- a/include/flux/adaptor/cursors.hpp
+++ b/include/flux/adaptor/cursors.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <typename Base>
-struct cursors_adaptor : inline_sequence_base<cursors_adaptor<Base>> {
+struct cursors_adaptor : inline_iter_base<cursors_adaptor<Base>> {
 private:
     Base base_;
 
@@ -95,7 +95,7 @@ struct cursors_fn {
 FLUX_EXPORT inline constexpr auto cursors = detail::cursors_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::cursors() &&
+constexpr auto inline_iter_base<D>::cursors() &&
     requires multipass_sequence<D>
 {
     return flux::cursors(std::move(derived()));

--- a/include/flux/adaptor/cycle.hpp
+++ b/include/flux/adaptor/cycle.hpp
@@ -38,7 +38,7 @@ public:
           data_(count)
     {}
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/cycle.hpp
+++ b/include/flux/adaptor/cycle.hpp
@@ -21,7 +21,7 @@ template <>
 struct cycle_data<true> {};
 
 template <multipass_sequence Base, bool IsInfinite>
-struct cycle_adaptor : inline_sequence_base<cycle_adaptor<Base, IsInfinite>> {
+struct cycle_adaptor : inline_iter_base<cycle_adaptor<Base, IsInfinite>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS cycle_data<IsInfinite> data_;
@@ -242,14 +242,14 @@ struct cycle_fn {
 FLUX_EXPORT inline constexpr auto cycle = detail::cycle_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::cycle() &&
+constexpr auto inline_iter_base<D>::cycle() &&
     requires infinite_sequence<D> || multipass_sequence<D>
 {
     return flux::cycle(std::move(derived()));
 }
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::cycle(num::integral auto count) &&
+constexpr auto inline_iter_base<D>::cycle(num::integral auto count) &&
     requires multipass_sequence<D>
 {
     return flux::cycle(std::move(derived()), count);

--- a/include/flux/adaptor/cycle.hpp
+++ b/include/flux/adaptor/cycle.hpp
@@ -184,7 +184,7 @@ public:
                                        cursor_type const& from,
                                        cursor_type const& to) -> distance_t
             requires random_access_sequence<decltype(self.base_)> &&
-                     sized_sequence<decltype(self.base_)>
+                     sized_iterable<decltype(self.base_)>
         {
             auto dist = num::cast<distance_t>(to.n) - num::cast<distance_t>(from.n);
             dist = num::mul(dist, flux::size(self.base_));
@@ -201,7 +201,7 @@ public:
         }
 
         static constexpr auto size(auto& self) -> distance_t
-            requires (!IsInfinite && sized_sequence<Base>)
+            requires (!IsInfinite && sized_iterable<Base>)
         {
             return num::mul(flux::size(self.base_),
                             num::cast<flux::distance_t>(self.data_.count));

--- a/include/flux/adaptor/cycle.hpp
+++ b/include/flux/adaptor/cycle.hpp
@@ -38,7 +38,7 @@ public:
           data_(count)
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/drop.hpp
+++ b/include/flux/adaptor/drop.hpp
@@ -28,7 +28,7 @@ public:
     constexpr Base& base() & { return base_; }
     constexpr Base const& base() const& { return base_; }
 
-    struct flux_sequence_traits : passthrough_traits_base {
+    struct flux_iter_traits : passthrough_traits_base {
         using value_type = value_t<Base>;
 
         static constexpr bool disable_multipass = !multipass_sequence<Base>;

--- a/include/flux/adaptor/drop.hpp
+++ b/include/flux/adaptor/drop.hpp
@@ -41,14 +41,14 @@ public:
         }
 
         static constexpr auto size(auto& self)
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             return (cmp::max)(num::sub(flux::size(self.base()), self.count_),
                               distance_t{0});
         }
 
         static constexpr auto data(auto& self)
-            requires contiguous_sequence<Base> && sized_sequence<Base>
+            requires contiguous_sequence<Base> && sized_iterable<Base>
         {
             return flux::data(self.base()) + (cmp::min)(self.count_, flux::size(self.base_));
         }

--- a/include/flux/adaptor/drop.hpp
+++ b/include/flux/adaptor/drop.hpp
@@ -13,7 +13,7 @@ namespace flux {
 
 namespace detail {
 
-template <sequence Base>
+template <iterable Base>
 struct drop_adaptor : inline_sequence_base<drop_adaptor<Base>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
@@ -33,14 +33,34 @@ public:
 
         static constexpr bool disable_multipass = !multipass_sequence<Base>;
 
-        static constexpr auto first(auto& self) -> cursor_t<Base>
+        static constexpr auto iterate(auto& self, auto&& pred) -> bool
+        {
+            if constexpr (random_access_sequence<Base> && bounded_sequence<Base>) {
+                auto cur = flux::first(self.base_);
+                flux::inc(self.base_, cur, self.count_);
+                return flux::iterate(flux::slice(self.base_, cur, flux::last(self.base_)), FLUX_FWD(pred));
+            } else {
+                distance_t n = 0;
+                return flux::iterate(self.base_, [&pred, &n, count = self.count_](auto&& elem) {
+                    if (n < count) {
+                        ++n;
+                        return true; // continue
+                    } else {
+                        return std::invoke(pred, FLUX_FWD(elem));
+                    }
+                });
+            }
+        }
+
+        static constexpr auto first(auto& self) -> decltype(flux::first(self.base()))
+            requires sequence<decltype(self.base())>
         {
             auto cur = flux::first(self.base_);
             detail::advance(self.base_, cur, self.count_);
             return cur;
         }
 
-        static constexpr auto size(auto& self)
+        static constexpr auto size(auto& self) -> distance_t
             requires sized_iterable<Base>
         {
             return (cmp::max)(num::sub(flux::size(self.base()), self.count_),
@@ -52,25 +72,20 @@ public:
         {
             return flux::data(self.base()) + (cmp::min)(self.count_, flux::size(self.base_));
         }
-
-        static constexpr auto for_each_while(auto& self, auto&& pred) -> cursor_t<Base>
-        {
-            return default_sequence_traits::for_each_while(self, FLUX_FWD(pred));
-        }
     };
 };
 
 struct drop_fn {
-    template <adaptable_sequence Seq>
+    template <sink_iterable It>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, num::integral auto count) const
+    constexpr auto operator()(It&& it, num::integral auto count) const
     {
-        auto count_ = num::checked_cast<distance_t>(count);
+        auto count_ = num::cast<distance_t>(count);
         if (count_ < 0) {
             runtime_error("Negative argument passed to drop()");
         }
 
-        return drop_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq), count_);
+        return drop_adaptor<std::decay_t<It>>(FLUX_FWD(it), count_);
     }
 
 };

--- a/include/flux/adaptor/drop.hpp
+++ b/include/flux/adaptor/drop.hpp
@@ -14,7 +14,7 @@ namespace flux {
 namespace detail {
 
 template <iterable Base>
-struct drop_adaptor : inline_sequence_base<drop_adaptor<Base>> {
+struct drop_adaptor : inline_iter_base<drop_adaptor<Base>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     distance_t count_;
@@ -95,7 +95,7 @@ struct drop_fn {
 FLUX_EXPORT inline constexpr auto drop = detail::drop_fn{};
 
 template <typename Derived>
-constexpr auto inline_sequence_base<Derived>::drop(num::integral auto count) &&
+constexpr auto inline_iter_base<Derived>::drop(num::integral auto count) &&
 {
     return flux::drop(std::move(derived()), count);
 }

--- a/include/flux/adaptor/drop_while.hpp
+++ b/include/flux/adaptor/drop_while.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <iterable Base, typename Pred>
-struct drop_while_adaptor : inline_sequence_base<drop_while_adaptor<Base, Pred>> {
+struct drop_while_adaptor : inline_iter_base<drop_while_adaptor<Base, Pred>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Pred pred_;
@@ -84,7 +84,7 @@ FLUX_EXPORT inline constexpr auto drop_while = detail::drop_while_fn{};
 template <typename D>
 template <typename Pred>
     requires std::predicate<Pred&, element_t<D>>
-constexpr auto inline_sequence_base<D>::drop_while(Pred pred) &&
+constexpr auto inline_iter_base<D>::drop_while(Pred pred) &&
 {
     return flux::drop_while(std::move(derived()), std::move(pred));
 };

--- a/include/flux/adaptor/drop_while.hpp
+++ b/include/flux/adaptor/drop_while.hpp
@@ -29,7 +29,7 @@ public:
           pred_(FLUX_FWD(pred))
     {}
 
-    struct flux_sequence_traits : detail::passthrough_traits_base {
+    struct flux_iter_traits : detail::passthrough_traits_base {
         using value_type = value_t<Base>;
 
         static constexpr bool disable_multipass = !multipass_sequence<Base>;
@@ -62,8 +62,8 @@ public:
                    flux::distance(self.base_, flux::first(self.base_), first(self));
         }
 
-        using default_sequence_traits::size;
-        using default_sequence_traits::for_each_while;
+        using default_iter_traits::size;
+        using default_iter_traits::for_each_while;
     };
 };
 

--- a/include/flux/adaptor/filter.hpp
+++ b/include/flux/adaptor/filter.hpp
@@ -30,7 +30,7 @@ public:
     [[nodiscard]]
     constexpr auto base() && -> Base { return std::move(base_); }
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/filter.hpp
+++ b/include/flux/adaptor/filter.hpp
@@ -30,7 +30,7 @@ public:
     [[nodiscard]]
     constexpr auto base() && -> Base { return std::move(base_); }
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/filter.hpp
+++ b/include/flux/adaptor/filter.hpp
@@ -14,7 +14,7 @@ namespace flux {
 namespace detail {
 
 template <iterable Base, typename Pred>
-class filter_adaptor : public inline_sequence_base<filter_adaptor<Base, Pred>>
+class filter_adaptor : public inline_iter_base<filter_adaptor<Base, Pred>>
 {
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Pred pred_;
@@ -146,7 +146,7 @@ FLUX_EXPORT inline constexpr auto filter = detail::filter_fn{};
 template <typename D>
 template <typename Pred>
     requires std::predicate<Pred&, element_t<D>>
-constexpr auto inline_sequence_base<D>::filter(Pred pred) &&
+constexpr auto inline_iter_base<D>::filter(Pred pred) &&
 {
     return detail::filter_adaptor<D, Pred>(std::move(derived()), std::move(pred));
 }

--- a/include/flux/adaptor/filter.hpp
+++ b/include/flux/adaptor/filter.hpp
@@ -45,7 +45,8 @@ public:
 
         static constexpr bool disable_multipass = !multipass_sequence<Base>;
 
-        static consteval auto element_type(auto& self) -> element_t<decltype((self.base_))>;
+        template <typename Self>
+        static consteval auto element_type(Self& self) -> element_t<decltype((self.base_))>;
 
         static constexpr auto iterate(auto& self, auto func) -> bool
         {

--- a/include/flux/adaptor/filter_map.hpp
+++ b/include/flux/adaptor/filter_map.hpp
@@ -41,7 +41,7 @@ template <typename D>
 template <typename Func>
 requires std::invocable<Func&, element_t<D>> &&
          detail::optional_like<std::invoke_result_t<Func&, element_t<D>>>
-constexpr auto inline_sequence_base<D>::filter_map(Func func) &&
+constexpr auto inline_iter_base<D>::filter_map(Func func) &&
 {
     return flux::filter_map(derived(), std::move(func));
 }
@@ -63,7 +63,7 @@ struct filter_deref_fn {
 FLUX_EXPORT inline constexpr auto filter_deref = detail::filter_deref_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::filter_deref() && requires detail::optional_like<value_t<D>>
+constexpr auto inline_iter_base<D>::filter_deref() && requires detail::optional_like<value_t<D>>
 {
     return flux::filter_deref(derived());
 }

--- a/include/flux/adaptor/filter_map.hpp
+++ b/include/flux/adaptor/filter_map.hpp
@@ -20,12 +20,12 @@ struct filter_map_fn {
     using strip_rvalue_ref_t = std::conditional_t<
         std::is_rvalue_reference_v<T>, std::remove_reference_t<T>, T>;
 
-    template <adaptable_sequence Seq, typename Func>
-        requires (std::invocable<Func&, element_t<Seq>> &&
-                  optional_like<std::remove_cvref_t<std::invoke_result_t<Func&, element_t<Seq>>>>)
-    constexpr auto operator()(Seq&& seq, Func func) const
+    template <sink_iterable It, typename Func>
+        requires (std::invocable<Func&, element_t<It>> &&
+                  optional_like<std::remove_cvref_t<std::invoke_result_t<Func&, element_t<It>>>>)
+    constexpr auto operator()(It&& it, Func func) const
     {
-        return flux::map(FLUX_FWD(seq), std::move(func))
+        return flux::map(FLUX_FWD(it), std::move(func))
             .filter([](auto&& opt) { return static_cast<bool>(opt); })
             .map([](auto&& opt) -> strip_rvalue_ref_t<decltype(*FLUX_FWD(opt))> {
                 return *FLUX_FWD(opt);
@@ -50,11 +50,11 @@ namespace detail
 {
 
 struct filter_deref_fn {
-    template <adaptable_sequence Seq>
-        requires optional_like<value_t<Seq>>
-    constexpr auto operator()(Seq&& seq) const
+    template <sink_iterable It>
+        requires optional_like<value_t<It>>
+    constexpr auto operator()(It&& it) const
     {
-        return filter_map(FLUX_FWD(seq), [](auto&& opt) -> decltype(auto) { return FLUX_FWD(opt); });
+        return filter_map(FLUX_FWD(it), [](auto&& opt) -> decltype(auto) { return FLUX_FWD(opt); });
     }
 };
 

--- a/include/flux/adaptor/flatten.hpp
+++ b/include/flux/adaptor/flatten.hpp
@@ -23,7 +23,8 @@ public:
     {}
 
     struct flux_sequence_traits {
-        static consteval auto element_type(auto& self)
+        template <typename Self>
+        static consteval auto element_type(Self& self)
             -> element_t<element_t<decltype((self.base_))>>;
 
         static constexpr auto iterate(auto& self, auto&& pred) -> bool

--- a/include/flux/adaptor/flatten.hpp
+++ b/include/flux/adaptor/flatten.hpp
@@ -12,8 +12,31 @@ namespace flux {
 
 namespace detail {
 
-template <sequence Base>
+template <iterable Base>
 struct flatten_adaptor : inline_sequence_base<flatten_adaptor<Base>> {
+private:
+    Base base_;
+
+public:
+    constexpr explicit flatten_adaptor(decays_to<Base> auto&& base)
+        : base_(FLUX_FWD(base))
+    {}
+
+    struct flux_sequence_traits {
+        static consteval auto element_type(auto& self)
+            -> element_t<element_t<decltype((self.base_))>>;
+
+        static constexpr auto iterate(auto& self, auto&& pred) -> bool
+        {
+            return flux::iterate(self.base_, [&pred](auto&& inner) {
+                return flux::iterate(inner, pred);
+            });
+        }
+    };
+};
+
+template <sequence Base>
+struct flatten_adaptor<Base> : inline_sequence_base<flatten_adaptor<Base>> {
 private:
     using InnerSeq = element_t<Base>;
 
@@ -231,12 +254,12 @@ public:
 };
 
 struct flatten_fn {
-    template <adaptable_sequence Seq>
-        requires sequence<element_t<Seq>>
+    template <sink_iterable It>
+        requires iterable<element_t<It>>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq) const -> sequence auto
+    constexpr auto operator()(It&& it) const -> iterable auto
     {
-        return flatten_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
+        return flatten_adaptor<std::decay_t<It>>(FLUX_FWD(it));
     }
 };
 
@@ -246,7 +269,7 @@ FLUX_EXPORT inline constexpr auto flatten = detail::flatten_fn{};
 
 template <typename Derived>
 constexpr auto inline_sequence_base<Derived>::flatten() &&
-        requires sequence<element_t<Derived>>
+        requires iterable<element_t<Derived>>
 {
     return flux::flatten(std::move(derived()));
 }

--- a/include/flux/adaptor/flatten.hpp
+++ b/include/flux/adaptor/flatten.hpp
@@ -22,7 +22,7 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    struct flux_sequence_traits {
+    struct flux_iter_traits {
         template <typename Self>
         static consteval auto element_type(Self& self)
             -> element_t<element_t<decltype((self.base_))>>;
@@ -49,7 +49,7 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         using self_t = flatten_adaptor;
 
@@ -129,7 +129,7 @@ public:
         : base_(FLUX_FWD(base))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         using InnerSeq = element_t<Base>;
 

--- a/include/flux/adaptor/flatten.hpp
+++ b/include/flux/adaptor/flatten.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <iterable Base>
-struct flatten_adaptor : inline_sequence_base<flatten_adaptor<Base>> {
+struct flatten_adaptor : inline_iter_base<flatten_adaptor<Base>> {
 private:
     Base base_;
 
@@ -37,7 +37,7 @@ public:
 };
 
 template <sequence Base>
-struct flatten_adaptor<Base> : inline_sequence_base<flatten_adaptor<Base>> {
+struct flatten_adaptor<Base> : inline_iter_base<flatten_adaptor<Base>> {
 private:
     using InnerSeq = element_t<Base>;
 
@@ -120,7 +120,7 @@ public:
 template <multipass_sequence Base>
     requires std::is_reference_v<element_t<Base>> &&
              multipass_sequence<element_t<Base>>
-struct flatten_adaptor<Base> : inline_sequence_base<flatten_adaptor<Base>> {
+struct flatten_adaptor<Base> : inline_iter_base<flatten_adaptor<Base>> {
 private:
     Base base_;
 
@@ -269,7 +269,7 @@ struct flatten_fn {
 FLUX_EXPORT inline constexpr auto flatten = detail::flatten_fn{};
 
 template <typename Derived>
-constexpr auto inline_sequence_base<Derived>::flatten() &&
+constexpr auto inline_iter_base<Derived>::flatten() &&
         requires iterable<element_t<Derived>>
 {
     return flux::flatten(std::move(derived()));

--- a/include/flux/adaptor/flatten.hpp
+++ b/include/flux/adaptor/flatten.hpp
@@ -37,6 +37,7 @@ public:
 };
 
 template <sequence Base>
+    requires sequence<element_t<Base>>
 struct flatten_adaptor<Base> : inline_iter_base<flatten_adaptor<Base>> {
 private:
     using InnerSeq = element_t<Base>;

--- a/include/flux/adaptor/flatten_with.hpp
+++ b/include/flux/adaptor/flatten_with.hpp
@@ -27,7 +27,7 @@ inline constexpr auto variant_emplace =
 };
 
 template <iterable Base, multipass_sequence Pattern>
-struct flatten_with_adaptor : inline_sequence_base<flatten_with_adaptor<Base, Pattern>> {
+struct flatten_with_adaptor : inline_iter_base<flatten_with_adaptor<Base, Pattern>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Pattern pattern_;
@@ -68,7 +68,7 @@ public:
 
 template <sequence Base, multipass_sequence Pattern>
 struct flatten_with_adaptor<Base, Pattern>
-    : inline_sequence_base<flatten_with_adaptor<Base, Pattern>>
+    : inline_iter_base<flatten_with_adaptor<Base, Pattern>>
 {
 private:
     using InnerSeq = element_t<Base>;
@@ -198,7 +198,7 @@ template <multipass_sequence Base, multipass_sequence Pattern>
     requires std::is_lvalue_reference_v<element_t<Base>> &&
              multipass_sequence<element_t<Base>>
 struct flatten_with_adaptor<Base, Pattern>
-    : inline_sequence_base<flatten_with_adaptor<Base, Pattern>> {
+    : inline_iter_base<flatten_with_adaptor<Base, Pattern>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Pattern pattern_;
@@ -412,7 +412,7 @@ template <adaptable_sequence Pattern>
     requires sequence<element_t<Derived>> &&
              multipass_sequence<Pattern> &&
              detail::flatten_with_compatible<element_t<Derived>, Pattern>
-constexpr auto inline_sequence_base<Derived>::flatten_with(Pattern&& pattern) &&
+constexpr auto inline_iter_base<Derived>::flatten_with(Pattern&& pattern) &&
 {
     return flux::flatten_with(std::move(derived()), FLUX_FWD(pattern));
 }
@@ -421,7 +421,7 @@ template <typename Derived>
 template <typename Value>
     requires sequence<element_t<Derived>> &&
              std::constructible_from<value_t<element_t<Derived>>, Value&&>
-constexpr auto inline_sequence_base<Derived>::flatten_with(Value value) &&
+constexpr auto inline_iter_base<Derived>::flatten_with(Value value) &&
 {
     return flux::flatten_with(std::move(derived()), std::move(value));
 }

--- a/include/flux/adaptor/flatten_with.hpp
+++ b/include/flux/adaptor/flatten_with.hpp
@@ -8,6 +8,7 @@
 
 #include <flux/core.hpp>
 
+#include <flux/adaptor/map.hpp>
 #include <flux/sequence/single.hpp>
 
 namespace flux {
@@ -409,7 +410,7 @@ FLUX_EXPORT inline constexpr auto flatten_with = detail::flatten_with_fn{};
 
 template <typename Derived>
 template <adaptable_sequence Pattern>
-    requires sequence<element_t<Derived>> &&
+    requires iterable<element_t<Derived>> &&
              multipass_sequence<Pattern> &&
              detail::flatten_with_compatible<element_t<Derived>, Pattern>
 constexpr auto inline_iter_base<Derived>::flatten_with(Pattern&& pattern) &&
@@ -419,7 +420,7 @@ constexpr auto inline_iter_base<Derived>::flatten_with(Pattern&& pattern) &&
 
 template <typename Derived>
 template <typename Value>
-    requires sequence<element_t<Derived>> &&
+    requires iterable<element_t<Derived>> &&
              std::constructible_from<value_t<element_t<Derived>>, Value&&>
 constexpr auto inline_iter_base<Derived>::flatten_with(Value value) &&
 {

--- a/include/flux/adaptor/flatten_with.hpp
+++ b/include/flux/adaptor/flatten_with.hpp
@@ -39,7 +39,7 @@ public:
           pattern_(FLUX_FWD(pattern))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
 
         template <typename Self>
         static consteval auto element_type(Self& self) -> std::common_reference_t<
@@ -84,7 +84,7 @@ public:
           pattern_(FLUX_FWD(pattern))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         using self_t = flatten_with_adaptor;
         using element_type_t =
@@ -210,7 +210,7 @@ public:
           pattern_(FLUX_FWD(pattern))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         using InnerSeq = element_t<Base>;
 

--- a/include/flux/adaptor/flatten_with.hpp
+++ b/include/flux/adaptor/flatten_with.hpp
@@ -46,9 +46,9 @@ public:
     struct flux_sequence_traits : default_sequence_traits {
     private:
         using self_t = flatten_with_adaptor;
-        using element_type =
+        using element_type_t =
             std::common_reference_t<element_t<InnerSeq>, element_t<Pattern>>;
-        using rvalue_element_type =
+        using rvalue_element_type_t =
             std::common_reference_t<rvalue_element_t<InnerSeq>, rvalue_element_t<Pattern>>;
 
         struct cursor_type {
@@ -120,27 +120,27 @@ public:
         }
 
         static constexpr auto read_at(self_t& self, cursor_type const& cur)
-            -> element_type
+            -> element_type_t
         {
             if (cur.inner_cur.index() == 0) {
-                return static_cast<element_type>(
+                return static_cast<element_type_t>(
                     flux::read_at(self.pattern_, std::get<0>(cur.inner_cur)));
             } else {
                 FLUX_ASSERT(self.inner_.has_value());
-                return static_cast<element_type>(
+                return static_cast<element_type_t>(
                     flux::read_at(*self.inner_, std::get<1>(cur.inner_cur)));
             }
         }
 
         static constexpr auto move_at(self_t& self, cursor_type const& cur)
-            -> rvalue_element_type
+            -> rvalue_element_type_t
         {
             if (cur.inner_cur.index() == 0) {
-                return static_cast<rvalue_element_type>(
+                return static_cast<rvalue_element_type_t>(
                     flux::move_at(self.pattern_, std::get<0>(cur.inner_cur)));
             } else {
                 FLUX_ASSERT(self.inner_.has_value());
-                return static_cast<rvalue_element_type>(
+                return static_cast<rvalue_element_type_t>(
                     flux::move_at(*self.inner_, std::get<1>(cur.inner_cur)));
             }
         }

--- a/include/flux/adaptor/flatten_with.hpp
+++ b/include/flux/adaptor/flatten_with.hpp
@@ -41,7 +41,8 @@ public:
 
     struct flux_sequence_traits : default_sequence_traits {
 
-        static consteval auto element_type(auto& self) -> std::common_reference_t<
+        template <typename Self>
+        static consteval auto element_type(Self& self) -> std::common_reference_t<
                 element_t<element_t<decltype((self.base_))>>,
                 element_t<decltype((self.pattern_))>>;
 

--- a/include/flux/adaptor/map.hpp
+++ b/include/flux/adaptor/map.hpp
@@ -39,7 +39,8 @@ public:
         static constexpr bool disable_multipass = !multipass_sequence<Base>;
         static constexpr bool is_infinite = infinite_sequence<Base>;
 
-        static consteval auto element_type(auto& self)
+        template <typename Self>
+        static consteval auto element_type(Self& self)
             -> std::invoke_result_t<Func const&, element_t<decltype((self.base_))>>;
 
         static constexpr auto iterate(auto& self, auto&& pred) -> bool

--- a/include/flux/adaptor/map.hpp
+++ b/include/flux/adaptor/map.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <iterable Base, typename Func>
-struct map_adaptor : inline_sequence_base<map_adaptor<Base, Func>>
+struct map_adaptor : inline_iter_base<map_adaptor<Base, Func>>
 {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
@@ -95,7 +95,7 @@ FLUX_EXPORT inline constexpr auto map = detail::map_fn{};
 template <typename Derived>
 template <typename Func>
     requires std::invocable<Func&, element_t<Derived>>
-constexpr auto inline_sequence_base<Derived>::map(Func func) &&
+constexpr auto inline_iter_base<Derived>::map(Func func) &&
 {
     return detail::map_adaptor<Derived, Func>(std::move(derived()), std::move(func));
 }

--- a/include/flux/adaptor/map.hpp
+++ b/include/flux/adaptor/map.hpp
@@ -19,7 +19,7 @@ private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Func func_;
 
-    friend struct sequence_traits<map_adaptor>;
+    friend struct iter_traits<map_adaptor>;
 
 public:
     constexpr map_adaptor(decays_to<Base> auto&& base, decays_to<Func> auto&& func)

--- a/include/flux/adaptor/map.hpp
+++ b/include/flux/adaptor/map.hpp
@@ -32,7 +32,7 @@ public:
     constexpr auto base() && -> Base&& { return std::move(base_); }
     constexpr auto base() const&& -> Base const&& { return std::move(base_); }
 
-    struct flux_sequence_traits  : detail::passthrough_traits_base
+    struct flux_iter_traits  : detail::passthrough_traits_base
     {
         using value_type = std::remove_cvref_t<std::invoke_result_t<Func&, element_t<Base>>>;
 
@@ -71,8 +71,8 @@ public:
             });
         }
 
-        using default_sequence_traits::move_at;
-        using default_sequence_traits::move_at_unchecked;
+        using default_iter_traits::move_at;
+        using default_iter_traits::move_at_unchecked;
 
         static void data() = delete; // we're not a contiguous sequence
     };

--- a/include/flux/adaptor/mask.hpp
+++ b/include/flux/adaptor/mask.hpp
@@ -25,7 +25,7 @@ public:
           mask_(FLUX_FWD(mask))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/mask.hpp
+++ b/include/flux/adaptor/mask.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <sequence Base, sequence Mask>
-struct mask_adaptor : inline_sequence_base<mask_adaptor<Base, Mask>>
+struct mask_adaptor : inline_iter_base<mask_adaptor<Base, Mask>>
 {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
@@ -158,7 +158,7 @@ FLUX_EXPORT inline constexpr auto mask = detail::mask_fn{};
 template <typename D>
 template <adaptable_sequence Mask>
     requires detail::boolean_testable<element_t<Mask>>
-constexpr auto inline_sequence_base<D>::mask(Mask&& mask_) &&
+constexpr auto inline_iter_base<D>::mask(Mask&& mask_) &&
 {
     return flux::mask(std::move(derived()), FLUX_FWD(mask_));
 }

--- a/include/flux/adaptor/read_only.hpp
+++ b/include/flux/adaptor/read_only.hpp
@@ -29,7 +29,7 @@ public:
         : map(FLUX_FWD(base), cast_to_const<const_element_t<Base>>{})
     {}
 
-    struct flux_sequence_traits : map::flux_sequence_traits {
+    struct flux_iter_traits : map::flux_iter_traits {
     private:
         template <typename B = Base>
         using const_rvalue_element_t = std::common_reference_t<

--- a/include/flux/adaptor/read_only.hpp
+++ b/include/flux/adaptor/read_only.hpp
@@ -19,7 +19,7 @@ struct cast_to_const {
 };
 
 template <sequence Base>
-    requires (not read_only_sequence<Base>)
+    requires (not read_only_iterable<Base>)
 struct read_only_adaptor : map_adaptor<Base, cast_to_const<const_element_t<Base>>> {
 private:
     using map = map_adaptor<Base, cast_to_const<const_element_t<Base>>>;
@@ -61,9 +61,9 @@ public:
 struct read_only_fn {
     template <adaptable_sequence Seq>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq) const -> read_only_sequence auto
+    constexpr auto operator()(Seq&& seq) const -> read_only_iterable auto
     {
-        if constexpr (read_only_sequence<Seq>) {
+        if constexpr (read_only_iterable<Seq>) {
             return FLUX_FWD(seq);
         } else {
             return read_only_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));

--- a/include/flux/adaptor/read_only.hpp
+++ b/include/flux/adaptor/read_only.hpp
@@ -78,7 +78,7 @@ struct read_only_fn {
 FLUX_EXPORT inline constexpr auto read_only = detail::read_only_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::read_only() &&
+constexpr auto inline_iter_base<D>::read_only() &&
 {
     return flux::read_only(std::move(derived()));
 }

--- a/include/flux/adaptor/read_only.hpp
+++ b/include/flux/adaptor/read_only.hpp
@@ -18,7 +18,7 @@ struct cast_to_const {
     constexpr auto operator()(auto&& elem) const -> T { return FLUX_FWD(elem); }
 };
 
-template <sequence Base>
+template <iterable Base>
     requires (not read_only_iterable<Base>)
 struct read_only_adaptor : map_adaptor<Base, cast_to_const<const_element_t<Base>>> {
 private:
@@ -31,22 +31,23 @@ public:
 
     struct flux_sequence_traits : map::flux_sequence_traits {
     private:
+        template <typename B = Base>
         using const_rvalue_element_t = std::common_reference_t<
-            value_t<Base> const&&, rvalue_element_t<Base>>;
+            value_t<B> const&&, rvalue_element_t<B>>;
 
     public:
         using value_type = value_t<Base>;
 
-        static constexpr auto move_at(auto& self, cursor_t<Base> const& cur)
-            -> const_rvalue_element_t
+        static constexpr auto move_at(auto& self, auto const& cur)
+            -> decltype(auto)
         {
-            return static_cast<const_rvalue_element_t>(flux::move_at(self.base(), cur));
+            return static_cast<const_rvalue_element_t<>>(flux::move_at(self.base(), cur));
         }
 
-        static constexpr auto move_at_unchecked(auto& self, cursor_t<Base> const& cur)
-            -> const_rvalue_element_t
+        static constexpr auto move_at_unchecked(auto& self, auto const& cur)
+            -> decltype(auto)
         {
-            return static_cast<const_rvalue_element_t>(flux::move_at_unchecked(self.base(), cur));
+            return static_cast<const_rvalue_element_t<>>(flux::move_at_unchecked(self.base(), cur));
         }
 
         static constexpr auto data(auto& self)
@@ -59,14 +60,14 @@ public:
 };
 
 struct read_only_fn {
-    template <adaptable_sequence Seq>
+    template <sink_iterable It>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq) const -> read_only_iterable auto
+    constexpr auto operator()(It&& it) const -> read_only_iterable auto
     {
-        if constexpr (read_only_iterable<Seq>) {
-            return FLUX_FWD(seq);
+        if constexpr (read_only_iterable<It>) {
+            return FLUX_FWD(it);
         } else {
-            return read_only_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq));
+            return read_only_adaptor<std::decay_t<It>>(FLUX_FWD(it));
         }
     }
 };

--- a/include/flux/adaptor/reverse.hpp
+++ b/include/flux/adaptor/reverse.hpp
@@ -27,7 +27,7 @@ public:
     [[nodiscard]] constexpr auto base() const& -> Base const& { return base_; }
     [[nodiscard]] constexpr auto base() && -> Base&& { return std::move(base_); }
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/reverse.hpp
+++ b/include/flux/adaptor/reverse.hpp
@@ -112,7 +112,7 @@ public:
         }
 
         static constexpr auto size(auto& self) -> distance_t
-            requires sized_sequence<decltype((self.base_))>
+            requires sized_iterable<decltype((self.base_))>
         {
             return flux::size(self.base_);
         }

--- a/include/flux/adaptor/reverse.hpp
+++ b/include/flux/adaptor/reverse.hpp
@@ -14,7 +14,7 @@ namespace detail {
 
 template <bidirectional_sequence Base>
     requires bounded_sequence<Base>
-struct reverse_adaptor : inline_sequence_base<reverse_adaptor<Base>>
+struct reverse_adaptor : inline_iter_base<reverse_adaptor<Base>>
 {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
@@ -167,7 +167,7 @@ struct reverse_fn {
 FLUX_EXPORT inline constexpr auto reverse = detail::reverse_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::reverse() &&
+constexpr auto inline_iter_base<D>::reverse() &&
     requires bidirectional_sequence<D> && bounded_sequence<D>
 {
     return flux::reverse(std::move(derived()));

--- a/include/flux/adaptor/reverse.hpp
+++ b/include/flux/adaptor/reverse.hpp
@@ -48,6 +48,7 @@ public:
         using value_type = value_t<Base>;
 
         static constexpr auto first(auto& self) -> cursor_type
+            requires bounded_sequence<decltype((self.base_))>
         {
             return cursor_type(flux::last(self.base_));
         }
@@ -64,28 +65,32 @@ public:
 
         template <typename Self>
         static constexpr auto read_at(Self& self, cursor_type const& cur)
-            -> element_t<decltype((self.base_))>
+            -> decltype(auto)
+            requires bidirectional_sequence<decltype((self.base_))>
         {
             return flux::read_at(self.base_, flux::prev(self.base_, cur.base_cur));
         }
 
         template <typename Self>
         static constexpr auto read_at_unchecked(Self& self, cursor_type const& cur)
-            -> element_t<decltype((self.base_))>
+            -> decltype(auto)
+            requires bidirectional_sequence<decltype((self.base_))>
         {
             return flux::read_at_unchecked(self.base_, flux::prev(self.base_, cur.base_cur));
         }
 
         template <typename Self>
         static constexpr auto move_at(Self& self, cursor_type const& cur)
-            -> rvalue_element_t<decltype((self.base_))>
+            -> decltype(auto)
+            requires bidirectional_sequence<decltype((self.base_))>
         {
             return flux::move_at(self.base_, flux::prev(self.base_, cur.base_cur));
         }
 
         template <typename Self>
         static constexpr auto move_at_unchecked(Self& self, cursor_type const& cur)
-            -> rvalue_element_t<decltype((self.base_))>
+            -> decltype(auto)
+            requires bidirectional_sequence<decltype((self.base_))>
         {
             return flux::move_at_unchecked(self.base_, flux::prev(self.base_, cur.base_cur));
         }
@@ -112,14 +117,12 @@ public:
         }
 
         static constexpr auto size(auto& self) -> distance_t
-            requires sized_iterable<decltype((self.base_))>
+            requires sized_iterable<Base>
         {
             return flux::size(self.base_);
         }
 
         static constexpr auto for_each_while(auto& self, auto&& pred) -> cursor_type
-            requires bidirectional_sequence<decltype((self.base_))> &&
-                     bounded_sequence<decltype((self.base_))>
         {
             auto cur = flux::last(self.base_);
             const auto end = flux::first(self.base_);

--- a/include/flux/adaptor/reverse.hpp
+++ b/include/flux/adaptor/reverse.hpp
@@ -27,7 +27,7 @@ public:
     [[nodiscard]] constexpr auto base() const& -> Base const& { return base_; }
     [[nodiscard]] constexpr auto base() && -> Base&& { return std::move(base_); }
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/scan.hpp
+++ b/include/flux/adaptor/scan.hpp
@@ -129,7 +129,7 @@ public:
         }
 
         static constexpr auto size(self_t& self) -> distance_t
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             if constexpr (Mode == scan_mode::exclusive) {
                 return num::add(flux::size(self.base_), distance_t{1});

--- a/include/flux/adaptor/scan.hpp
+++ b/include/flux/adaptor/scan.hpp
@@ -15,18 +15,13 @@ namespace flux {
 
 namespace detail {
 
-enum class scan_mode {
-    inclusive,
-    exclusive
-};
+enum class scan_mode { inclusive, exclusive };
 
-template <scan_mode>
-struct scan_cursor_base {};
+template <typename, typename, typename, scan_mode>
+struct scan_iterable_traits;
 
-template <>
-struct scan_cursor_base<scan_mode::exclusive> {
-    bool is_last;
-};
+template <typename, typename, typename, scan_mode>
+struct scan_sequence_traits;
 
 template <typename Base, typename Func, typename R, scan_mode Mode>
 struct scan_adaptor : inline_sequence_base<scan_adaptor<Base, Func, R, Mode>> {
@@ -38,146 +33,186 @@ private:
 public:
     constexpr scan_adaptor(decays_to<Base> auto&& base, Func&& func, auto&& init)
         : base_(FLUX_FWD(base)),
-          func_(std::move(func)),
+          func_(FLUX_FWD(func)),
           accum_(FLUX_FWD(init))
     {}
 
     scan_adaptor(scan_adaptor&&) = default;
     scan_adaptor& operator=(scan_adaptor&&) = default;
 
-    struct flux_sequence_traits : default_sequence_traits {
-    private:
-
-        struct cursor_type : private scan_cursor_base<Mode> {
-            cursor_type(cursor_type&&) = default;
-            cursor_type& operator=(cursor_type&&) = default;
-
-        private:
-            friend struct flux_sequence_traits;
-
-            constexpr explicit cursor_type(cursor_t<Base>&& base_cur)
-                : base_cur(std::move(base_cur))
-            {}
-
-            cursor_t<Base> base_cur;
-        };
-
-        using self_t = scan_adaptor;
-
-        static constexpr auto update(self_t& self, cursor_t<Base> const& cur) -> void
-        {
-            if (!flux::is_last(self.base_, cur)) {
-                self.accum_ = std::invoke(self.func_, std::move(self.accum_),
-                                          flux::read_at(self.base_, cur));
-            }
-        }
-
-    public:
-        static inline constexpr bool is_infinite = infinite_sequence<Base>;
-
-        static constexpr auto first(self_t& self) -> cursor_type
-        {
-            auto cur = flux::first(self.base_);
-            if constexpr (Mode == scan_mode::inclusive) {
-                update(self, cur);
-                return cursor_type(std::move(cur));
-            } else if constexpr (Mode == scan_mode::exclusive) {
-                bool last = flux::is_last(self.base_, cur);
-                cursor_type out = cursor_type(std::move(cur));
-                out.is_last = last;
-                return out;
-            }
-        }
-
-        static constexpr auto is_last(self_t& self, cursor_type const& cur) -> bool
-        {
-            if constexpr (Mode == scan_mode::exclusive) {
-                return cur.is_last;
-            } else {
-                return flux::is_last(self.base_, cur.base_cur);
-            }
-        }
-
-        static constexpr auto inc(self_t& self, cursor_type& cur) -> void
-        {
-            if constexpr (Mode == scan_mode::inclusive) {
-                flux::inc(self.base_, cur.base_cur);
-                update(self, cur.base_cur);
-            } else {
-                update(self, cur.base_cur);
-                if (flux::is_last(self.base_, cur.base_cur)) {
-                    cur.is_last = true;
-                } else {
-                    flux::inc(self.base_, cur.base_cur);
-                }
-            }
-        }
-
-        static constexpr auto read_at(self_t& self, cursor_type const&) -> R const&
-        {
-            return self.accum_;
-        }
-
-        static constexpr auto last(self_t& self) -> cursor_type
-            requires bounded_sequence<Base>
-        {
-            auto cur = cursor_type(flux::last(self.base_));
-            if constexpr (Mode == scan_mode::exclusive) {
-                cur.is_last = true;
-            }
-            return cur;
-        }
-
-        static constexpr auto size(self_t& self) -> distance_t
-            requires sized_iterable<Base>
-        {
-            if constexpr (Mode == scan_mode::exclusive) {
-                return num::add(flux::size(self.base_), distance_t{1});
-            } else {
-                return flux::size(self.base_);
-            }
-        }
-
-        static constexpr auto for_each_while(self_t& self, auto&& pred) -> cursor_type
-            requires (Mode != scan_mode::exclusive)
-        {
-            return cursor_type(flux::for_each_while(self.base_, [&](auto&& elem) {
-                self.accum_ = std::invoke(self.func_, std::move(self.accum_), FLUX_FWD(elem));
-                return std::invoke(pred, std::as_const(self.accum_));
-            }));
-        }
-
-        using default_sequence_traits::for_each_while; // when Mode == exclusive
-    };
+    friend struct scan_iterable_traits<Base, Func, R, Mode>;
+    friend struct scan_sequence_traits<Base, Func, R, Mode>;
 };
 
 struct scan_fn {
-    template <adaptable_sequence Seq, typename Func, std::movable Init = value_t<Seq>,
-              typename R = fold_result_t<Seq, Func, Init>>
-        requires foldable<Seq, Func, Init>
+    template <sink_iterable It, typename Func, std::movable Init = value_t<It>,
+              typename R = fold_result_t<It, Func, Init>>
+        requires foldable<It, Func, Init>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Func func, Init init = Init{}) const
-        -> sequence auto
+    constexpr auto operator()(It&& it, Func func, Init init = Init{}) const -> iterable auto
     {
-        return scan_adaptor<std::decay_t<Seq>, Func, R, scan_mode::inclusive>(
-            FLUX_FWD(seq), std::move(func), std::move(init));
+        return scan_adaptor<std::decay_t<It>, Func, R, scan_mode::inclusive>(
+            FLUX_FWD(it), std::move(func), std::move(init));
     }
 };
 
 struct prescan_fn {
-    template <adaptable_sequence Seq, typename Func, std::movable Init,
-              typename R = fold_result_t<Seq, Func, Init>>
-        requires foldable<Seq, Func, Init>
+    template <sink_iterable It, typename Func, std::movable Init,
+              typename R = fold_result_t<It, Func, Init>>
+        requires foldable<It, Func, Init>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Func func, Init init) const
-        -> sequence auto
+    constexpr auto operator()(It&& it, Func func, Init init) const -> iterable auto
     {
-        return scan_adaptor<std::decay_t<Seq>, Func, R, scan_mode::exclusive>(
-            FLUX_FWD(seq), std::move(func), std::move(init));
+        return scan_adaptor<std::decay_t<It>, Func, R, scan_mode::exclusive>(
+            FLUX_FWD(it), std::move(func), std::move(init));
     }
 };
 
+template <typename Base, typename Func, typename R, scan_mode Mode>
+struct scan_iterable_traits : default_sequence_traits {
+private:
+    using self_t = scan_adaptor<Base, Func, R, Mode>;
+
+public:
+    static consteval auto element_type(self_t&) -> R const&;
+
+    static constexpr auto iterate(self_t& self, auto&& pred) -> bool
+    {
+        if constexpr (Mode == scan_mode::exclusive) {
+            if (!std::invoke(pred, self.accum_)) {
+                return false;
+            }
+        }
+
+        return flux::iterate(self.base_, [&](auto&& elem) {
+            self.accum_ = std::invoke(self.func_, std::move(self.accum_), FLUX_FWD(elem));
+            return std::invoke(pred, std::as_const(self.accum_));
+        });
+    }
+
+    static constexpr auto size(self_t& self) -> distance_t
+        requires sized_iterable<Base>
+    {
+        if constexpr (Mode == scan_mode::exclusive) {
+            return num::add(flux::size(self.base_), distance_t{1});
+        } else {
+            return flux::size(self.base_);
+        }
+    }
+};
+
+template <scan_mode>
+struct scan_cursor_base { };
+
+template <>
+struct scan_cursor_base<scan_mode::exclusive> {
+    bool is_last;
+};
+
+template <typename Base, typename Func, typename R, scan_mode Mode>
+struct scan_sequence_traits : scan_iterable_traits<Base, Func, R, Mode> {
+private:
+    struct cursor_type : private scan_cursor_base<Mode> {
+        cursor_type(cursor_type&&) = default;
+        cursor_type& operator=(cursor_type&&) = default;
+
+    private:
+        friend struct scan_sequence_traits;
+
+        constexpr explicit cursor_type(cursor_t<Base>&& base_cur)
+            : base_cur(std::move(base_cur))
+        {}
+
+        cursor_t<Base> base_cur;
+    };
+
+    using self_t = scan_adaptor<Base, Func, R, Mode>;
+
+    static constexpr auto update(self_t& self, cursor_t<Base> const& cur) -> void
+    {
+        if (!flux::is_last(self.base_, cur)) {
+            self.accum_
+                = std::invoke(self.func_, std::move(self.accum_), flux::read_at(self.base_, cur));
+        }
+    }
+
+public:
+    static inline constexpr bool is_infinite = infinite_sequence<Base>;
+
+    static constexpr auto first(self_t& self) -> cursor_type
+    {
+        auto cur = flux::first(self.base_);
+        if constexpr (Mode == scan_mode::inclusive) {
+            update(self, cur);
+            return cursor_type(std::move(cur));
+        } else if constexpr (Mode == scan_mode::exclusive) {
+            bool last = flux::is_last(self.base_, cur);
+            cursor_type out = cursor_type(std::move(cur));
+            out.is_last = last;
+            return out;
+        }
+    }
+
+    static constexpr auto is_last(self_t& self, cursor_type const& cur) -> bool
+    {
+        if constexpr (Mode == scan_mode::exclusive) {
+            return cur.is_last;
+        } else {
+            return flux::is_last(self.base_, cur.base_cur);
+        }
+    }
+
+    static constexpr auto inc(self_t& self, cursor_type& cur) -> void
+    {
+        if constexpr (Mode == scan_mode::inclusive) {
+            flux::inc(self.base_, cur.base_cur);
+            update(self, cur.base_cur);
+        } else {
+            update(self, cur.base_cur);
+            if (flux::is_last(self.base_, cur.base_cur)) {
+                cur.is_last = true;
+            } else {
+                flux::inc(self.base_, cur.base_cur);
+            }
+        }
+    }
+
+    static constexpr auto read_at(self_t& self, cursor_type const&) -> R const&
+    {
+        return self.accum_;
+    }
+
+    static constexpr auto last(self_t& self) -> cursor_type
+        requires bounded_sequence<Base>
+    {
+        auto cur = cursor_type(flux::last(self.base_));
+        if constexpr (Mode == scan_mode::exclusive) {
+            cur.is_last = true;
+        }
+        return cur;
+    }
+
+    static constexpr auto for_each_while(self_t& self, auto&& pred) -> cursor_type
+        requires(Mode != scan_mode::exclusive)
+    {
+        return cursor_type(flux::for_each_while(self.base_, [&](auto&& elem) {
+            self.accum_ = std::invoke(self.func_, std::move(self.accum_), FLUX_FWD(elem));
+            return std::invoke(pred, std::as_const(self.accum_));
+        }));
+    }
+
+    using default_sequence_traits::for_each_while; // when Mode == exclusive
+};
+
 } // namespace detail
+
+template <iterable Base, typename Func, typename R, detail::scan_mode Mode>
+struct sequence_traits<detail::scan_adaptor<Base, Func, R, Mode>>
+    : detail::scan_iterable_traits<Base, Func, R, Mode> {};
+
+template <sequence Base, typename Func, typename R, detail::scan_mode Mode>
+struct sequence_traits<detail::scan_adaptor<Base, Func, R, Mode>>
+    : detail::scan_sequence_traits<Base, Func, R, Mode> {};
 
 FLUX_EXPORT inline constexpr auto scan = detail::scan_fn{};
 FLUX_EXPORT inline constexpr auto prescan = detail::prescan_fn{};

--- a/include/flux/adaptor/scan.hpp
+++ b/include/flux/adaptor/scan.hpp
@@ -24,7 +24,7 @@ template <typename, typename, typename, scan_mode>
 struct scan_sequence_traits;
 
 template <typename Base, typename Func, typename R, scan_mode Mode>
-struct scan_adaptor : inline_sequence_base<scan_adaptor<Base, Func, R, Mode>> {
+struct scan_adaptor : inline_iter_base<scan_adaptor<Base, Func, R, Mode>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Func func_;
@@ -220,7 +220,7 @@ FLUX_EXPORT inline constexpr auto prescan = detail::prescan_fn{};
 template <typename Derived>
 template <typename D, typename Func, typename Init>
     requires foldable<Derived, Func, Init>
-constexpr auto inline_sequence_base<Derived>::scan(Func func, Init init) &&
+constexpr auto inline_iter_base<Derived>::scan(Func func, Init init) &&
 {
     return flux::scan(std::move(derived()), std::move(func), std::move(init));
 }
@@ -228,7 +228,7 @@ constexpr auto inline_sequence_base<Derived>::scan(Func func, Init init) &&
 template <typename Derived>
 template <typename Func, typename Init>
     requires foldable<Derived, Func, Init>
-constexpr auto inline_sequence_base<Derived>::prescan(Func func, Init init) &&
+constexpr auto inline_iter_base<Derived>::prescan(Func func, Init init) &&
 {
     return flux::prescan(std::move(derived()), std::move(func), std::move(init));
 }

--- a/include/flux/adaptor/scan.hpp
+++ b/include/flux/adaptor/scan.hpp
@@ -207,11 +207,11 @@ public:
 } // namespace detail
 
 template <iterable Base, typename Func, typename R, detail::scan_mode Mode>
-struct sequence_traits<detail::scan_adaptor<Base, Func, R, Mode>>
+struct iter_traits<detail::scan_adaptor<Base, Func, R, Mode>>
     : detail::scan_iterable_traits<Base, Func, R, Mode> {};
 
 template <sequence Base, typename Func, typename R, detail::scan_mode Mode>
-struct sequence_traits<detail::scan_adaptor<Base, Func, R, Mode>>
+struct iter_traits<detail::scan_adaptor<Base, Func, R, Mode>>
     : detail::scan_sequence_traits<Base, Func, R, Mode> {};
 
 FLUX_EXPORT inline constexpr auto scan = detail::scan_fn{};

--- a/include/flux/adaptor/scan.hpp
+++ b/include/flux/adaptor/scan.hpp
@@ -69,7 +69,7 @@ struct prescan_fn {
 };
 
 template <typename Base, typename Func, typename R, scan_mode Mode>
-struct scan_iterable_traits : default_sequence_traits {
+struct scan_iterable_traits : default_iter_traits {
 private:
     using self_t = scan_adaptor<Base, Func, R, Mode>;
 
@@ -201,7 +201,7 @@ public:
         }));
     }
 
-    using default_sequence_traits::for_each_while; // when Mode == exclusive
+    using default_iter_traits::for_each_while; // when Mode == exclusive
 };
 
 } // namespace detail

--- a/include/flux/adaptor/scan_first.hpp
+++ b/include/flux/adaptor/scan_first.hpp
@@ -39,7 +39,7 @@ public:
 };
 
 template <typename Base, typename Func, typename R>
-struct scan_first_iterable_traits : default_sequence_traits {
+struct scan_first_iterable_traits : default_iter_traits {
 private:
     using self_t = scan_first_adaptor<Base, Func, R>;
 

--- a/include/flux/adaptor/scan_first.hpp
+++ b/include/flux/adaptor/scan_first.hpp
@@ -161,11 +161,11 @@ struct scan_first_fn {
 } // namespace detail
 
 template <iterable Base, typename Func, typename R>
-struct sequence_traits<detail::scan_first_adaptor<Base, Func, R>>
+struct iter_traits<detail::scan_first_adaptor<Base, Func, R>>
     : detail::scan_first_iterable_traits<Base, Func, R> {};
 
 template <sequence Base, typename Func, typename R>
-struct sequence_traits<detail::scan_first_adaptor<Base, Func, R>>
+struct iter_traits<detail::scan_first_adaptor<Base, Func, R>>
     : detail::scan_first_sequence_traits<Base, Func, R> {};
 
 FLUX_EXPORT inline constexpr auto scan_first = detail::scan_first_fn{};

--- a/include/flux/adaptor/scan_first.hpp
+++ b/include/flux/adaptor/scan_first.hpp
@@ -22,7 +22,7 @@ template <typename, typename, typename>
 struct scan_first_sequence_traits;
 
 template <typename Base, typename Func, typename R>
-struct scan_first_adaptor : inline_sequence_base<scan_first_adaptor<Base, Func, R>> {
+struct scan_first_adaptor : inline_iter_base<scan_first_adaptor<Base, Func, R>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Func func_;
@@ -173,7 +173,7 @@ FLUX_EXPORT inline constexpr auto scan_first = detail::scan_first_fn{};
 template <typename Derived>
 template <typename Func>
     requires foldable<Derived, Func, element_t<Derived>>
-constexpr auto inline_sequence_base<Derived>::scan_first(Func func) &&
+constexpr auto inline_iter_base<Derived>::scan_first(Func func) &&
 {
     return flux::scan_first(std::move(derived()), std::move(func));
 }

--- a/include/flux/adaptor/scan_first.hpp
+++ b/include/flux/adaptor/scan_first.hpp
@@ -90,7 +90,7 @@ public:
         }
 
         static constexpr auto size(self_t& self) -> distance_t
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             return flux::size(self.base_);
         }

--- a/include/flux/adaptor/scan_first.hpp
+++ b/include/flux/adaptor/scan_first.hpp
@@ -15,6 +15,12 @@ namespace flux {
 
 namespace detail {
 
+template <typename, typename, typename>
+struct scan_first_iterable_traits;
+
+template <typename, typename, typename>
+struct scan_first_sequence_traits;
+
 template <typename Base, typename Func, typename R>
 struct scan_first_adaptor : inline_sequence_base<scan_first_adaptor<Base, Func, R>> {
 private:
@@ -28,103 +34,139 @@ public:
           func_(std::move(func))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
-    private:
-        struct cursor_type {
-            cursor_type(cursor_type&&) = default;
-            cursor_type& operator=(cursor_type&&) = default;
+    friend struct scan_first_iterable_traits<Base, Func, R>;
+    friend struct scan_first_sequence_traits<Base, Func, R>;
+};
 
-        private:
-            friend struct flux_sequence_traits;
+template <typename Base, typename Func, typename R>
+struct scan_first_iterable_traits : default_sequence_traits {
+private:
+    using self_t = scan_first_adaptor<Base, Func, R>;
 
-            constexpr explicit cursor_type(cursor_t<Base>&& base_cur)
-                : base_cur(std::move(base_cur))
-            {}
+public:
+    static consteval auto element_type(self_t&) -> R const&;
 
-            cursor_t<Base> base_cur;
-        };
-
-        using self_t = scan_first_adaptor;
-
-    public:
-        static constexpr auto first(self_t& self) -> cursor_type
-        {
-            auto cur = flux::first(self.base_);
-            if (!flux::is_last(self.base_, cur)) {
-                self.accum_.emplace(flux::read_at(self.base_, cur));
+    static constexpr auto iterate(self_t& self, auto&& pred) -> bool
+    {
+        return flux::iterate(self.base_, [&](auto&& elem) {
+            if (self.accum_.has_value()) {
+                self.accum_.emplace(
+                std::invoke(self.func_,
+                    std::move(self.accum_.value_unchecked()),
+                    FLUX_FWD(elem)));
+            } else {
+                self.accum_.emplace(FLUX_FWD(elem));
             }
-            return cursor_type(std::move(cur));
-        }
+            return std::invoke(pred, self.accum_.value_unchecked());
+        });
+    }
 
-        static constexpr auto is_last(self_t& self, cursor_type const& cur) -> bool
-        {
-            return flux::is_last(self.base_, cur.base_cur);
-        }
+    static constexpr auto size(self_t& self) -> distance_t
+        requires sized_iterable<Base>
+    {
+        return flux::size(self.base_);
+    }
+};
 
-        static constexpr auto inc(self_t& self, cursor_type& cur) -> void
-        {
-            flux::inc(self.base_, cur.base_cur);
-            if (!flux::is_last(self.base_, cur.base_cur)) {
+template <typename Base, typename Func, typename R>
+struct scan_first_sequence_traits : scan_first_iterable_traits<Base, Func, R> {
+private:
+    struct cursor_type {
+        cursor_type(cursor_type&&) = default;
+        cursor_type& operator=(cursor_type&&) = default;
+
+    private:
+        friend struct scan_first_sequence_traits;
+
+        constexpr explicit cursor_type(cursor_t<Base>&& base_cur)
+            : base_cur(std::move(base_cur))
+        {}
+
+        cursor_t<Base> base_cur;
+    };
+
+    using self_t = scan_first_adaptor<Base, Func, R>;
+
+public:
+    static constexpr auto first(self_t& self) -> cursor_type
+    {
+        auto cur = flux::first(self.base_);
+        if (!flux::is_last(self.base_, cur)) {
+            self.accum_.emplace(flux::read_at(self.base_, cur));
+        }
+        return cursor_type(std::move(cur));
+    }
+
+    static constexpr auto is_last(self_t& self, cursor_type const& cur) -> bool
+    {
+        return flux::is_last(self.base_, cur.base_cur);
+    }
+
+    static constexpr auto inc(self_t& self, cursor_type& cur) -> void
+    {
+        flux::inc(self.base_, cur.base_cur);
+        if (!flux::is_last(self.base_, cur.base_cur)) {
+            self.accum_.emplace(
+                std::invoke(self.func_,
+                            std::move(self.accum_.value_unchecked()),
+                            flux::read_at(self.base_, cur.base_cur)));
+        }
+    }
+
+    static constexpr auto read_at(self_t& self, cursor_type const&) -> R const&
+    {
+        return self.accum_.value();
+    }
+
+    static constexpr auto read_at_unchecked(self_t& self, cursor_type const&)
+        -> R const&
+    {
+        return self.accum_.value_unchecked();
+    }
+
+    static constexpr auto last(self_t& self) -> cursor_type
+        requires bounded_sequence<Base>
+    {
+        return cursor_type(flux::last(self.base_));
+    }
+
+    static constexpr auto for_each_while(self_t& self, auto&& pred) -> cursor_type
+    {
+        return cursor_type(flux::for_each_while(self.base_, [&](auto&& elem) {
+            if (self.accum_.has_value()) {
                 self.accum_.emplace(
                     std::invoke(self.func_,
                                 std::move(self.accum_.value_unchecked()),
-                                flux::read_at(self.base_, cur.base_cur)));
+                                FLUX_FWD(elem)));
+            } else {
+                self.accum_.emplace(FLUX_FWD(elem));
             }
-        }
-
-        static constexpr auto read_at(self_t& self, cursor_type const&) -> R const&
-        {
-            return self.accum_.value();
-        }
-
-        static constexpr auto read_at_unchecked(self_t& self, cursor_type const&)
-            -> R const&
-        {
-            return self.accum_.value_unchecked();
-        }
-
-        static constexpr auto last(self_t& self) -> cursor_type
-            requires bounded_sequence<Base>
-        {
-            return cursor_type(flux::last(self.base_));
-        }
-
-        static constexpr auto size(self_t& self) -> distance_t
-            requires sized_iterable<Base>
-        {
-            return flux::size(self.base_);
-        }
-
-        static constexpr auto for_each_while(self_t& self, auto&& pred) -> cursor_type
-        {
-            return cursor_type(flux::for_each_while(self.base_, [&](auto&& elem) {
-                if (self.accum_.has_value()) {
-                    self.accum_.emplace(
-                        std::invoke(self.func_,
-                                    std::move(self.accum_.value_unchecked()),
-                                    FLUX_FWD(elem)));
-                } else {
-                    self.accum_.emplace(FLUX_FWD(elem));
-                }
-                return std::invoke(pred, self.accum_.value_unchecked());
-            }));
-        }
-    };
+            return std::invoke(pred, self.accum_.value_unchecked());
+        }));
+    }
 };
 
 struct scan_first_fn {
-    template <adaptable_sequence Seq, typename Func>
-        requires foldable<Seq, Func, element_t<Seq>>
+    template <sink_iterable It, typename Func>
+        requires foldable<It, Func, element_t<It>>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Func func) const -> sequence auto
+    constexpr auto operator()(It&& it, Func func) const -> iterable auto
     {
-        using R = fold_result_t<Seq, Func, element_t<Seq>>;
-        return scan_first_adaptor<std::decay_t<Seq>, Func, R>(
-            FLUX_FWD(seq), std::move(func));
+        using R = fold_result_t<It, Func, element_t<It>>;
+        return scan_first_adaptor<std::decay_t<It>, Func, R>(
+            FLUX_FWD(it), std::move(func));
     }
 };
 
 } // namespace detail
+
+template <iterable Base, typename Func, typename R>
+struct sequence_traits<detail::scan_first_adaptor<Base, Func, R>>
+    : detail::scan_first_iterable_traits<Base, Func, R> {};
+
+template <sequence Base, typename Func, typename R>
+struct sequence_traits<detail::scan_first_adaptor<Base, Func, R>>
+    : detail::scan_first_sequence_traits<Base, Func, R> {};
 
 FLUX_EXPORT inline constexpr auto scan_first = detail::scan_first_fn{};
 

--- a/include/flux/adaptor/set_adaptors.hpp
+++ b/include/flux/adaptor/set_adaptors.hpp
@@ -14,7 +14,7 @@ namespace flux::detail {
 
 template <sequence Base1, sequence Base2, typename Cmp>
 struct set_union_adaptor
-    : flux::inline_sequence_base<set_union_adaptor<Base1, Base2, Cmp>>
+    : flux::inline_iter_base<set_union_adaptor<Base1, Base2, Cmp>>
 {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base1 base1_;
@@ -147,7 +147,7 @@ public:
 
 template <sequence Base1, sequence Base2, typename Cmp>
 struct set_difference_adaptor
-    : flux::inline_sequence_base<set_difference_adaptor<Base1, Base2, Cmp>>
+    : flux::inline_iter_base<set_difference_adaptor<Base1, Base2, Cmp>>
 {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base1 base1_;
@@ -250,7 +250,7 @@ public:
 
 template <sequence Base1, sequence Base2, typename Cmp>
 struct set_symmetric_difference_adaptor
-    : flux::inline_sequence_base<set_symmetric_difference_adaptor<Base1, Base2, Cmp>>
+    : flux::inline_iter_base<set_symmetric_difference_adaptor<Base1, Base2, Cmp>>
 {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base1 base1_;
@@ -395,7 +395,7 @@ public:
 
 template <sequence Base1, sequence Base2, typename Cmp>
 struct set_intersection_adaptor
-    : flux::inline_sequence_base<set_intersection_adaptor<Base1, Base2, Cmp>>
+    : flux::inline_iter_base<set_intersection_adaptor<Base1, Base2, Cmp>>
 {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base1 base1_;

--- a/include/flux/adaptor/set_adaptors.hpp
+++ b/include/flux/adaptor/set_adaptors.hpp
@@ -28,7 +28,7 @@ public:
           cmp_(cmp)
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
 
         struct cursor_type {
@@ -161,7 +161,7 @@ public:
           cmp_(cmp)
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
 
         struct cursor_type {
@@ -264,7 +264,7 @@ public:
           cmp_(cmp)
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
 
         struct cursor_type {
@@ -409,7 +409,7 @@ public:
           cmp_(cmp)
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
 
         struct cursor_type {

--- a/include/flux/adaptor/slide.hpp
+++ b/include/flux/adaptor/slide.hpp
@@ -25,7 +25,7 @@ public:
           win_sz_(win_sz)
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> from;

--- a/include/flux/adaptor/slide.hpp
+++ b/include/flux/adaptor/slide.hpp
@@ -102,7 +102,7 @@ public:
         }
 
         static constexpr auto size(auto& self) -> distance_t
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             auto s = num::add(num::sub(flux::size(self.base_), self.win_sz_), distance_t{1});
             return (cmp::max)(s, distance_t{0});

--- a/include/flux/adaptor/slide.hpp
+++ b/include/flux/adaptor/slide.hpp
@@ -14,7 +14,7 @@ namespace flux {
 namespace detail {
 
 template <multipass_sequence Base>
-struct slide_adaptor : inline_sequence_base<slide_adaptor<Base>> {
+struct slide_adaptor : inline_iter_base<slide_adaptor<Base>> {
 private:
     Base base_;
     distance_t win_sz_;
@@ -127,7 +127,7 @@ struct slide_fn {
 FLUX_EXPORT inline constexpr auto slide = detail::slide_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::slide(num::integral auto win_sz) &&
+constexpr auto inline_iter_base<D>::slide(num::integral auto win_sz) &&
         requires multipass_sequence<D>
 {
     FLUX_ASSERT(win_sz > 0);

--- a/include/flux/adaptor/split.hpp
+++ b/include/flux/adaptor/split.hpp
@@ -21,7 +21,7 @@ concept splitter_for = requires(Splitter& splitter, Seq& seq, cursor_t<Seq> cons
 };
 
 template <multipass_sequence Base, splitter_for<Base> Splitter>
-struct split_adaptor : inline_sequence_base<split_adaptor<Base, Splitter>> {
+struct split_adaptor : inline_iter_base<split_adaptor<Base, Splitter>> {
 private:
     FLUX_NO_UNIQUE_ADDRESS Base base_;
     FLUX_NO_UNIQUE_ADDRESS Splitter splitter_;
@@ -210,7 +210,7 @@ template <typename Pattern>
     requires multipass_sequence<Derived> &&
              multipass_sequence<Pattern> &&
              std::equality_comparable_with<element_t<Derived>, element_t<Pattern>>
-constexpr auto inline_sequence_base<Derived>::split(Pattern&& pattern) &&
+constexpr auto inline_iter_base<Derived>::split(Pattern&& pattern) &&
 {
     return flux::split(std::move(derived()), FLUX_FWD(pattern));
 }
@@ -219,7 +219,7 @@ template <typename Derived>
 template <typename Delim>
     requires multipass_sequence<Derived> &&
              std::equality_comparable_with<element_t<Derived>, Delim const&>
-constexpr auto inline_sequence_base<Derived>::split(Delim&& delim) &&
+constexpr auto inline_iter_base<Derived>::split(Delim&& delim) &&
 {
     return flux::split(std::move(derived()), FLUX_FWD(delim));
 }
@@ -228,7 +228,7 @@ template <typename Derived>
 template <typename Pred>
     requires multipass_sequence<Derived> &&
              std::predicate<Pred const&, element_t<Derived>>
-constexpr auto inline_sequence_base<Derived>::split(Pred pred) &&
+constexpr auto inline_iter_base<Derived>::split(Pred pred) &&
 {
     return flux::split(std::move(derived()), std::move(pred));
 }

--- a/include/flux/adaptor/split.hpp
+++ b/include/flux/adaptor/split.hpp
@@ -32,7 +32,7 @@ public:
           splitter_(FLUX_FWD(splitter))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> cur{};

--- a/include/flux/adaptor/split_string.hpp
+++ b/include/flux/adaptor/split_string.hpp
@@ -6,7 +6,6 @@
 #ifndef FLUX_ADAPTOR_STRING_SPLIT_HPP_INCLUDED
 #define FLUX_ADAPTOR_STRING_SPLIT_HPP_INCLUDED
 
-#include "flux/core/concepts.hpp"
 #include <flux/adaptor/split.hpp>
 #include <flux/core/utils.hpp>
 

--- a/include/flux/adaptor/split_string.hpp
+++ b/include/flux/adaptor/split_string.hpp
@@ -6,6 +6,7 @@
 #ifndef FLUX_ADAPTOR_STRING_SPLIT_HPP_INCLUDED
 #define FLUX_ADAPTOR_STRING_SPLIT_HPP_INCLUDED
 
+#include "flux/core/concepts.hpp"
 #include <flux/adaptor/split.hpp>
 #include <flux/core/utils.hpp>
 
@@ -62,6 +63,7 @@ FLUX_EXPORT inline constexpr auto split_string = detail::split_string_fn{};
 
 template <typename D>
 constexpr auto inline_iter_base<D>::split_string(auto&& pattern) &&
+    requires multipass_sequence<D>
 {
     return flux::split_string(std::move(derived()), FLUX_FWD(pattern));
 }

--- a/include/flux/adaptor/split_string.hpp
+++ b/include/flux/adaptor/split_string.hpp
@@ -20,7 +20,7 @@ concept character = any_of<C, char, wchar_t, char8_t, char16_t, char32_t>;
 
 struct to_string_view_fn {
     template <contiguous_sequence Seq>
-        requires sized_sequence<Seq> && character<value_t<Seq>>
+        requires sized_iterable<Seq> && character<value_t<Seq>>
     constexpr auto operator()(Seq&& seq) const
     {
         return std::basic_string_view<value_t<Seq>>(flux::data(seq), flux::usize(seq));

--- a/include/flux/adaptor/split_string.hpp
+++ b/include/flux/adaptor/split_string.hpp
@@ -61,7 +61,7 @@ struct split_string_fn {
 FLUX_EXPORT inline constexpr auto split_string = detail::split_string_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::split_string(auto&& pattern) &&
+constexpr auto inline_iter_base<D>::split_string(auto&& pattern) &&
 {
     return flux::split_string(std::move(derived()), FLUX_FWD(pattern));
 }

--- a/include/flux/adaptor/stride.hpp
+++ b/include/flux/adaptor/stride.hpp
@@ -90,7 +90,7 @@ public:
         static void dec(...) = delete;
 
         static constexpr auto size(auto& self) -> distance_t
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             auto s = flux::size(self.base_);
             return s/self.stride_ + (s % self.stride_ == 0 ? 0 : 1);
@@ -191,7 +191,7 @@ public:
         }
 
         static constexpr auto last(auto& self) -> cursor_type
-            requires bounded_sequence<Base> && sized_sequence<Base>
+            requires bounded_sequence<Base> && sized_iterable<Base>
         {
             distance_t missing =
                 (self.stride_ - flux::size(self.base_) % self.stride_) % self.stride_;
@@ -209,7 +209,7 @@ public:
         }
 
         static constexpr auto size(auto& self) -> distance_t
-            requires sized_sequence<Base>
+            requires sized_iterable<Base>
         {
             auto s = flux::size(self.base_);
             return s/self.stride_ + (s % self.stride_ == 0 ? 0 : 1);

--- a/include/flux/adaptor/stride.hpp
+++ b/include/flux/adaptor/stride.hpp
@@ -81,6 +81,8 @@ public:
         using value_type = value_t<Base>;
         static inline constexpr bool is_infinite = infinite_sequence<Base>;
 
+        using default_sequence_traits::iterate;
+
         static constexpr auto inc(auto& self, cursor_t<Base>& cur) -> void
         {
             advance(self.base(), cur, self.stride_);

--- a/include/flux/adaptor/stride.hpp
+++ b/include/flux/adaptor/stride.hpp
@@ -19,7 +19,7 @@ inline constexpr struct advance_fn {
     {
         if (offset > 0) {
             distance_t counter = 0;
-            while (offset-- > 0 && !flux::is_last(seq, cur))  {
+            while (offset-- > 0 && !flux::is_last(seq, cur)) {
                 flux::inc(seq, cur);
                 ++counter;
             }
@@ -35,7 +35,8 @@ inline constexpr struct advance_fn {
                 }
                 return offset;
             } else {
-                runtime_error("advance() called with negative offset and non-bidirectional sequence");
+                runtime_error(
+                    "advance() called with negative offset and non-bidirectional sequence");
             }
         } else {
             return 0;
@@ -51,8 +52,8 @@ inline constexpr struct advance_fn {
             flux::inc(seq, cur, dist);
             return num::sub(offset, dist);
         } else if (offset < 0) {
-            auto dist = num::neg((cmp::min)(flux::distance(seq, flux::first(seq), cur),
-                                            num::neg(offset)));
+            auto dist = num::neg(
+                (cmp::min)(flux::distance(seq, flux::first(seq), cur), num::neg(offset)));
             flux::inc(seq, cur, dist);
             return num::sub(offset, dist);
         } else {
@@ -76,195 +77,204 @@ public:
     constexpr auto base() & -> Base& { return base_; }
     constexpr auto base() const& -> Base const& { return base_; }
 
-    struct flux_sequence_traits : passthrough_traits_base {
-
-        using value_type = value_t<Base>;
-        static inline constexpr bool is_infinite = infinite_sequence<Base>;
-
-        using default_sequence_traits::iterate;
-
-        static constexpr auto inc(auto& self, cursor_t<Base>& cur) -> void
-        {
-            advance(self.base(), cur, self.stride_);
-        }
-
-        // This version of stride is never bidir
-        static void dec(...) = delete;
-
-        static constexpr auto size(auto& self) -> distance_t
-            requires sized_iterable<Base>
-        {
-            auto s = flux::size(self.base_);
-            return s/self.stride_ + (s % self.stride_ == 0 ? 0 : 1);
-        }
-
-        static constexpr auto for_each_while(auto& self, auto&& pred) -> cursor_t<Base>
-            requires sequence<decltype((self.base_))>
-        {
-            distance_t n = self.stride_;
-            return flux::for_each_while(self.base_, [&n, &pred, s = self.stride_](auto&& elem) {
-                if (++n < s) {
-                    return true;
-                } else {
-                    n = 0;
-                    return std::invoke(pred, FLUX_FWD(elem));
-                }
-            });
-        }
-
-    };
+    constexpr auto stride() const -> distance_t { return stride_; }
 };
 
-template <bidirectional_sequence Base>
-struct stride_adaptor<Base> : inline_sequence_base<stride_adaptor<Base>> {
+template <typename Base>
+struct stride_iterable_traits {
+    using value_type = value_t<Base>;
+
+    static consteval auto element_type(auto& self) -> element_t<decltype(self.base())>;
+
+    static constexpr auto iterate(auto& self, auto&& pred) -> bool
+    {
+        distance_t n = self.stride();
+        distance_t s = num::sub(n, distance_t{1});
+        return flux::iterate(self.base(), [&n, &pred, s](auto&& elem) {
+            if (n < s) {
+                n = num::add(n, distance_t{1});
+                return true;
+            } else {
+                n = 0;
+                return std::invoke(pred, FLUX_FWD(elem));
+            }
+        });
+    }
+
+    static constexpr auto size(auto& self) -> distance_t
+        requires sized_iterable<Base>
+    {
+        auto s = flux::size(self.base());
+        return num::add(num::div(s, self.stride()),
+            (num::mod(s, self.stride()) == 0 ? distance_t{0} : distance_t{1}));
+    }
+};
+
+template <typename Base>
+struct stride_sequence_traits : stride_iterable_traits<Base>, passthrough_traits_base {
+    using stride_iterable_traits<Base>::element_type;
+    using stride_iterable_traits<Base>::iterate;
+    using stride_iterable_traits<Base>::size;
+
+    static constexpr auto inc(auto& self, cursor_t<Base>& cur) -> void
+    {
+        advance(self.base(), cur, self.stride());
+    }
+
+    // This version of stride is never bidir
+    static void dec(...) = delete;
+
+    static constexpr auto for_each_while(auto& self, auto&& pred) -> cursor_t<Base>
+        requires sequence<decltype(self.base())>
+    {
+        distance_t n = self.stride();
+        return flux::for_each_while(self.base(), [&n, &pred, s = self.stride()](auto&& elem) {
+            if (++n < s) {
+                return true;
+            } else {
+                n = 0;
+                return std::invoke(pred, FLUX_FWD(elem));
+            }
+        });
+    }
+};
+
+template <typename Base>
+struct stride_bidir_traits : stride_iterable_traits<Base> {
 private:
-    Base base_;
-    distance_t stride_;
+    struct cursor_type {
+        cursor_t<Base> cur{};
+        distance_t missing = 0;
 
-public:
-    constexpr stride_adaptor(decays_to<Base> auto&& base, distance_t stride)
-        : base_(FLUX_FWD(base)),
-          stride_(stride)
-    {}
-
-    struct flux_sequence_traits : default_sequence_traits {
-    private:
-        struct cursor_type {
-            cursor_t<Base> cur{};
-            distance_t missing = 0;
-
-            friend constexpr auto operator==(cursor_type const& lhs, cursor_type const& rhs) -> bool
-            {
-                return lhs.cur == rhs.cur;
-            }
-
-            friend constexpr auto operator<=>(cursor_type const& lhs, cursor_type const& rhs)
-                -> std::strong_ordering
-                requires ordered_cursor<cursor_t<Base>>
-            {
-                return lhs.cur <=> rhs.cur;
-            }
-        };
-
-    public:
-        using value_type = value_t<Base>;
-        static constexpr bool is_infinite = infinite_sequence<Base>;
-
-        static constexpr auto first(auto& self) -> cursor_type
+        friend constexpr auto operator==(cursor_type const& lhs, cursor_type const& rhs) -> bool
         {
-            return cursor_type {
-                .cur = flux::first(self.base_),
-                .missing = 0
-            };
+            return lhs.cur == rhs.cur;
         }
 
-        static constexpr auto is_last(auto& self, cursor_type const& cur) -> bool
+        friend constexpr auto operator<=>(cursor_type const& lhs, cursor_type const& rhs)
+            -> std::strong_ordering
+            requires ordered_cursor<cursor_t<Base>>
         {
-            return flux::is_last(self.base_, cur.cur);
-        }
-
-        static constexpr auto inc(auto& self, cursor_type& cur) -> void
-        {
-            cur.missing = advance(self.base_, cur.cur, self.stride_);
-        }
-
-        static constexpr auto read_at(auto& self, cursor_type const& cur)
-            -> decltype(flux::read_at(self.base_, cur.cur))
-        {
-            return flux::read_at(self.base_, cur.cur);
-        }
-
-        static constexpr auto move_at(auto& self, cursor_type const& cur)
-            -> decltype(flux::move_at(self.base_, cur.cur))
-        {
-            return flux::move_at(self.base_, cur.cur);
-        }
-
-        static constexpr auto read_at_unchecked(auto& self, cursor_type const& cur)
-            -> decltype(flux::read_at_unchecked(self.base_, cur.cur))
-        {
-            return flux::read_at_unchecked(self.base_, cur.cur);
-        }
-
-        static constexpr auto move_at_unchecked(auto& self, cursor_type const& cur)
-            -> decltype(flux::move_at_unchecked(self.base_, cur.cur))
-        {
-            return flux::move_at_unchecked(self.base_, cur.cur);
-        }
-
-        static constexpr auto last(auto& self) -> cursor_type
-            requires bounded_sequence<Base> && sized_iterable<Base>
-        {
-            distance_t missing =
-                (self.stride_ - flux::size(self.base_) % self.stride_) % self.stride_;
-            return cursor_type{
-                .cur = flux::last(self.base_),
-                .missing = missing
-            };
-        }
-
-        static constexpr auto dec(auto& self, cursor_type& cur) -> void
-            requires bidirectional_sequence<Base>
-        {
-            advance(self.base_, cur.cur, cur.missing - self.stride_);
-            cur.missing = 0;
-        }
-
-        static constexpr auto size(auto& self) -> distance_t
-            requires sized_iterable<Base>
-        {
-            auto s = flux::size(self.base_);
-            return s/self.stride_ + (s % self.stride_ == 0 ? 0 : 1);
-        }
-
-        static constexpr auto distance(auto& self, cursor_type const& from,
-                                       cursor_type const& to) -> distance_t
-            requires random_access_sequence<Base>
-        {
-            return (flux::distance(self.base_, from.cur, to.cur) - from.missing + to.missing)/self.stride_;
-        }
-
-        static constexpr auto inc(auto& self, cursor_type& cur, distance_t offset) -> void
-            requires random_access_sequence<Base>
-        {
-            if (offset > 0) {
-                cur.missing = num::mod(advance(self.base_, cur.cur, num::mul(offset, self.stride_)),
-                                       self.stride_);
-            } else if (offset < 0) {
-                advance(self.base_, cur.cur, num::add(num::mul(offset, self.stride_), cur.missing));
-                cur.missing = 0;
-            }
-        }
-
-        static constexpr auto for_each_while(auto& self, auto&& pred) -> cursor_type
-            requires sequence<decltype((self.base_))>
-        {
-            distance_t n = self.stride_;
-            auto c = flux::for_each_while(self.base_, [&n, &pred, s = self.stride_](auto&& elem) {
-                if (++n < s) {
-                    return true;
-                } else {
-                    n = 0;
-                    return std::invoke(pred, FLUX_FWD(elem));
-                }
-            });
-            return cursor_type{std::move(c), (n + 1) % self.stride_};
+            return lhs.cur <=> rhs.cur;
         }
     };
+
+public:
+    using value_type = value_t<Base>;
+    static constexpr bool is_infinite = infinite_sequence<Base>;
+
+    static constexpr auto first(auto& self) -> cursor_type
+    {
+        return cursor_type{.cur = flux::first(self.base()), .missing = 0};
+    }
+
+    static constexpr auto is_last(auto& self, cursor_type const& cur) -> bool
+    {
+        return flux::is_last(self.base(), cur.cur);
+    }
+
+    static constexpr auto inc(auto& self, cursor_type& cur) -> void
+    {
+        cur.missing = advance(self.base(), cur.cur, self.stride());
+    }
+
+    static constexpr auto read_at(auto& self, cursor_type const& cur)
+        -> decltype(flux::read_at(self.base(), cur.cur))
+    {
+        return flux::read_at(self.base(), cur.cur);
+    }
+
+    static constexpr auto move_at(auto& self, cursor_type const& cur)
+        -> decltype(flux::move_at(self.base(), cur.cur))
+    {
+        return flux::move_at(self.base(), cur.cur);
+    }
+
+    static constexpr auto read_at_unchecked(auto& self, cursor_type const& cur)
+        -> decltype(flux::read_at_unchecked(self.base(), cur.cur))
+    {
+        return flux::read_at_unchecked(self.base(), cur.cur);
+    }
+
+    static constexpr auto move_at_unchecked(auto& self, cursor_type const& cur)
+        -> decltype(flux::move_at_unchecked(self.base(), cur.cur))
+    {
+        return flux::move_at_unchecked(self.base(), cur.cur);
+    }
+
+    static constexpr auto last(auto& self) -> cursor_type
+        requires bounded_sequence<Base> && sized_iterable<Base>
+    {
+        distance_t missing = (self.stride() - flux::size(self.base()) % self.stride()) % self.stride();
+        return cursor_type{.cur = flux::last(self.base()), .missing = missing};
+    }
+
+    static constexpr auto dec(auto& self, cursor_type& cur) -> void
+        requires bidirectional_sequence<Base>
+    {
+        advance(self.base(), cur.cur, cur.missing - self.stride());
+        cur.missing = 0;
+    }
+
+    static constexpr auto distance(auto& self, cursor_type const& from, cursor_type const& to)
+        -> distance_t
+        requires random_access_sequence<Base>
+    {
+        return (flux::distance(self.base(), from.cur, to.cur) - from.missing + to.missing)
+            / self.stride();
+    }
+
+    static constexpr auto inc(auto& self, cursor_type& cur, distance_t offset) -> void
+        requires random_access_sequence<Base>
+    {
+        if (offset > 0) {
+            cur.missing = num::mod(advance(self.base(), cur.cur, num::mul(offset, self.stride())),
+                                   self.stride());
+        } else if (offset < 0) {
+            advance(self.base(), cur.cur, num::add(num::mul(offset, self.stride()), cur.missing));
+            cur.missing = 0;
+        }
+    }
+
+    static constexpr auto for_each_while(auto& self, auto&& pred) -> cursor_type
+        requires sequence<decltype(self.base())>
+    {
+        distance_t n = self.stride();
+        auto c = flux::for_each_while(self.base(), [&n, &pred, s = self.stride()](auto&& elem) {
+            if (++n < s) {
+                return true;
+            } else {
+                n = 0;
+                return std::invoke(pred, FLUX_FWD(elem));
+            }
+        });
+        return cursor_type{std::move(c), (n + 1) % self.stride()};
+    }
 };
 
 struct stride_fn {
-    template <adaptable_sequence Seq>
+    template <sink_iterable It>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, num::integral auto by) const
+    constexpr auto operator()(It&& it, num::integral auto by) const
     {
         FLUX_ASSERT(by > 0);
-        return stride_adaptor<std::decay_t<Seq>>(FLUX_FWD(seq),
-                                                 num::checked_cast<distance_t>(by));
+        return stride_adaptor<std::decay_t<It>>(FLUX_FWD(it), num::checked_cast<distance_t>(by));
     }
 };
 
 } // namespace detail
+
+template <typename Base>
+struct sequence_traits<detail::stride_adaptor<Base>>
+    : detail::stride_iterable_traits<Base> {};
+
+template <sequence Base>
+struct sequence_traits<detail::stride_adaptor<Base>>
+    : detail::stride_sequence_traits<Base> {};
+
+template <bidirectional_sequence Base>
+struct sequence_traits<detail::stride_adaptor<Base>>
+    : detail::stride_bidir_traits<Base> {};
 
 FLUX_EXPORT inline constexpr auto stride = detail::stride_fn{};
 

--- a/include/flux/adaptor/stride.hpp
+++ b/include/flux/adaptor/stride.hpp
@@ -84,7 +84,8 @@ template <typename Base>
 struct stride_iterable_traits {
     using value_type = value_t<Base>;
 
-    static consteval auto element_type(auto& self) -> element_t<decltype(self.base())>;
+    template <typename Self>
+    static consteval auto element_type(Self& self) -> element_t<decltype(self.base())>;
 
     static constexpr auto iterate(auto& self, auto&& pred) -> bool
     {

--- a/include/flux/adaptor/stride.hpp
+++ b/include/flux/adaptor/stride.hpp
@@ -63,7 +63,7 @@ inline constexpr struct advance_fn {
 } advance;
 
 template <typename Base>
-struct stride_adaptor : inline_sequence_base<stride_adaptor<Base>> {
+struct stride_adaptor : inline_iter_base<stride_adaptor<Base>> {
 private:
     Base base_;
     distance_t stride_;
@@ -280,7 +280,7 @@ struct iter_traits<detail::stride_adaptor<Base>>
 FLUX_EXPORT inline constexpr auto stride = detail::stride_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::stride(num::integral auto by) &&
+constexpr auto inline_iter_base<D>::stride(num::integral auto by) &&
 {
     return flux::stride(std::move(derived()), by);
 }

--- a/include/flux/adaptor/stride.hpp
+++ b/include/flux/adaptor/stride.hpp
@@ -266,15 +266,15 @@ struct stride_fn {
 } // namespace detail
 
 template <typename Base>
-struct sequence_traits<detail::stride_adaptor<Base>>
+struct iter_traits<detail::stride_adaptor<Base>>
     : detail::stride_iterable_traits<Base> {};
 
 template <sequence Base>
-struct sequence_traits<detail::stride_adaptor<Base>>
+struct iter_traits<detail::stride_adaptor<Base>>
     : detail::stride_sequence_traits<Base> {};
 
 template <bidirectional_sequence Base>
-struct sequence_traits<detail::stride_adaptor<Base>>
+struct iter_traits<detail::stride_adaptor<Base>>
     : detail::stride_bidir_traits<Base> {};
 
 FLUX_EXPORT inline constexpr auto stride = detail::stride_fn{};

--- a/include/flux/adaptor/take.hpp
+++ b/include/flux/adaptor/take.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <iterable Base>
-struct take_adaptor : inline_sequence_base<take_adaptor<Base>>
+struct take_adaptor : inline_iter_base<take_adaptor<Base>>
 {
 private:
     Base base_;
@@ -186,7 +186,7 @@ struct take_fn {
 FLUX_EXPORT inline constexpr auto take = detail::take_fn{};
 
 template <typename Derived>
-constexpr auto inline_sequence_base<Derived>::take(num::integral auto count) &&
+constexpr auto inline_iter_base<Derived>::take(num::integral auto count) &&
 {
     return flux::take(std::move(derived()), count);
 }

--- a/include/flux/adaptor/take.hpp
+++ b/include/flux/adaptor/take.hpp
@@ -28,7 +28,7 @@ public:
     [[nodiscard]] constexpr auto base() const& -> Base const& { return base_; }
     [[nodiscard]] constexpr auto base() && -> Base&& { return std::move(base_); }
 
-    struct flux_sequence_traits {
+    struct flux_sequence_traits : default_sequence_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/take.hpp
+++ b/include/flux/adaptor/take.hpp
@@ -112,7 +112,7 @@ public:
         }
 
         static constexpr auto size(auto& self)
-            requires sized_sequence<Base> || infinite_sequence<Base>
+            requires sized_iterable<Base> || infinite_sequence<Base>
         {
             if constexpr (infinite_sequence<Base>) {
                 return self.count_;
@@ -122,7 +122,7 @@ public:
         }
 
         static constexpr auto last(auto& self) -> cursor_type
-            requires (random_access_sequence<Base> && sized_sequence<Base>) ||
+            requires (random_access_sequence<Base> && sized_iterable<Base>) ||
                       infinite_sequence<Base>
         {
             return cursor_type{

--- a/include/flux/adaptor/take.hpp
+++ b/include/flux/adaptor/take.hpp
@@ -28,7 +28,7 @@ public:
     [[nodiscard]] constexpr auto base() const& -> Base const& { return base_; }
     [[nodiscard]] constexpr auto base() && -> Base&& { return std::move(base_); }
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             cursor_t<Base> base_cur;

--- a/include/flux/adaptor/take.hpp
+++ b/include/flux/adaptor/take.hpp
@@ -7,6 +7,7 @@
 #define FLUX_ADAPTOR_TAKE_HPP_INCLUDED
 
 #include <flux/core.hpp>
+#include <flux/adaptor/stride.hpp>
 
 namespace flux {
 
@@ -40,7 +41,7 @@ public:
 
     public:
         using value_type = value_t<Base>;
-        
+
         template <typename Self>
         static consteval auto element_type(Self& self) -> element_t<decltype((self.base_))>;
 
@@ -49,7 +50,7 @@ public:
             if constexpr (random_access_sequence<Base> && bounded_sequence<Base>)
             {
                 auto cur = flux::first(self.base_);
-                flux::inc(self.base_, cur, self.count_);
+                flux::detail::advance(self.base_, cur, self.count_);
                 return flux::iterate(flux::slice(self.base_, flux::first(self.base_), cur), FLUX_FWD(pred));
             } else {
                 distance_t n = self.count_;

--- a/include/flux/adaptor/take.hpp
+++ b/include/flux/adaptor/take.hpp
@@ -40,8 +40,9 @@ public:
 
     public:
         using value_type = value_t<Base>;
-
-        static consteval auto element_type(auto& self) -> element_t<decltype((self.base_))>;
+        
+        template <typename Self>
+        static consteval auto element_type(Self& self) -> element_t<decltype((self.base_))>;
 
         static constexpr auto iterate(auto& self, auto&& pred) -> bool
         {

--- a/include/flux/adaptor/take_while.hpp
+++ b/include/flux/adaptor/take_while.hpp
@@ -56,6 +56,9 @@ struct sequence_traits<detail::take_while_adaptor<Base, Pred>>
 
     static constexpr bool is_infinite = false;
 
+    using default_sequence_traits::element_type;
+    using default_sequence_traits::iterate;
+
     template <typename Self>
     static constexpr bool is_last(Self& self, cursor_t<Self> const& cur)
         requires std::predicate<decltype((self.pred_)), element_t<decltype(self.base_)>>

--- a/include/flux/adaptor/take_while.hpp
+++ b/include/flux/adaptor/take_while.hpp
@@ -20,7 +20,7 @@ private:
 
     constexpr auto base() & -> Base& { return base_; }
 
-    friend struct sequence_traits<take_while_adaptor>;
+    friend struct iter_traits<take_while_adaptor>;
     friend struct passthrough_traits_base;
 
 public:
@@ -47,7 +47,7 @@ struct take_while_fn {
 } // namespace detail
 
 template <iterable Base, typename Pred>
-struct sequence_traits<detail::take_while_adaptor<Base, Pred>>
+struct iter_traits<detail::take_while_adaptor<Base, Pred>>
     : default_sequence_traits {
 
     template <typename Self>
@@ -72,7 +72,7 @@ struct sequence_traits<detail::take_while_adaptor<Base, Pred>>
 };
 
 template <sequence Base, typename Pred>
-struct sequence_traits<detail::take_while_adaptor<Base, Pred>>
+struct iter_traits<detail::take_while_adaptor<Base, Pred>>
     : detail::passthrough_traits_base
 {
     using self_t = detail::take_while_adaptor<Base, Pred>;

--- a/include/flux/adaptor/take_while.hpp
+++ b/include/flux/adaptor/take_while.hpp
@@ -50,7 +50,8 @@ template <iterable Base, typename Pred>
 struct sequence_traits<detail::take_while_adaptor<Base, Pred>>
     : default_sequence_traits {
 
-    static consteval auto element_type(auto& self)
+    template <typename Self>
+    static consteval auto element_type(Self& self)
         -> element_t<decltype((self.base_))>;
 
     static constexpr auto iterate(auto& self, auto&& iter_pred) -> bool

--- a/include/flux/adaptor/take_while.hpp
+++ b/include/flux/adaptor/take_while.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <iterable Base, typename Pred>
-struct take_while_adaptor : inline_sequence_base<take_while_adaptor<Base, Pred>> {
+struct take_while_adaptor : inline_iter_base<take_while_adaptor<Base, Pred>> {
 private:
     Base base_;
     Pred pred_;
@@ -130,7 +130,7 @@ FLUX_EXPORT inline constexpr auto take_while = detail::take_while_fn{};
 template <typename D>
 template <typename Pred>
     requires std::predicate<Pred&, element_t<D>>
-constexpr auto inline_sequence_base<D>::take_while(Pred pred) &&
+constexpr auto inline_iter_base<D>::take_while(Pred pred) &&
 {
     return flux::take_while(std::move(derived()), std::move(pred));
 }

--- a/include/flux/adaptor/take_while.hpp
+++ b/include/flux/adaptor/take_while.hpp
@@ -48,7 +48,7 @@ struct take_while_fn {
 
 template <iterable Base, typename Pred>
 struct iter_traits<detail::take_while_adaptor<Base, Pred>>
-    : default_sequence_traits {
+    : default_iter_traits {
 
     template <typename Self>
     static consteval auto element_type(Self& self)
@@ -81,7 +81,7 @@ struct iter_traits<detail::take_while_adaptor<Base, Pred>>
 
     static constexpr bool is_infinite = false;
 
-    using default_sequence_traits::element_type;
+    using default_iter_traits::element_type;
 
     static constexpr auto iterate(auto& self, auto&& iter_pred) -> bool
     {

--- a/include/flux/adaptor/unchecked.hpp
+++ b/include/flux/adaptor/unchecked.hpp
@@ -25,7 +25,7 @@ public:
     constexpr auto base() & -> Base& { return base_; }
     constexpr auto base() const& -> Base const& { return base_; }
 
-    struct flux_sequence_traits : passthrough_traits_base {
+    struct flux_iter_traits : passthrough_traits_base {
 
         using value_type = value_t<Base>;
         static constexpr bool disable_multipass = !multipass_sequence<Base>;

--- a/include/flux/adaptor/unchecked.hpp
+++ b/include/flux/adaptor/unchecked.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <sequence Base>
-struct unchecked_adaptor : inline_sequence_base<unchecked_adaptor<Base>> {
+struct unchecked_adaptor : inline_iter_base<unchecked_adaptor<Base>> {
 private:
     Base base_;
 

--- a/include/flux/adaptor/zip.hpp
+++ b/include/flux/adaptor/zip.hpp
@@ -135,7 +135,7 @@ public:
 namespace detail {
 
 template <sequence... Bases>
-struct zip_adaptor : inline_sequence_base<zip_adaptor<Bases...>> {
+struct zip_adaptor : inline_iter_base<zip_adaptor<Bases...>> {
 private:
     pair_or_tuple_t<Bases...> bases_;
 
@@ -162,7 +162,7 @@ struct zip_fn {
 };
 
 template <typename Func, sequence... Bases>
-struct zip_map_adaptor : inline_sequence_base<zip_map_adaptor<Func, Bases...>> {
+struct zip_map_adaptor : inline_iter_base<zip_map_adaptor<Func, Bases...>> {
 private:
     pair_or_tuple_t<Bases...> bases_;
     FLUX_NO_UNIQUE_ADDRESS Func func_;

--- a/include/flux/adaptor/zip.hpp
+++ b/include/flux/adaptor/zip.hpp
@@ -139,7 +139,7 @@ struct zip_adaptor : inline_sequence_base<zip_adaptor<Bases...>> {
 private:
     pair_or_tuple_t<Bases...> bases_;
 
-    friend struct sequence_traits<zip_adaptor>;
+    friend struct iter_traits<zip_adaptor>;
     friend struct zip_traits_base<Bases...>;
 
 public:
@@ -167,7 +167,7 @@ private:
     pair_or_tuple_t<Bases...> bases_;
     FLUX_NO_UNIQUE_ADDRESS Func func_;
 
-    friend struct sequence_traits<zip_map_adaptor>;
+    friend struct iter_traits<zip_map_adaptor>;
     friend struct zip_traits_base<Bases...>;
 
 public:
@@ -193,7 +193,7 @@ struct zip_map_fn {
 } // namespace detail
 
 template <typename... Bases>
-struct sequence_traits<detail::zip_adaptor<Bases...>> : zip_traits_base<Bases...>
+struct iter_traits<detail::zip_adaptor<Bases...>> : zip_traits_base<Bases...>
 {
 private:
     using base = zip_traits_base<Bases...>;
@@ -247,7 +247,7 @@ public:
 };
 
 template <typename Func, typename... Bases>
-struct sequence_traits<detail::zip_map_adaptor<Func, Bases...>> : zip_traits_base<Bases...>
+struct iter_traits<detail::zip_map_adaptor<Func, Bases...>> : zip_traits_base<Bases...>
 {
 private:
     using base = zip_traits_base<Bases...>;

--- a/include/flux/adaptor/zip.hpp
+++ b/include/flux/adaptor/zip.hpp
@@ -114,7 +114,7 @@ public:
 
     template <typename Self>
         requires (random_access_sequence<const_like_t<Self, Bases>> && ...)
-                && (sized_sequence<const_like_t<Self, Bases>> && ...)
+                && (sized_iterable<const_like_t<Self, Bases>> && ...)
     static constexpr auto last(Self& self)
     {
         auto cur = first(self);
@@ -122,7 +122,7 @@ public:
     }
 
     template <typename Self>
-        requires (sized_sequence<const_like_t<Self, Bases>> && ...)
+        requires (sized_iterable<const_like_t<Self, Bases>> && ...)
     static constexpr auto size(Self& self)
     {
         return std::apply([&](auto&... args) {

--- a/include/flux/adaptor/zip.hpp
+++ b/include/flux/adaptor/zip.hpp
@@ -31,7 +31,7 @@ using pair_or_tuple_t = typename pair_or_tuple<Ts...>::type;
 }
 
 template <typename... Bases>
-struct zip_traits_base : default_sequence_traits {
+struct zip_traits_base : default_iter_traits {
 private:
     template <typename From, typename To>
     using const_like_t = std::conditional_t<std::is_const_v<From>, To const, To>;
@@ -281,8 +281,8 @@ public:
         return read_(flux::read_at_unchecked, self, cur);
     }
 
-    using default_sequence_traits::move_at;
-    using default_sequence_traits::move_at_unchecked;
+    using default_iter_traits::move_at;
+    using default_iter_traits::move_at_unchecked;
 };
 
 FLUX_EXPORT inline constexpr auto zip = detail::zip_fn{};

--- a/include/flux/algorithm/all_any_none.hpp
+++ b/include/flux/algorithm/all_any_none.hpp
@@ -60,21 +60,21 @@ FLUX_EXPORT inline constexpr auto any = any_detail::fn{};
 
 template <typename D>
 template <predicate_for<D> Pred>
-constexpr auto inline_sequence_base<D>::all(Pred pred)
+constexpr auto inline_iter_base<D>::all(Pred pred)
 {
     return flux::all(derived(), std::move(pred));
 }
 
 template <typename D>
 template <predicate_for<D> Pred>
-constexpr auto inline_sequence_base<D>::any(Pred pred)
+constexpr auto inline_iter_base<D>::any(Pred pred)
 {
     return flux::any(derived(), std::move(pred));
 }
 
 template <typename D>
 template <predicate_for<D> Pred>
-constexpr auto inline_sequence_base<D>::none(Pred pred)
+constexpr auto inline_iter_base<D>::none(Pred pred)
 {
     return flux::none(derived(), std::move(pred));
 }

--- a/include/flux/algorithm/all_any_none.hpp
+++ b/include/flux/algorithm/all_any_none.hpp
@@ -13,13 +13,13 @@ namespace flux {
 namespace all_detail {
 
 struct fn {
-    template <sequence Seq, typename Pred>
-        requires std::predicate<Pred&, element_t<Seq>>
-    constexpr bool operator()(Seq&& seq, Pred pred) const
+    template <iterable It, typename Pred>
+        requires std::predicate<Pred&, element_t<It>>
+    constexpr bool operator()(It&& it, Pred pred) const
     {
-        return is_last(seq, for_each_while(seq, [&](auto&& elem) {
+        return iterate(it, [&](auto&& elem) {
             return std::invoke(pred, FLUX_FWD(elem));
-        }));
+        });
     }
 };
 
@@ -30,13 +30,13 @@ FLUX_EXPORT inline constexpr auto all = all_detail::fn{};
 namespace none_detail {
 
 struct fn {
-    template <sequence Seq, typename Pred>
-        requires std::predicate<Pred&, element_t<Seq>>
-    constexpr bool operator()(Seq&& seq, Pred pred) const
+    template <iterable It, typename Pred>
+        requires std::predicate<Pred&, element_t<It>>
+    constexpr bool operator()(It&& it, Pred pred) const
     {
-        return is_last(seq, for_each_while(seq, [&](auto&& elem) {
+        return iterate(it, [&](auto&& elem) {
             return !std::invoke(pred, FLUX_FWD(elem));
-        }));
+        });
     }
 };
 
@@ -47,13 +47,13 @@ FLUX_EXPORT inline constexpr auto none = none_detail::fn{};
 namespace any_detail {
 
 struct fn {
-    template <sequence Seq, typename Pred>
-        requires std::predicate<Pred&, element_t<Seq>>
-    constexpr bool operator()(Seq&& seq, Pred pred) const
+    template <iterable It, typename Pred>
+        requires std::predicate<Pred&, element_t<It>>
+    constexpr bool operator()(It&& it, Pred pred) const
     {
-        return !is_last(seq, for_each_while(seq, [&](auto&& elem) {
+        return !iterate(it, [&](auto&& elem) {
             return !std::invoke(pred, FLUX_FWD(elem));
-        }));
+        });
     }
 };
 

--- a/include/flux/algorithm/all_any_none.hpp
+++ b/include/flux/algorithm/all_any_none.hpp
@@ -13,8 +13,7 @@ namespace flux {
 namespace all_detail {
 
 struct fn {
-    template <iterable It, typename Pred>
-        requires std::predicate<Pred&, element_t<It>>
+    template <iterable It, predicate_for<It> Pred>
     constexpr bool operator()(It&& it, Pred pred) const
     {
         return iterate(it, [&](auto&& elem) {
@@ -30,8 +29,7 @@ FLUX_EXPORT inline constexpr auto all = all_detail::fn{};
 namespace none_detail {
 
 struct fn {
-    template <iterable It, typename Pred>
-        requires std::predicate<Pred&, element_t<It>>
+    template <iterable It, predicate_for<It> Pred>
     constexpr bool operator()(It&& it, Pred pred) const
     {
         return iterate(it, [&](auto&& elem) {
@@ -47,8 +45,7 @@ FLUX_EXPORT inline constexpr auto none = none_detail::fn{};
 namespace any_detail {
 
 struct fn {
-    template <iterable It, typename Pred>
-        requires std::predicate<Pred&, element_t<It>>
+    template <iterable It, predicate_for<It> Pred>
     constexpr bool operator()(It&& it, Pred pred) const
     {
         return !iterate(it, [&](auto&& elem) {
@@ -62,24 +59,21 @@ struct fn {
 FLUX_EXPORT inline constexpr auto any = any_detail::fn{};
 
 template <typename D>
-template <typename Pred>
-    requires std::predicate<Pred&, element_t<D>>
+template <predicate_for<D> Pred>
 constexpr auto inline_sequence_base<D>::all(Pred pred)
 {
     return flux::all(derived(), std::move(pred));
 }
 
 template <typename D>
-template <typename Pred>
-    requires std::predicate<Pred&, element_t<D>>
+template <predicate_for<D> Pred>
 constexpr auto inline_sequence_base<D>::any(Pred pred)
 {
     return flux::any(derived(), std::move(pred));
 }
 
 template <typename D>
-template <typename Pred>
-    requires std::predicate<Pred&, element_t<D>>
+template <predicate_for<D> Pred>
 constexpr auto inline_sequence_base<D>::none(Pred pred)
 {
     return flux::none(derived(), std::move(pred));

--- a/include/flux/algorithm/compare.hpp
+++ b/include/flux/algorithm/compare.hpp
@@ -51,8 +51,8 @@ public:
             std::same_as<Cmp, std::compare_three_way> &&
             contiguous_sequence<Seq1> && 
             contiguous_sequence<Seq2> &&
-            sized_sequence<Seq1> && 
-            sized_sequence<Seq2> &&
+            sized_iterable<Seq1> &&
+            sized_iterable<Seq2> &&
             std::same_as<value_t<Seq1>, value_t<Seq2>> &&
             std::unsigned_integral<value_t<Seq1>> &&
             ((sizeof(value_t<Seq1>) == 1) || (std::endian::native == std::endian::big));

--- a/include/flux/algorithm/contains.hpp
+++ b/include/flux/algorithm/contains.hpp
@@ -29,7 +29,7 @@ FLUX_EXPORT inline constexpr auto contains = detail::contains_fn{};
 template <typename D>
 template <typename Value>
     requires std::equality_comparable_with<element_t<D>, Value const&>
-constexpr auto inline_sequence_base<D>::contains(Value const& value) -> bool
+constexpr auto inline_iter_base<D>::contains(Value const& value) -> bool
 {
     return flux::contains(derived(), value);
 }

--- a/include/flux/algorithm/contains.hpp
+++ b/include/flux/algorithm/contains.hpp
@@ -6,21 +6,18 @@
 #ifndef FLUX_ALGORITHM_CONTAINS_HPP_INCLUDED
 #define FLUX_ALGORITHM_CONTAINS_HPP_INCLUDED
 
-#include <flux/core.hpp>
+#include <flux/algorithm/all_any_none.hpp>
 
 namespace flux {
 
 namespace detail {
 
 struct contains_fn {
-    template <sequence Seq, typename Value>
-        requires std::equality_comparable_with<element_t<Seq>, Value const&>
-    constexpr auto operator()(Seq&& seq, Value const& value) const
-        -> bool
+    template <iterable It, typename Value>
+        requires std::equality_comparable_with<element_t<It>, Value const&>
+    constexpr auto operator()(It&& it, Value const& value) const -> bool
     {
-        return !flux::is_last(seq, flux::for_each_while(seq, [&](auto&& elem) {
-            return FLUX_FWD(elem) != value;
-        }));
+        return any(it, [&](auto&& elem) { return FLUX_FWD(elem) == value; });
     }
 };
 

--- a/include/flux/algorithm/count.hpp
+++ b/include/flux/algorithm/count.hpp
@@ -73,7 +73,7 @@ FLUX_EXPORT inline constexpr auto count_eq = detail::count_eq_fn{};
 FLUX_EXPORT inline constexpr auto count_if = detail::count_if_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::count()
+constexpr auto inline_iter_base<D>::count()
 {
     return flux::count(derived());
 }
@@ -81,7 +81,7 @@ constexpr auto inline_sequence_base<D>::count()
 template <typename D>
 template <typename Value>
     requires std::equality_comparable_with<element_t<D>, Value const&>
-constexpr auto inline_sequence_base<D>::count_eq(Value const& value)
+constexpr auto inline_iter_base<D>::count_eq(Value const& value)
 {
     return flux::count_eq(derived(), value);
 }
@@ -89,7 +89,7 @@ constexpr auto inline_sequence_base<D>::count_eq(Value const& value)
 template <typename D>
 template <typename Pred>
     requires std::predicate<Pred&, element_t<D>>
-constexpr auto inline_sequence_base<D>::count_if(Pred pred)
+constexpr auto inline_iter_base<D>::count_if(Pred pred)
 {
     return flux::count_if(derived(), std::move(pred));
 }

--- a/include/flux/algorithm/count.hpp
+++ b/include/flux/algorithm/count.hpp
@@ -17,7 +17,7 @@ struct count_fn {
     [[nodiscard]]
     constexpr auto operator()(It&& it) const -> distance_t
     {
-        if constexpr (sized_sequence<It>) {
+        if constexpr (sized_iterable<It>) {
             return flux::size(it);
         } else {
             distance_t counter = 0;

--- a/include/flux/algorithm/count.hpp
+++ b/include/flux/algorithm/count.hpp
@@ -13,16 +13,16 @@ namespace flux {
 namespace detail {
 
 struct count_fn {
-    template <sequence Seq>
+    template <iterable It>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq) const -> distance_t
+    constexpr auto operator()(It&& it) const -> distance_t
     {
-        if constexpr (sized_sequence<Seq>) {
-            return flux::size(seq);
+        if constexpr (sized_sequence<It>) {
+            return flux::size(it);
         } else {
             distance_t counter = 0;
-            flux::for_each_while(seq, [&](auto&&) {
-                ++counter;
+            flux::iterate(it, [&](auto&&) {
+                counter = flux::num::add(counter, distance_t{1});
                 return true;
             });
             return counter;
@@ -31,16 +31,16 @@ struct count_fn {
 };
 
 struct count_eq_fn {
-    template <sequence Seq, typename Value>
-        requires std::equality_comparable_with<element_t<Seq>, Value const&>
+    template <iterable It, typename Value>
+        requires std::equality_comparable_with<element_t<It>, Value const&>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Value const& value) const
+    constexpr auto operator()(It&& it, Value const& value) const
         -> distance_t
     {
         distance_t counter = 0;
-        flux::for_each_while(seq, [&](auto&& elem) {
+        iterate(it, [&](auto&& elem) {
             if (value == FLUX_FWD(elem)) {
-                ++counter;
+                counter = flux::num::add(counter, distance_t{1});
             }
             return true;
         });
@@ -49,16 +49,16 @@ struct count_eq_fn {
 };
 
 struct count_if_fn {
-    template <sequence Seq, typename Pred>
-        requires std::predicate<Pred&, element_t<Seq>>
+    template <iterable It, typename Pred>
+        requires std::predicate<Pred&, element_t<It>>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Pred pred) const
+    constexpr auto operator()(It&& it, Pred pred) const
         -> distance_t
     {
         distance_t counter = 0;
-        flux::for_each_while(seq, [&](auto&& elem) {
+        iterate(it, [&](auto&& elem) {
             if (std::invoke(pred, FLUX_FWD(elem))) {
-                ++counter;
+                counter = flux::num::add(counter, distance_t{1});
             }
             return true;
         });

--- a/include/flux/algorithm/ends_with.hpp
+++ b/include/flux/algorithm/ends_with.hpp
@@ -18,7 +18,7 @@ private:
     template <typename H, typename N>
     static constexpr auto bidir_impl(H& h, N& n, auto& cmp) -> bool
     {
-        if constexpr (sized_sequence<H> && sized_sequence<N>) {
+        if constexpr (sized_iterable<H> && sized_iterable<N>) {
             if (flux::size(h) < flux::size(n)) {
                 return false;
             }
@@ -55,8 +55,8 @@ private:
 public:
     template <sequence Haystack, sequence Needle, typename Cmp = std::ranges::equal_to>
         requires std::predicate<Cmp&, element_t<Haystack>, element_t<Needle>> &&
-                 (multipass_sequence<Haystack> || sized_sequence<Haystack>) &&
-                 (multipass_sequence<Needle> || sized_sequence<Needle>)
+                 (multipass_sequence<Haystack> || sized_iterable<Haystack>) &&
+                 (multipass_sequence<Needle> || sized_iterable<Needle>)
     constexpr auto operator()(Haystack&& haystack, Needle&& needle, Cmp cmp = Cmp{}) const
         -> bool
     {
@@ -89,8 +89,8 @@ FLUX_EXPORT inline constexpr auto ends_with = detail::ends_with_fn{};
 template <typename Derived>
 template <sequence Needle, typename Cmp>
     requires std::predicate<Cmp&, element_t<Derived>, element_t<Needle>> &&
-             (multipass_sequence<Derived> || sized_sequence<Derived>) &&
-             (multipass_sequence<Needle> || sized_sequence<Needle>)
+             (multipass_sequence<Derived> || sized_iterable<Derived>) &&
+             (multipass_sequence<Needle> || sized_iterable<Needle>)
 constexpr auto inline_sequence_base<Derived>::ends_with(Needle&& needle, Cmp cmp) -> bool
 {
     return flux::ends_with(derived(), FLUX_FWD(needle), std::move(cmp));

--- a/include/flux/algorithm/ends_with.hpp
+++ b/include/flux/algorithm/ends_with.hpp
@@ -91,7 +91,7 @@ template <sequence Needle, typename Cmp>
     requires std::predicate<Cmp&, element_t<Derived>, element_t<Needle>> &&
              (multipass_sequence<Derived> || sized_iterable<Derived>) &&
              (multipass_sequence<Needle> || sized_iterable<Needle>)
-constexpr auto inline_sequence_base<Derived>::ends_with(Needle&& needle, Cmp cmp) -> bool
+constexpr auto inline_iter_base<Derived>::ends_with(Needle&& needle, Cmp cmp) -> bool
 {
     return flux::ends_with(derived(), FLUX_FWD(needle), std::move(cmp));
 }

--- a/include/flux/algorithm/ends_with.hpp
+++ b/include/flux/algorithm/ends_with.hpp
@@ -6,6 +6,7 @@
 #ifndef FLUX_ALGORITHM_ENDS_WITH_HPP_INCLUDED
 #define FLUX_ALGORITHM_ENDS_WITH_HPP_INCLUDED
 
+#include <flux/adaptor/stride.hpp>
 #include <flux/algorithm/count.hpp>
 #include <flux/algorithm/equal.hpp>
 
@@ -88,7 +89,8 @@ FLUX_EXPORT inline constexpr auto ends_with = detail::ends_with_fn{};
 
 template <typename Derived>
 template <sequence Needle, typename Cmp>
-    requires std::predicate<Cmp&, element_t<Derived>, element_t<Needle>> &&
+    requires sequence<Derived> &&
+             std::predicate<Cmp&, element_t<Derived>, element_t<Needle>> &&
              (multipass_sequence<Derived> || sized_iterable<Derived>) &&
              (multipass_sequence<Needle> || sized_iterable<Needle>)
 constexpr auto inline_iter_base<Derived>::ends_with(Needle&& needle, Cmp cmp) -> bool

--- a/include/flux/algorithm/equal.hpp
+++ b/include/flux/algorithm/equal.hpp
@@ -39,7 +39,7 @@ public:
     constexpr auto operator()(Seq1&& seq1, Seq2&& seq2, Cmp cmp = {}) const
         -> bool
     {
-        if constexpr (sized_sequence<Seq1> && sized_sequence<Seq2>) {
+        if constexpr (sized_iterable<Seq1> && sized_iterable<Seq2>) {
             if (flux::size(seq1) != flux::size(seq2)) {
                 return false;
             }
@@ -48,7 +48,7 @@ public:
         constexpr bool can_memcmp = 
             std::same_as<Cmp, std::ranges::equal_to> &&
             contiguous_sequence<Seq1> && contiguous_sequence<Seq2> &&
-            sized_sequence<Seq1> && sized_sequence<Seq2> &&
+            sized_iterable<Seq1> && sized_iterable<Seq2> &&
             std::same_as<value_t<Seq1>, value_t<Seq2>> &&
             (std::integral<value_t<Seq1>> || std::is_pointer_v<value_t<Seq1>>) &&
             std::has_unique_object_representations_v<value_t<Seq1>>;
@@ -82,7 +82,7 @@ public:
                  std::is_invocable_v<equal_fn&, Seq1&, Seq2&, equal_fn&>)
     constexpr auto operator()(Seq1&& seq1, Seq2&& seq2) const -> bool
     {
-        if constexpr (sized_sequence<Seq1> && sized_sequence<Seq2>) {
+        if constexpr (sized_iterable<Seq1> && sized_iterable<Seq2>) {
             if (flux::size(seq1) != flux::size(seq2)) {
                 return false;
             }

--- a/include/flux/algorithm/fill.hpp
+++ b/include/flux/algorithm/fill.hpp
@@ -27,7 +27,7 @@ public:
     {
         constexpr bool can_memset = 
             contiguous_sequence<It> &&
-            sized_sequence<It> &&
+            sized_iterable<It> &&
             std::same_as<Value, value_t<It>> &&
             // only allow memset on single byte types
             sizeof(value_t<It>) == 1 &&

--- a/include/flux/algorithm/fill.hpp
+++ b/include/flux/algorithm/fill.hpp
@@ -59,7 +59,7 @@ FLUX_EXPORT inline constexpr auto fill = detail::fill_fn{};
 template <typename D>
 template <typename Value>
     requires writable_iterable_of<D, Value const&>
-constexpr void inline_sequence_base<D>::fill(Value const& value)
+constexpr void inline_iter_base<D>::fill(Value const& value)
 {
     flux::fill(derived(), value);
 }

--- a/include/flux/algorithm/fill.hpp
+++ b/include/flux/algorithm/fill.hpp
@@ -22,33 +22,32 @@ private:
     }
 
 public:
-    template <typename Value, writable_sequence_of<Value> Seq>
-    constexpr void operator()(Seq&& seq, Value const& value) const
+    template <typename Value, writable_iterable_of<Value> It>
+    constexpr void operator()(It&& it, Value const& value) const
     {
         constexpr bool can_memset = 
-            contiguous_sequence<Seq> &&
-            sized_sequence<Seq> &&
-            std::same_as<Value, value_t<Seq>> &&
+            contiguous_sequence<It> &&
+            sized_sequence<It> &&
+            std::same_as<Value, value_t<It>> &&
             // only allow memset on single byte types
-            sizeof(value_t<Seq>) == 1 &&
-            std::is_trivially_copyable_v<value_t<Seq>>;
+            sizeof(value_t<It>) == 1 &&
+            std::is_trivially_copyable_v<value_t<It>>;
 
         if constexpr (can_memset) {
             if (std::is_constant_evaluated()) {
-                impl(seq, value); // LCOV_EXCL_LINE
+                impl(it, value); // LCOV_EXCL_LINE
             } else {
-                auto size = flux::usize(seq);
-                if(size == 0) {
+                auto size = flux::usize(it);
+                if (size == 0) {
                     return;
                 }
                 
-                FLUX_ASSERT(flux::data(seq) != nullptr);
+                FLUX_ASSERT(flux::data(it) != nullptr);
                 
-                std::memset(flux::data(seq), value,
-                    size * sizeof(value_t<Seq>));
+                std::memset(flux::data(it), value, size);
             }
         } else {
-            impl(seq, value);
+            impl(it, value);
         }
     }
 };
@@ -59,7 +58,7 @@ FLUX_EXPORT inline constexpr auto fill = detail::fill_fn{};
 
 template <typename D>
 template <typename Value>
-    requires writable_sequence_of<D, Value const&>
+    requires writable_iterable_of<D, Value const&>
 constexpr void inline_sequence_base<D>::fill(Value const& value)
 {
     flux::fill(derived(), value);

--- a/include/flux/algorithm/find.hpp
+++ b/include/flux/algorithm/find.hpp
@@ -92,7 +92,7 @@ FLUX_EXPORT inline constexpr auto find_if_not = detail::find_if_not_fn{};
 template <typename D>
 template <typename Value>
     requires std::equality_comparable_with<element_t<D>, Value const&>
-constexpr auto inline_sequence_base<D>::find(Value const& val)
+constexpr auto inline_iter_base<D>::find(Value const& val)
 {
     return flux::find(derived(), val);
 }
@@ -100,7 +100,7 @@ constexpr auto inline_sequence_base<D>::find(Value const& val)
 template <typename D>
 template <typename Pred>
     requires std::predicate<Pred&, element_t<D>>
-constexpr auto inline_sequence_base<D>::find_if(Pred pred)
+constexpr auto inline_iter_base<D>::find_if(Pred pred)
 {
     return flux::find_if(derived(), std::ref(pred));
 }
@@ -108,7 +108,7 @@ constexpr auto inline_sequence_base<D>::find_if(Pred pred)
 template <typename D>
 template <typename Pred>
     requires std::predicate<Pred&, element_t<D>>
-constexpr auto inline_sequence_base<D>::find_if_not(Pred pred)
+constexpr auto inline_iter_base<D>::find_if_not(Pred pred)
 {
     return flux::find_if_not(derived(), std::ref(pred));
 }

--- a/include/flux/algorithm/find.hpp
+++ b/include/flux/algorithm/find.hpp
@@ -30,7 +30,7 @@ public:
         requires std::equality_comparable_with<element_t<Seq>, Value const&>
     constexpr auto operator()(Seq&& seq, Value const& value) const -> cursor_t<Seq>
     {
-        constexpr auto can_memchr = 
+        constexpr auto can_memchr =
             contiguous_sequence<Seq> && sized_iterable<Seq> &&
             std::same_as<Value, value_t<Seq>> &&
             flux::detail::any_of<value_t<Seq>, char, signed char, unsigned char, char8_t, std::byte>;
@@ -91,7 +91,8 @@ FLUX_EXPORT inline constexpr auto find_if_not = detail::find_if_not_fn{};
 
 template <typename D>
 template <typename Value>
-    requires std::equality_comparable_with<element_t<D>, Value const&>
+    requires sequence<D> &&
+             std::equality_comparable_with<element_t<D>, Value const&>
 constexpr auto inline_iter_base<D>::find(Value const& val)
 {
     return flux::find(derived(), val);
@@ -99,7 +100,8 @@ constexpr auto inline_iter_base<D>::find(Value const& val)
 
 template <typename D>
 template <typename Pred>
-    requires std::predicate<Pred&, element_t<D>>
+    requires sequence<D> &&
+             std::predicate<Pred&, element_t<D>>
 constexpr auto inline_iter_base<D>::find_if(Pred pred)
 {
     return flux::find_if(derived(), std::ref(pred));
@@ -107,7 +109,8 @@ constexpr auto inline_iter_base<D>::find_if(Pred pred)
 
 template <typename D>
 template <typename Pred>
-    requires std::predicate<Pred&, element_t<D>>
+    requires sequence<D> &&
+             std::predicate<Pred&, element_t<D>>
 constexpr auto inline_iter_base<D>::find_if_not(Pred pred)
 {
     return flux::find_if_not(derived(), std::ref(pred));

--- a/include/flux/algorithm/find.hpp
+++ b/include/flux/algorithm/find.hpp
@@ -31,7 +31,7 @@ public:
     constexpr auto operator()(Seq&& seq, Value const& value) const -> cursor_t<Seq>
     {
         constexpr auto can_memchr = 
-            contiguous_sequence<Seq> && sized_sequence<Seq> && 
+            contiguous_sequence<Seq> && sized_iterable<Seq> &&
             std::same_as<Value, value_t<Seq>> &&
             flux::detail::any_of<value_t<Seq>, char, signed char, unsigned char, char8_t, std::byte>;
 

--- a/include/flux/algorithm/find_min_max.hpp
+++ b/include/flux/algorithm/find_min_max.hpp
@@ -86,7 +86,7 @@ FLUX_EXPORT inline constexpr auto find_minmax = detail::find_minmax_fn{};
 template <typename D>
 template <typename Cmp>
     requires weak_ordering_for<Cmp, D>
-constexpr auto inline_sequence_base<D>::find_min(Cmp cmp)
+constexpr auto inline_iter_base<D>::find_min(Cmp cmp)
 {
     return flux::find_min(derived(), std::move(cmp));
 }
@@ -94,7 +94,7 @@ constexpr auto inline_sequence_base<D>::find_min(Cmp cmp)
 template <typename D>
 template <typename Cmp>
     requires weak_ordering_for<Cmp, D>
-constexpr auto inline_sequence_base<D>::find_max(Cmp cmp)
+constexpr auto inline_iter_base<D>::find_max(Cmp cmp)
 {
     return flux::find_max(derived(), std::move(cmp));
 }
@@ -102,7 +102,7 @@ constexpr auto inline_sequence_base<D>::find_max(Cmp cmp)
 template <typename D>
 template <typename Cmp>
     requires weak_ordering_for<Cmp, D>
-constexpr auto inline_sequence_base<D>::find_minmax(Cmp cmp)
+constexpr auto inline_iter_base<D>::find_minmax(Cmp cmp)
 {
     return flux::find_minmax(derived(), std::move(cmp));
 }

--- a/include/flux/algorithm/find_min_max.hpp
+++ b/include/flux/algorithm/find_min_max.hpp
@@ -85,7 +85,7 @@ FLUX_EXPORT inline constexpr auto find_minmax = detail::find_minmax_fn{};
 
 template <typename D>
 template <typename Cmp>
-    requires weak_ordering_for<Cmp, D>
+    requires sequence<D> && weak_ordering_for<Cmp, D>
 constexpr auto inline_iter_base<D>::find_min(Cmp cmp)
 {
     return flux::find_min(derived(), std::move(cmp));
@@ -93,7 +93,7 @@ constexpr auto inline_iter_base<D>::find_min(Cmp cmp)
 
 template <typename D>
 template <typename Cmp>
-    requires weak_ordering_for<Cmp, D>
+    requires sequence<D> && weak_ordering_for<Cmp, D>
 constexpr auto inline_iter_base<D>::find_max(Cmp cmp)
 {
     return flux::find_max(derived(), std::move(cmp));
@@ -101,7 +101,7 @@ constexpr auto inline_iter_base<D>::find_max(Cmp cmp)
 
 template <typename D>
 template <typename Cmp>
-    requires weak_ordering_for<Cmp, D>
+    requires sequence<D> && weak_ordering_for<Cmp, D>
 constexpr auto inline_iter_base<D>::find_minmax(Cmp cmp)
 {
     return flux::find_minmax(derived(), std::move(cmp));

--- a/include/flux/algorithm/fold.hpp
+++ b/include/flux/algorithm/fold.hpp
@@ -109,7 +109,7 @@ template <typename Derived>
 template <typename D, typename Func, typename Init>
     requires foldable<Derived, Func, Init>
 [[nodiscard]]
-constexpr auto inline_sequence_base<Derived>::fold(Func func, Init init) -> fold_result_t<D, Func, Init>
+constexpr auto inline_iter_base<Derived>::fold(Func func, Init init) -> fold_result_t<D, Func, Init>
 {
     return flux::fold(derived(), std::move(func), std::move(init));
 }
@@ -118,13 +118,13 @@ template <typename Derived>
 template <typename D, typename Func>
     requires std::invocable<Func&, value_t<D>, element_t<D>> &&
              std::assignable_from<value_t<D>&, std::invoke_result_t<Func&, value_t<D>, element_t<D>>>
-constexpr auto inline_sequence_base<Derived>::fold_first(Func func)
+constexpr auto inline_iter_base<Derived>::fold_first(Func func)
 {
     return flux::fold_first(derived(), std::move(func));
 }
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::sum()
+constexpr auto inline_iter_base<D>::sum()
     requires foldable<D, std::plus<>, value_t<D>> &&
              std::default_initializable<value_t<D>>
 {
@@ -132,7 +132,7 @@ constexpr auto inline_sequence_base<D>::sum()
 }
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::product()
+constexpr auto inline_iter_base<D>::product()
     requires foldable<D, std::multiplies<>, value_t<D>> &&
              requires { value_t<D>(1); }
 {

--- a/include/flux/algorithm/fold.hpp
+++ b/include/flux/algorithm/fold.hpp
@@ -13,16 +13,13 @@ namespace flux {
 namespace detail {
 
 struct fold_op {
-    template <sequence Seq, typename Func, std::movable Init = value_t<Seq>,
-              typename R = fold_result_t<Seq, Func, Init>>
-        requires std::invocable<Func&,  Init, element_t<Seq>> &&
-                 std::invocable<Func&, R, element_t<Seq>> &&
-                 std::convertible_to<Init, R> &&
-                 std::assignable_from<Init&, std::invoke_result_t<Func&, R, element_t<Seq>>>
-    constexpr auto operator()(Seq&& seq, Func func, Init init = Init{}) const -> R
+    template <iterable It, typename Func, std::movable Init = value_t<It>,
+              typename R = fold_result_t<It, Func, Init>>
+        requires foldable<It, Func, Init>
+    constexpr auto operator()(It&& it, Func func, Init init = Init{}) const -> R
     {
         R init_ = R(std::move(init));
-        flux::for_each_while(seq, [&func, &init_](auto&& elem) {
+        iterate(it, [&func, &init_](auto&& elem) {
             init_ = std::invoke(func, std::move(init_), FLUX_FWD(elem));
             return true;
         });
@@ -31,27 +28,23 @@ struct fold_op {
 };
 
 struct fold_first_op {
-    template <sequence Seq, typename Func, typename V = value_t<Seq>>
-        requires std::invocable<Func&, V, element_t<Seq>> &&
-                 std::assignable_from<value_t<Seq>&, std::invoke_result_t<Func&, V&&, element_t<Seq>>>
+    template <iterable It, typename Func, typename V = value_t<It>>
+        requires std::invocable<Func&, V, element_t<It>> &&
+                 std::assignable_from<V&, std::invoke_result_t<Func&, V&&, element_t<It>>>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Func func) const -> flux::optional<V>
+    constexpr auto operator()(It&& it, Func func) const -> flux::optional<V>
     {
-        auto cur = flux::first(seq);
+        using Opt = optional<V>;
 
-        if (flux::is_last(seq, cur)) {
-            return std::nullopt;
-        }
-
-        V init(flux::read_at(seq, cur));
-        flux::inc(seq, cur);
-
-        while (!flux::is_last(seq, cur)) {
-            init = std::invoke(func, std::move(init), flux::read_at(seq, cur));
-            flux::inc(seq, cur);
-        }
-
-        return flux::optional<V>(std::in_place, std::move(init));
+        return fold_op{}(it, [&func](Opt&& opt, auto&& elem) -> Opt {
+            if (opt.has_value()) {
+                auto& acc = opt.value_unchecked();
+                acc = std::invoke(func, std::move(acc), FLUX_FWD(elem));
+            } else {
+                opt.emplace(FLUX_FWD(elem));
+            }
+            return opt;
+        }, Opt{});
     }
 };
 
@@ -66,41 +59,41 @@ consteval bool libcpp_fold_invoke_workaround_required()
 }
 
 struct sum_op {
-    template <sequence Seq>
-        requires std::default_initializable<value_t<Seq>> &&
-                 std::invocable<fold_op, Seq, std::plus<>>
+    template <iterable It>
+        requires foldable<It, std::plus<>, value_t<It>> &&
+                 requires { value_t<It>{0}; }
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq) const -> value_t<Seq>
+    constexpr auto operator()(It&& it) const -> value_t<It>
     {
-        if constexpr (num::integral<value_t<Seq>>) {
+        if constexpr (num::integral<value_t<It>>) {
             if constexpr (libcpp_fold_invoke_workaround_required()) {
                 auto add = []<typename T>(T lhs, T rhs) -> T { return num::add(lhs, rhs); };
-                return fold_op{}(FLUX_FWD(seq), add, value_t<Seq>(0));
+                return fold_op{}(FLUX_FWD(it), add, value_t<It>(0));
             } else {
-                return fold_op{}(FLUX_FWD(seq), num::add, value_t<Seq>(0));
+                return fold_op{}(FLUX_FWD(it), num::add, value_t<It>(0));
             }
         } else {
-            return fold_op{}(FLUX_FWD(seq), std::plus<>{}, value_t<Seq>(0));
+            return fold_op{}(FLUX_FWD(it), std::plus<>{}, value_t<It>(0));
         }
     }
 };
 
 struct product_op {
-    template <sequence Seq>
-        requires std::invocable<fold_op, Seq, std::multiplies<>> &&
-                 requires { value_t<Seq>(1); }
+    template <iterable It>
+        requires foldable<It, std::multiplies<>, value_t<It>> &&
+                 requires { value_t<It>{1}; }
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq) const -> value_t<Seq>
+    constexpr auto operator()(It&& it) const -> value_t<It>
     {
-        if constexpr (num::integral<value_t<Seq>>) {
+        if constexpr (num::integral<value_t<It>>) {
             if constexpr (libcpp_fold_invoke_workaround_required()) {
                 auto mul = []<typename T>(T lhs, T rhs) -> T { return num::mul(lhs, rhs); };
-                return fold_op{}(FLUX_FWD(seq), mul, value_t<Seq>(1));
+                return fold_op{}(FLUX_FWD(it), mul, value_t<It>(1));
             } else {
-                return fold_op{}(FLUX_FWD(seq), num::mul, value_t<Seq>(1));
+                return fold_op{}(FLUX_FWD(it), num::mul, value_t<It>(1));
             }
         } else {
-            return fold_op{}(FLUX_FWD(seq), std::multiplies<>{}, value_t<Seq>(1));
+            return fold_op{}(FLUX_FWD(it), std::multiplies<>{}, value_t<It>(1));
         }
     }
 };

--- a/include/flux/algorithm/for_each.hpp
+++ b/include/flux/algorithm/for_each.hpp
@@ -13,13 +13,12 @@ namespace flux {
 namespace detail {
 
 struct for_each_fn {
-
-    template <sequence Seq, typename Func>
-        requires (std::invocable<Func&, element_t<Seq>> &&
-                  !infinite_sequence<Seq>)
-    constexpr auto operator()(Seq&& seq, Func func) const -> Func
+    template <iterable It, typename Func>
+        requires (std::invocable<Func&, element_t<It>> &&
+                  !infinite_sequence<It>)
+    constexpr auto operator()(It&& it, Func func) const -> Func
     {
-        (void) flux::for_each_while(FLUX_FWD(seq), [&](auto&& elem) {
+        (void) iterate(it, [&](auto&& elem) {
             std::invoke(func, FLUX_FWD(elem));
             return true;
         });

--- a/include/flux/algorithm/for_each.hpp
+++ b/include/flux/algorithm/for_each.hpp
@@ -33,7 +33,7 @@ FLUX_EXPORT inline constexpr auto for_each = detail::for_each_fn{};
 template <typename D>
 template <typename Func>
     requires std::invocable<Func&, element_t<D>>
-constexpr auto inline_sequence_base<D>::for_each(Func func) -> Func
+constexpr auto inline_iter_base<D>::for_each(Func func) -> Func
 {
     return flux::for_each(derived(), std::move(func));
 }

--- a/include/flux/algorithm/inplace_reverse.hpp
+++ b/include/flux/algorithm/inplace_reverse.hpp
@@ -33,7 +33,7 @@ struct inplace_reverse_fn {
 FLUX_EXPORT inline constexpr auto inplace_reverse = detail::inplace_reverse_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::inplace_reverse()
+constexpr auto inline_iter_base<D>::inplace_reverse()
     requires bounded_sequence<D> && detail::element_swappable_with<D, D>
 {
     return flux::inplace_reverse(derived());

--- a/include/flux/algorithm/minmax.hpp
+++ b/include/flux/algorithm/minmax.hpp
@@ -22,14 +22,14 @@ struct minmax_result {
 namespace detail {
 
 struct min_op {
-    template <sequence Seq, weak_ordering_for<Seq> Cmp = std::compare_three_way>
+    template <iterable It, weak_ordering_for<It> Cmp = std::compare_three_way>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Cmp cmp = Cmp{}) const
-        -> flux::optional<value_t<Seq>>
+    constexpr auto operator()(It&& it, Cmp cmp = Cmp{}) const
+        -> flux::optional<value_t<It>>
     {
-        return flux::fold_first(FLUX_FWD(seq), [&](auto min, auto&& elem) -> value_t<Seq> {
+        return flux::fold_first(it, [&](auto min, auto&& elem) -> value_t<It> {
             if (std::invoke(cmp, elem, min) < 0) {
-                return value_t<Seq>(FLUX_FWD(elem));
+                return value_t<It>(FLUX_FWD(elem));
             } else {
                 return min;
             }
@@ -38,14 +38,14 @@ struct min_op {
 };
 
 struct max_op {
-    template <sequence Seq, weak_ordering_for<Seq> Cmp = std::compare_three_way>
+    template <iterable It, weak_ordering_for<It> Cmp = std::compare_three_way>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Cmp cmp = Cmp{}) const
-        -> flux::optional<value_t<Seq>>
+    constexpr auto operator()(It&& it, Cmp cmp = Cmp{}) const
+        -> flux::optional<value_t<It>>
     {
-        return flux::fold_first(FLUX_FWD(seq), [&](auto max, auto&& elem) -> value_t<Seq> {
+        return flux::fold_first(it, [&](auto max, auto&& elem) -> value_t<It> {
             if (!(std::invoke(cmp, elem, max) < 0)) {
-                return value_t<Seq>(FLUX_FWD(elem));
+                return value_t<It>(FLUX_FWD(elem));
             } else {
                 return max;
             }
@@ -54,33 +54,29 @@ struct max_op {
 };
 
 struct minmax_op {
-    template <sequence Seq, weak_ordering_for<Seq> Cmp = std::compare_three_way>
+    template <iterable It, weak_ordering_for<It> Cmp = std::compare_three_way>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq, Cmp cmp = Cmp{}) const
-        -> flux::optional<minmax_result<value_t<Seq>>>
+    constexpr auto operator()(It&& seq, Cmp cmp = Cmp{}) const
+        -> flux::optional<minmax_result<value_t<It>>>
     {
-        using R = minmax_result<value_t<Seq>>;
+        using Opt = optional<minmax_result<value_t<It>>>;
 
-        auto cur = flux::first(seq);
-        if (flux::is_last(seq, cur)) {
-            return std::nullopt;
-        }
-
-        R init = R{value_t<Seq>(flux::read_at(seq, cur)),
-                   value_t<Seq>(flux::read_at(seq, cur))};
-
-        auto fold_fn = [&](R mm, auto&& elem) -> R {
-            if (std::invoke(cmp, elem, mm.min) < 0) {
-                mm.min = value_t<Seq>(elem);
+        auto fold_fn = [&cmp](Opt o, auto&& elem) -> Opt {
+            if (o.has_value()) {
+                auto& mm = o.value_unchecked();
+                if (std::invoke(cmp, elem, mm.min) < 0) {
+                    mm.min = value_t<It>(elem);
+                }
+                if (!(std::invoke(cmp, elem, mm.max) < 0)) {
+                    mm.max = value_t<It>(FLUX_FWD(elem));
+                }
+            } else {
+                o.emplace(value_t<It>(elem), value_t<It>(elem));
             }
-            if (!(std::invoke(cmp, elem, mm.max) < 0)) {
-                mm.max = value_t<Seq>(FLUX_FWD(elem));
-            }
-            return mm;
+            return o;
         };
 
-        return flux::optional<R>(std::in_place,
-                                flux::fold(flux::slice(seq, std::move(cur), flux::last), fold_fn, std::move(init)));
+        return flux::fold(seq, fold_fn, Opt{});
     }
 };
 

--- a/include/flux/algorithm/minmax.hpp
+++ b/include/flux/algorithm/minmax.hpp
@@ -89,7 +89,7 @@ FLUX_EXPORT inline constexpr auto minmax = detail::minmax_op{};
 template <typename Derived>
 template <typename Cmp>
     requires weak_ordering_for<Cmp, Derived>
-constexpr auto inline_sequence_base<Derived>::max(Cmp cmp)
+constexpr auto inline_iter_base<Derived>::max(Cmp cmp)
 {
     return flux::max(derived(), std::move(cmp));
 }
@@ -97,7 +97,7 @@ constexpr auto inline_sequence_base<Derived>::max(Cmp cmp)
 template <typename Derived>
 template <typename Cmp>
     requires weak_ordering_for<Cmp, Derived>
-constexpr auto inline_sequence_base<Derived>::min(Cmp cmp)
+constexpr auto inline_iter_base<Derived>::min(Cmp cmp)
 {
     return flux::min(derived(), std::move(cmp));
 }
@@ -105,7 +105,7 @@ constexpr auto inline_sequence_base<Derived>::min(Cmp cmp)
 template <typename Derived>
 template <typename Cmp>
     requires weak_ordering_for<Cmp, Derived>
-constexpr auto inline_sequence_base<Derived>::minmax(Cmp cmp)
+constexpr auto inline_iter_base<Derived>::minmax(Cmp cmp)
 {
     return flux::minmax(derived(), std::move(cmp));
 }

--- a/include/flux/algorithm/output_to.hpp
+++ b/include/flux/algorithm/output_to.hpp
@@ -28,7 +28,7 @@ private:
     }
 
 public:
-    template <sequence Seq, std::weakly_incrementable Iter>
+    template <iterable Seq, std::weakly_incrementable Iter>
         requires std::indirectly_writable<Iter, element_t<Seq>>
     constexpr auto operator()(Seq&& seq, Iter iter) const -> Iter
     {

--- a/include/flux/algorithm/output_to.hpp
+++ b/include/flux/algorithm/output_to.hpp
@@ -65,7 +65,7 @@ template <typename D>
 template <typename Iter>
     requires std::weakly_incrementable<Iter> &&
              std::indirectly_writable<Iter, element_t<D>>
-constexpr auto inline_sequence_base<D>::output_to(Iter iter) -> Iter
+constexpr auto inline_iter_base<D>::output_to(Iter iter) -> Iter
 {
     return flux::output_to(derived(), std::move(iter));
 }

--- a/include/flux/algorithm/output_to.hpp
+++ b/include/flux/algorithm/output_to.hpp
@@ -34,7 +34,7 @@ public:
     {
         constexpr bool can_memcpy =
             contiguous_sequence<Seq> &&
-            sized_sequence<Seq> &&
+            sized_iterable<Seq> &&
             std::contiguous_iterator<Iter> &&
             std::is_trivially_copyable_v<value_t<Seq>>;
 

--- a/include/flux/algorithm/sort.hpp
+++ b/include/flux/algorithm/sort.hpp
@@ -32,7 +32,7 @@ template <typename Cmp>
              bounded_sequence<D> &&
              detail::element_swappable_with<D, D> &&
              weak_ordering_for<Cmp, D>
-constexpr void inline_sequence_base<D>::sort(Cmp cmp)
+constexpr void inline_iter_base<D>::sort(Cmp cmp)
 {
     return flux::sort(derived(), std::ref(cmp));
 }

--- a/include/flux/algorithm/starts_with.hpp
+++ b/include/flux/algorithm/starts_with.hpp
@@ -60,7 +60,7 @@ FLUX_EXPORT inline constexpr auto starts_with = detail::starts_with_fn{};
 template <typename Derived>
 template <sequence Needle, typename Cmp>
     requires std::predicate<Cmp&, element_t<Derived>, element_t<Needle>>
-constexpr auto inline_sequence_base<Derived>::starts_with(Needle&& needle, Cmp cmp) -> bool
+constexpr auto inline_iter_base<Derived>::starts_with(Needle&& needle, Cmp cmp) -> bool
 {
     return flux::starts_with(derived(), FLUX_FWD(needle), std::move(cmp));
 }

--- a/include/flux/algorithm/starts_with.hpp
+++ b/include/flux/algorithm/starts_with.hpp
@@ -17,7 +17,7 @@ struct starts_with_fn {
         requires std::predicate<Cmp&, element_t<Haystack>, element_t<Needle>>
     constexpr auto operator()(Haystack&& haystack, Needle&& needle, Cmp cmp = Cmp{}) const -> bool
     {
-        if constexpr (sized_sequence<Haystack> && sized_sequence<Needle>) {
+        if constexpr (sized_iterable<Haystack> && sized_iterable<Needle>) {
             if (flux::size(haystack) < flux::size(needle)) {
                 return false;
             }

--- a/include/flux/algorithm/starts_with.hpp
+++ b/include/flux/algorithm/starts_with.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 struct starts_with_fn {
-    template <sequence Haystack, sequence Needle, typename Cmp = std::ranges::equal_to>
+    template <iterable Haystack, sequence Needle, typename Cmp = std::ranges::equal_to>
         requires std::predicate<Cmp&, element_t<Haystack>, element_t<Needle>>
     constexpr auto operator()(Haystack&& haystack, Needle&& needle, Cmp cmp = Cmp{}) const -> bool
     {

--- a/include/flux/algorithm/to.hpp
+++ b/include/flux/algorithm/to.hpp
@@ -161,14 +161,14 @@ constexpr auto to(It&& it, Args&&... args)
 
 template <typename D>
 template <typename Container, typename... Args>
-constexpr auto inline_sequence_base<D>::to(Args&&... args) -> Container
+constexpr auto inline_iter_base<D>::to(Args&&... args) -> Container
 {
     return flux::to<Container>(derived(), FLUX_FWD(args)...);
 }
 
 template <typename D>
 template <template <typename...> typename Container, typename... Args>
-constexpr auto inline_sequence_base<D>::to(Args&&... args)
+constexpr auto inline_iter_base<D>::to(Args&&... args)
 {
     return flux::to<Container>(derived(), FLUX_FWD(args)...);
 }

--- a/include/flux/algorithm/to.hpp
+++ b/include/flux/algorithm/to.hpp
@@ -13,33 +13,32 @@
 namespace flux {
 
 FLUX_EXPORT
-struct from_sequence_t {
-    explicit from_sequence_t() = default;
+struct from_iterable_t {
+    explicit from_iterable_t() = default;
 };
 
-FLUX_EXPORT inline constexpr auto from_sequence = from_sequence_t{};
+FLUX_EXPORT inline constexpr auto from_iterable = from_iterable_t{};
 
 namespace detail {
 
-template <typename C, typename Seq, typename... Args>
-concept direct_sequence_constructible =
-    std::constructible_from<C, Seq, Args...>;
+template <typename C, typename It, typename... Args>
+concept direct_iterable_constructible =
+    std::constructible_from<C, It, Args...>;
 
-template <typename C, typename Seq, typename... Args>
-concept from_sequence_constructible =
-    std::constructible_from<C, from_sequence_t, Seq, Args...>;
+template <typename C, typename It, typename... Args>
+concept from_iterable_constructible =
+    std::constructible_from<C, from_iterable_t, It, Args...>;
 
 template <typename C>
 using container_value_t = typename C::value_type; // Let's just assume it exists
 
-template <sequence Seq>
+template <std::ranges::input_range Rng>
 using common_iterator_t =
-    std::ranges::iterator_t<decltype(std::views::common(FLUX_DECLVAL(Seq)))>;
+    std::ranges::iterator_t<decltype(std::views::common(FLUX_DECLVAL(Rng)))>;
 
-
-template <typename C, typename Seq, typename... Args>
+template <typename C, typename Rng, typename... Args>
 concept cpp17_range_constructible =
-    std::constructible_from<C, common_iterator_t<Seq>, common_iterator_t<Seq>, Args...>;
+    std::constructible_from<C, common_iterator_t<Rng>, common_iterator_t<Rng>, Args...>;
 
 template <typename C, typename Elem>
 concept container_insertable =
@@ -50,11 +49,10 @@ concept container_insertable =
 
 template <typename C, typename Seq, typename... Args>
 concept container_convertible =
-    direct_sequence_constructible<C, Seq, Args...> ||
-    from_sequence_constructible<C, Seq, Args...> ||
+    direct_iterable_constructible<C, Seq, Args...> ||
+    from_iterable_constructible<C, Seq, Args...> ||
     cpp17_range_constructible<C, Seq, Args...> ||
-    (  std::constructible_from<C, Args...> &&
-        container_insertable<C, element_t<Seq>>);
+    (std::constructible_from<C, Args...> && container_insertable<C, element_t<Seq>>);
 
 template <typename C>
 concept reservable_container =
@@ -75,89 +73,89 @@ constexpr auto make_inserter(C& c)
     }
 }
 
-template <template <typename...> typename C, typename Seq, typename... Args>
-using ctad_direct_seq = decltype(C(FLUX_DECLVAL(Seq), FLUX_DECLVAL(Args)...));
+template <template <typename...> typename C, typename It, typename... Args>
+using ctad_direct_iterable = decltype(C(FLUX_DECLVAL(It), FLUX_DECLVAL(Args)...));
 
-template <template <typename...> typename C, typename Seq, typename... Args>
-using ctad_from_seq = decltype((C(from_sequence, FLUX_DECLVAL(Seq), FLUX_DECLVAL(Args)...)));
+template <template <typename...> typename C, typename It, typename... Args>
+using ctad_from_iterable = decltype((C(from_iterable, FLUX_DECLVAL(It), FLUX_DECLVAL(Args)...)));
 
-template <template <typename...> typename C, typename Seq, typename... Args>
-using ctad_from_iters = decltype(C(FLUX_DECLVAL(common_iterator_t<Seq>), FLUX_DECLVAL(common_iterator_t<Seq>), FLUX_DECLVAL(Args)...));
+template <template <typename...> typename C, typename Rng, typename... Args>
+using ctad_from_iters = decltype(C(FLUX_DECLVAL(common_iterator_t<Rng>), FLUX_DECLVAL(common_iterator_t<Rng>), FLUX_DECLVAL(Args)...));
 
-template <template <typename...> typename C, typename Seq, typename... Args>
+template <template <typename...> typename C, typename It, typename... Args>
 concept can_deduce_container_type =
-    requires { typename ctad_direct_seq<C, Seq, Args...>; } ||
-    requires { typename ctad_from_seq<C, Seq, Args...>; } ||
-    requires { typename ctad_from_iters<C, Seq, Args...>; } ||
-    ( sizeof...(Args) == 0 && requires { typename C<value_t<Seq>>; });
+    requires { typename ctad_direct_iterable<C, It, Args...>; } ||
+    requires { typename ctad_from_iterable<C, It, Args...>; } ||
+    requires { typename ctad_from_iters<C, It, Args...>; } ||
+    ( sizeof...(Args) == 0 && requires { typename C<value_t<It>>; });
 
 template <typename T>
 struct type_t { using type = T; };
 
-template <template <typename...> typename C, typename Seq, typename... Args>
-    requires can_deduce_container_type<C, Seq, Args...>
+template <template <typename...> typename C, typename It, typename... Args>
+    requires can_deduce_container_type<C, It, Args...>
 consteval auto deduce_container_type()
 {
-    if constexpr (requires { typename ctad_direct_seq<C, Seq, Args...>; }) {
-        return type_t<decltype(C(FLUX_DECLVAL(Seq), FLUX_DECLVAL(Args)...))>{};
-    } else if constexpr (requires { typename ctad_from_seq<C, Seq, Args...>; }) {
-        return type_t<decltype((C(from_sequence, FLUX_DECLVAL(Seq), FLUX_DECLVAL(Args)...)))>{};
-    } else if constexpr (requires { typename ctad_from_iters<C, Seq, Args...>; }) {
-        using I = common_iterator_t<Seq>;
-        return type_t<decltype(C(FLUX_DECLVAL(I), FLUX_DECLVAL(I), FLUX_DECLVAL(Args)...))>{};
+    if constexpr (requires { typename ctad_direct_iterable<C, It, Args...>; }) {
+        return type_t<decltype(C(FLUX_DECLVAL(It), FLUX_DECLVAL(Args)...))>{};
+    } else if constexpr (requires { typename ctad_from_iterable<C, It, Args...>; }) {
+        return type_t<decltype((C(from_iterable, FLUX_DECLVAL(It), FLUX_DECLVAL(Args)...)))>{};
+    } else if constexpr (requires { typename ctad_from_iters<C, It, Args...>; }) {
+        using CI = common_iterator_t<It>;
+        return type_t<decltype(C(FLUX_DECLVAL(CI), FLUX_DECLVAL(CI), FLUX_DECLVAL(Args)...))>{};
     } else {
-        static_assert(requires { typename C<value_t<Seq>>; });
-        return type_t<C<value_t<Seq>>>{};
+        static_assert(requires { typename C<value_t<It>>; });
+        return type_t<C<value_t<It>>>{};
     }
 }
 
-template <template <typename...> typename C, typename Seq, typename... Args>
-    requires can_deduce_container_type<C, Seq, Args...>
-using deduced_container_t = typename decltype(deduce_container_type<C, Seq, Args...>())::type;
+template <template <typename...> typename C, typename It, typename... Args>
+    requires can_deduce_container_type<C, It, Args...>
+using deduced_container_t = typename decltype(deduce_container_type<C, It, Args...>())::type;
 
 
 } // namespace detail
 
 FLUX_EXPORT
-template <typename Container, sequence Seq, typename... Args>
-    requires (std::convertible_to<element_t<Seq>, detail::container_value_t<Container>> &&
-                 detail::container_convertible<Container, Seq, Args...>) ||
-             sequence<element_t<Seq>>
-constexpr auto to(Seq&& seq, Args&&... args) -> Container
+template <typename Container, iterable It, typename... Args>
+    requires (std::convertible_to<element_t<It>, detail::container_value_t<Container>> &&
+                 detail::container_convertible<Container, It, Args...>) ||
+             iterable<element_t<It>>
+constexpr auto to(It&& it, Args&&... args) -> Container
 {
-    if constexpr (std::convertible_to<element_t<Seq>, detail::container_value_t<Container>>) {
-        if constexpr (detail::direct_sequence_constructible<Container, Seq, Args...>) {
-            return Container(FLUX_FWD(seq), FLUX_FWD(args)...);
-        } else if constexpr (detail::from_sequence_constructible<Container, Seq, Args...>) {
-            return Container(from_sequence, FLUX_FWD(seq), FLUX_FWD(args)...);
-        } else if constexpr (detail::cpp17_range_constructible<Container, Seq, Args...>) {
-            auto view_ = std::views::common(FLUX_FWD(seq));
+    if constexpr (std::convertible_to<element_t<It>, detail::container_value_t<Container>>) {
+        if constexpr (detail::direct_iterable_constructible<Container, It, Args...>) {
+            return Container(FLUX_FWD(it), FLUX_FWD(args)...);
+        } else if constexpr (detail::from_iterable_constructible<Container, It, Args...>) {
+            return Container(from_iterable, FLUX_FWD(it), FLUX_FWD(args)...);
+        } else if constexpr (std::ranges::input_range<It> && detail::cpp17_range_constructible<Container, It, Args...>) {
+            auto view_ = std::views::common(FLUX_FWD(it));
             return Container(view_.begin(), view_.end(), FLUX_FWD(args)...);
         } else {
             auto c = Container(FLUX_FWD(args)...);
-            if constexpr (sized_sequence<Seq> && detail::reservable_container<Container>) {
-                c.reserve(flux::usize(seq));
+            if constexpr (sized_sequence<It> && detail::reservable_container<Container>) {
+                c.reserve(flux::usize(it));
             }
-            flux::output_to(seq, detail::make_inserter<element_t<Seq>>(c));
+            flux::output_to(it, detail::make_inserter<element_t<It>>(c));
             return c;
         }
     } else {
-        static_assert(sequence<element_t<Seq>>);
-        return flux::to<Container>(flux::map(flux::from_fwd_ref(FLUX_FWD(seq)), [](auto&& elem) {
+        static_assert(iterable<element_t<It>>);
+        return flux::to<Container>(flux::map(flux::from_fwd_ref(FLUX_FWD(it)), [](auto&& elem) {
             return flux::to<detail::container_value_t<Container>>(FLUX_FWD(elem));
         }), FLUX_FWD(args)...);
     }
 }
 
 FLUX_EXPORT
-template <template <typename...> typename Container, sequence Seq, typename... Args>
-    requires detail::can_deduce_container_type<Container, Seq, Args...> &&
+template <template <typename...> typename Container, iterable It, typename... Args>
+    requires detail::can_deduce_container_type<Container, It, Args...> &&
              detail::container_convertible<
-                 detail::deduced_container_t<Container, Seq, Args...>, Seq, Args...>
-constexpr auto to(Seq&& seq, Args&&... args)
+                 detail::deduced_container_t<Container, It, Args...>, It, Args...>
+constexpr auto to(It&& it, Args&&... args)
 {
-    using C_ = detail::deduced_container_t<Container, Seq, Args...>;
-    return flux::to<C_>(FLUX_FWD(seq), FLUX_FWD(args)...);
+    using C_ = detail::deduced_container_t<Container, It, Args...>;
+    return flux::to<C_>(FLUX_FWD(it), FLUX_FWD(args)...);
 }
 
 

--- a/include/flux/algorithm/to.hpp
+++ b/include/flux/algorithm/to.hpp
@@ -133,7 +133,7 @@ constexpr auto to(It&& it, Args&&... args) -> Container
             return Container(view_.begin(), view_.end(), FLUX_FWD(args)...);
         } else {
             auto c = Container(FLUX_FWD(args)...);
-            if constexpr (sized_sequence<It> && detail::reservable_container<Container>) {
+            if constexpr (sized_iterable<It> && detail::reservable_container<Container>) {
                 c.reserve(flux::usize(it));
             }
             flux::output_to(it, detail::make_inserter<element_t<It>>(c));

--- a/include/flux/algorithm/write_to.hpp
+++ b/include/flux/algorithm/write_to.hpp
@@ -16,22 +16,22 @@ namespace detail {
 
 struct write_to_fn {
 
-    template <sequence Seq, typename OStream>
+    template <iterable It, typename OStream>
         requires std::derived_from<OStream, std::ostream>
-    auto operator()(Seq&& seq, OStream& os) const
+    auto operator()(It&& it, OStream& os) const
         -> std::ostream&
     {
         bool first = true;
         os << '[';
 
-        flux::for_each(FLUX_FWD(seq), [&os, &first](auto&& elem) {
+        flux::for_each(it, [&os, &first](auto&& elem) {
             if (first) {
                 first = false;
             } else {
                 os << ", ";
             }
 
-            if constexpr (sequence<element_t<Seq>>) {
+            if constexpr (iterable<element_t<It>>) {
                 write_to_fn{}(FLUX_FWD(elem), os);
             } else {
                 os << FLUX_FWD(elem);

--- a/include/flux/algorithm/write_to.hpp
+++ b/include/flux/algorithm/write_to.hpp
@@ -48,7 +48,7 @@ struct write_to_fn {
 FLUX_EXPORT inline constexpr auto write_to = detail::write_to_fn{};
 
 template <typename Derived>
-auto inline_sequence_base<Derived>::write_to(std::ostream& os) -> std::ostream&
+auto inline_iter_base<Derived>::write_to(std::ostream& os) -> std::ostream&
 {
     return flux::write_to(derived(), os);
 }

--- a/include/flux/core.hpp
+++ b/include/flux/core.hpp
@@ -9,7 +9,7 @@
 #include <flux/core/concepts.hpp>
 #include <flux/core/default_impls.hpp>
 #include <flux/core/functional.hpp>
-#include <flux/core/inline_sequence_base.hpp>
+#include <flux/core/inline_iter_base.hpp>
 #include <flux/core/numeric.hpp>
 #include <flux/core/operation_requirements.hpp>
 #include <flux/core/optional.hpp>

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -269,17 +269,17 @@ concept contiguous_sequence =
 
 namespace detail {
 
-template <typename Seq, typename Traits = sequence_traits<std::remove_cvref_t<Seq>>>
-concept sized_sequence_requirements =
-    requires (Seq& seq) {
-        { Traits::size(seq) } -> std::convertible_to<distance_t>;
+template <typename It, typename Traits = sequence_traits<std::remove_cvref_t<It>>>
+concept sized_iterable_requirements =
+    requires (It& it) {
+        { Traits::size(it) } -> std::convertible_to<distance_t>;
     };
 
 } // namespace detail
 
 FLUX_EXPORT
-template <typename Seq>
-concept sized_sequence = sequence<Seq> && detail::sized_sequence_requirements<Seq>;
+template <typename It>
+concept sized_iterable = iterable<It> && detail::sized_iterable_requirements<It>;
 
 FLUX_EXPORT
 template <typename It, typename T>
@@ -333,7 +333,7 @@ concept const_iterable =
     (random_access_sequence<It> == random_access_sequence<It const>) &&
     (contiguous_sequence<It> == contiguous_sequence<It const>) &&
     (bounded_sequence<It> == bounded_sequence<It const>) &&
-    (sized_sequence<It> == sized_sequence<It const>) &&
+    (sized_iterable<It> == sized_iterable<It const>) &&
     (infinite_sequence<It> == infinite_sequence<It const>) &&
     // If Seq is read-only, Seq const must be read-only as well
     (!read_only_iterable<It> || read_only_iterable<It const>);

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -358,7 +358,26 @@ concept trivially_copyable_sequence =
     std::is_trivially_copyable_v<Seq> &&
     sequence<Seq>;
 
+template <typename It>
+concept rvalue_iterable =
+    std::is_object_v<It> &&
+    std::move_constructible<It> &&
+    iterable<It>;
+
+template <typename It>
+concept trivially_copyable_lvalue_iterable =
+    std::is_lvalue_reference_v<It> &&
+    std::copyable<std::decay_t<It>> &&
+    std::is_trivially_copyable_v<std::decay_t<It>> &&
+    iterable<std::decay_t<It>>;
+
 }
+
+FLUX_EXPORT
+template <typename It>
+concept sink_iterable =
+    (detail::rvalue_iterable<It> || detail::trivially_copyable_lvalue_iterable<It>)
+    && !detail::is_ilist<It>;
 
 FLUX_EXPORT
 template <typename Seq>

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -52,7 +52,7 @@ concept ordered_cursor =
 
 FLUX_EXPORT
 template <typename T>
-struct sequence_traits;
+struct iter_traits;
 
 FLUX_EXPORT
 struct default_sequence_traits;
@@ -60,7 +60,7 @@ struct default_sequence_traits;
 namespace detail {
 
 template <typename T>
-using traits_t = sequence_traits<std::remove_cvref_t<T>>;
+using traits_t = iter_traits<std::remove_cvref_t<T>>;
 
 } // namespace detail
 
@@ -126,7 +126,7 @@ concept can_reference = requires { typename with_ref<T>; };
 template <typename E>
 using predicate_archetype = bool (*)(E);
 
-template <typename T, typename Traits = sequence_traits<std::remove_cvref_t<T>>>
+template <typename T, typename Traits = iter_traits<std::remove_cvref_t<T>>>
 concept iterable_concept =
     requires (T& self) {
         { Traits::element_type(self) } -> can_reference;
@@ -140,7 +140,7 @@ concept iterable_concept =
 #endif
     ;
 
-template <typename Seq, typename Traits = sequence_traits<std::remove_cvref_t<Seq>>>
+template <typename Seq, typename Traits = iter_traits<std::remove_cvref_t<Seq>>>
 concept sequence_requirements =
     requires (Seq& seq) {
         { Traits::first(seq) } -> cursor;
@@ -153,7 +153,7 @@ concept sequence_requirements =
         { Traits::inc(seq, cur) };
     };
 
-template <typename Seq, typename Traits = sequence_traits<std::remove_cvref_t<Seq>>>
+template <typename Seq, typename Traits = iter_traits<std::remove_cvref_t<Seq>>>
 concept sequence_concept =
     sequence_requirements<Seq> &&
     requires (Seq& seq, cursor_t<Seq> const& cur) {
@@ -202,7 +202,7 @@ concept multipass_sequence =
 
 namespace detail {
 
-template <typename Seq, typename Traits = sequence_traits<std::remove_cvref_t<Seq>>>
+template <typename Seq, typename Traits = iter_traits<std::remove_cvref_t<Seq>>>
 concept bidirectional_sequence_requirements =
     requires (Seq& seq, cursor_t<Seq>& cur) {
         { Traits::dec(seq, cur) };
@@ -216,7 +216,7 @@ concept bidirectional_sequence = multipass_sequence<Seq> && detail::bidirectiona
 
 namespace detail {
 
-template <typename Seq, typename Traits = sequence_traits<std::remove_cvref_t<Seq>>>
+template <typename Seq, typename Traits = iter_traits<std::remove_cvref_t<Seq>>>
 concept random_access_sequence_requirements =
     ordered_cursor<cursor_t<Seq>> &&
     requires (Seq& seq, cursor_t<Seq>& cur, distance_t offset) {
@@ -236,7 +236,7 @@ concept random_access_sequence =
 
 namespace detail {
 
-template <typename Seq, typename Traits = sequence_traits<std::remove_cvref_t<Seq>>>
+template <typename Seq, typename Traits = iter_traits<std::remove_cvref_t<Seq>>>
 concept bounded_sequence_requirements =
     requires (Seq& seq) {
         { Traits::last(seq) } -> std::same_as<cursor_t<Seq>>;
@@ -250,7 +250,7 @@ concept bounded_sequence = sequence<Seq> && detail::bounded_sequence_requirement
 
 namespace detail {
 
-template <typename Seq, typename Traits = sequence_traits<std::remove_cvref_t<Seq>>>
+template <typename Seq, typename Traits = iter_traits<std::remove_cvref_t<Seq>>>
 concept contiguous_sequence_requirements =
     std::is_lvalue_reference_v<element_t<Seq>> &&
     std::same_as<value_t<Seq>, std::remove_cvref_t<element_t<Seq>>> &&
@@ -269,7 +269,7 @@ concept contiguous_sequence =
 
 namespace detail {
 
-template <typename It, typename Traits = sequence_traits<std::remove_cvref_t<It>>>
+template <typename It, typename Traits = iter_traits<std::remove_cvref_t<It>>>
 concept sized_iterable_requirements =
     requires (It& it) {
         { Traits::size(it) } -> std::convertible_to<distance_t>;
@@ -523,7 +523,7 @@ concept has_nested_sequence_traits =
 
 template <typename T>
     requires detail::has_nested_sequence_traits<T>
-struct sequence_traits<T> : T::flux_sequence_traits {};
+struct iter_traits<T> : T::flux_sequence_traits {};
 
 namespace detail {
 

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -308,33 +308,35 @@ concept infinite_sequence =
     detail::is_infinite_seq<detail::traits_t<Seq>>;
 
 FLUX_EXPORT
-template <typename Seq>
-concept read_only_sequence =
-    sequence<Seq> &&
-    std::same_as<element_t<Seq>, const_element_t<Seq>>;
+template <typename It>
+concept read_only_iterable =
+    iterable<It> &&
+    std::same_as<element_t<It>, const_element_t<It>>;
 
 FLUX_EXPORT
-template <typename Seq>
-concept const_iterable_sequence =
-    // Seq and Seq const must both be sequences
-    sequence<Seq> && sequence<Seq const> &&
-    // Seq and Seq const must have the same cursor and value types
-    std::same_as<cursor_t<Seq>, cursor_t<Seq const>> &&
-    std::same_as<value_t<Seq>, value_t<Seq const>> &&
-    // Seq and Seq const must have the same const_element type
+template <typename It>
+concept const_iterable =
+    // It and It const must both be iterable
+    iterable<It> && iterable<It const> &&
+    // It and It const must have the same value type
+    std::same_as<value_t<It>, value_t<It const>> &&
+    // It and It const must have the same const_element type
 #ifdef FLUX_HAVE_CPP23_TUPLE_COMMON_REF
-    std::same_as<const_element_t<Seq>, const_element_t<Seq const>> &&
+    std::same_as<const_element_t<It>, const_element_t<It const>> &&
 #endif
-    // Seq and Seq const must model the same extended sequence concepts
-    (multipass_sequence<Seq> == multipass_sequence<Seq const>) &&
-    (bidirectional_sequence<Seq> == bidirectional_sequence<Seq const>) &&
-    (random_access_sequence<Seq> == random_access_sequence<Seq const>) &&
-    (contiguous_sequence<Seq> == contiguous_sequence<Seq const>) &&
-    (bounded_sequence<Seq> == bounded_sequence<Seq const>) &&
-    (sized_sequence<Seq> == sized_sequence<Seq const>) &&
-    (infinite_sequence<Seq> == infinite_sequence<Seq const>) &&
+    // It and It const must model the same extended sequence concepts,
+    // and if they are sequences they must have the same cursor type
+    (sequence<It> == sequence<It const>) &&
+    (!sequence<It> || (std::same_as<cursor_t<It>, cursor_t<It const>>)) &&
+    (multipass_sequence<It> == multipass_sequence<It const>) &&
+    (bidirectional_sequence<It> == bidirectional_sequence<It const>) &&
+    (random_access_sequence<It> == random_access_sequence<It const>) &&
+    (contiguous_sequence<It> == contiguous_sequence<It const>) &&
+    (bounded_sequence<It> == bounded_sequence<It const>) &&
+    (sized_sequence<It> == sized_sequence<It const>) &&
+    (infinite_sequence<It> == infinite_sequence<It const>) &&
     // If Seq is read-only, Seq const must be read-only as well
-    (!read_only_sequence<Seq> || read_only_sequence<Seq const>);
+    (!read_only_iterable<It> || read_only_iterable<It const>);
 
 namespace detail {
 

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -282,11 +282,11 @@ template <typename Seq>
 concept sized_sequence = sequence<Seq> && detail::sized_sequence_requirements<Seq>;
 
 FLUX_EXPORT
-template <typename Seq, typename T>
-concept writable_sequence_of =
-    sequence<Seq> &&
-    requires (element_t<Seq> elem, T&& item) {
-        { elem = FLUX_FWD(item) } -> std::same_as<element_t<Seq>&>;
+template <typename It, typename T>
+concept writable_iterable_of =
+    iterable<It> &&
+    requires (element_t<It> (*elem)(), T&& item) {
+        { elem() = FLUX_FWD(item) } -> std::same_as<element_t<It>&>;
     };
 
 namespace detail {

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -389,13 +389,13 @@ concept adaptable_sequence =
 
 FLUX_EXPORT
 template <typename D>
-struct inline_sequence_base;
+struct inline_iter_base;
 
 namespace detail {
 
 template <typename T, typename U>
-    requires (!std::same_as<T, inline_sequence_base<U>>)
-void derived_from_inline_sequence_base_test(T const&, inline_sequence_base<U> const&);
+    requires (!std::same_as<T, inline_iter_base<U>>)
+void derived_from_inline_sequence_base_test(T const&, inline_iter_base<U> const&);
 
 template <typename T>
 concept derived_from_inline_sequence_base = requires(T t) {

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -55,7 +55,7 @@ template <typename T>
 struct iter_traits;
 
 FLUX_EXPORT
-struct default_sequence_traits;
+struct default_iter_traits;
 
 namespace detail {
 
@@ -409,7 +409,7 @@ concept derived_from_inline_sequence_base = requires(T t) {
  * Default sequence_traits implementation
  */
 
-struct default_sequence_traits {
+struct default_iter_traits {
 
     template <typename Self>
         requires detail::sequence_requirements<Self>
@@ -515,15 +515,15 @@ struct default_sequence_traits {
 namespace detail {
 
 template <typename T>
-concept has_nested_sequence_traits =
-    requires { typename T::flux_sequence_traits; } &&
-    std::is_class_v<typename T::flux_sequence_traits>;
+concept has_nested_iter_traits =
+    requires { typename T::flux_iter_traits; } &&
+    std::is_class_v<typename T::flux_iter_traits>;
 
 }
 
 template <typename T>
-    requires detail::has_nested_sequence_traits<T>
-struct iter_traits<T> : T::flux_sequence_traits {};
+    requires detail::has_nested_iter_traits<T>
+struct iter_traits<T> : T::flux_iter_traits {};
 
 namespace detail {
 

--- a/include/flux/core/concepts.hpp
+++ b/include/flux/core/concepts.hpp
@@ -427,7 +427,7 @@ struct default_iter_traits {
         if constexpr (bounded_sequence<Self> && regular_cursor<cursor_t<Self>>) {
             auto const last = Traits::last(self);
             while (cur != last) {
-                if (!std::invoke(pred, Traits::read_at(self, cur))) {
+                if (!std::invoke(pred, Traits::read_at_unchecked(self, cur))) {
                     return false;
                 }
                 Traits::inc(self, cur);

--- a/include/flux/core/default_impls.hpp
+++ b/include/flux/core/default_impls.hpp
@@ -18,7 +18,7 @@ namespace flux {
  * Default implementation for C arrays of known bound
  */
 template <typename T, index_t N>
-struct iter_traits<T[N]> : default_sequence_traits {
+struct iter_traits<T[N]> : default_iter_traits {
 
     static constexpr auto first(auto const&) -> index_t { return index_t{0}; }
 
@@ -82,7 +82,7 @@ struct iter_traits<T[N]> : default_sequence_traits {
  * Default implementation for std::reference_wrapper<T>
  */
 template <iterable Seq>
-struct iter_traits<std::reference_wrapper<Seq>> : default_sequence_traits {
+struct iter_traits<std::reference_wrapper<Seq>> : default_iter_traits {
 
     using self_t = std::reference_wrapper<Seq>;
 
@@ -183,7 +183,7 @@ concept contiguous_sized_range = std::ranges::contiguous_range<R> && std::ranges
 template <typename R>
     requires (!detail::derived_from_inline_sequence_base<R> &&
                std::ranges::input_range<R>)
-struct iter_traits<R> : default_sequence_traits {
+struct iter_traits<R> : default_iter_traits {
 
     using value_type = std::ranges::range_value_t<R>;
 

--- a/include/flux/core/default_impls.hpp
+++ b/include/flux/core/default_impls.hpp
@@ -18,7 +18,7 @@ namespace flux {
  * Default implementation for C arrays of known bound
  */
 template <typename T, index_t N>
-struct sequence_traits<T[N]> : default_sequence_traits {
+struct iter_traits<T[N]> : default_sequence_traits {
 
     static constexpr auto first(auto const&) -> index_t { return index_t{0}; }
 
@@ -82,7 +82,7 @@ struct sequence_traits<T[N]> : default_sequence_traits {
  * Default implementation for std::reference_wrapper<T>
  */
 template <iterable Seq>
-struct sequence_traits<std::reference_wrapper<Seq>> : default_sequence_traits {
+struct iter_traits<std::reference_wrapper<Seq>> : default_sequence_traits {
 
     using self_t = std::reference_wrapper<Seq>;
 
@@ -183,7 +183,7 @@ concept contiguous_sized_range = std::ranges::contiguous_range<R> && std::ranges
 template <typename R>
     requires (!detail::derived_from_inline_sequence_base<R> &&
                std::ranges::input_range<R>)
-struct sequence_traits<R> : default_sequence_traits {
+struct iter_traits<R> : default_sequence_traits {
 
     using value_type = std::ranges::range_value_t<R>;
 

--- a/include/flux/core/default_impls.hpp
+++ b/include/flux/core/default_impls.hpp
@@ -194,6 +194,12 @@ struct sequence_traits<R> : default_sequence_traits {
         return true;
     }
 
+    template <std::ranges::sized_range Self>
+    static constexpr auto size(Self& self) -> distance_t
+    {
+        return num::cast<distance_t>(std::ranges::ssize(self));
+    }
+
     template <detail::contiguous_sized_range Self>
     static constexpr auto first(Self&) -> index_t { return index_t{0}; }
 
@@ -247,12 +253,6 @@ struct sequence_traits<R> : default_sequence_traits {
     static constexpr auto distance(Self&, index_t from, index_t to) -> distance_t
     {
         return num::sub(to, from);
-    }
-
-    template <detail::contiguous_sized_range Self>
-    static constexpr auto size(Self& self) -> distance_t
-    {
-        return num::cast<distance_t>(std::ranges::ssize(self));
     }
 
     template <detail::contiguous_sized_range Self>

--- a/include/flux/core/default_impls.hpp
+++ b/include/flux/core/default_impls.hpp
@@ -81,7 +81,7 @@ struct sequence_traits<T[N]> : default_sequence_traits {
 /*
  * Default implementation for std::reference_wrapper<T>
  */
-template <sequence Seq>
+template <iterable Seq>
 struct sequence_traits<std::reference_wrapper<Seq>> : default_sequence_traits {
 
     using self_t = std::reference_wrapper<Seq>;
@@ -89,6 +89,13 @@ struct sequence_traits<std::reference_wrapper<Seq>> : default_sequence_traits {
     using value_type = value_t<Seq>;
 
     static constexpr bool disable_multipass = !multipass_sequence<Seq>;
+
+    static consteval auto element_type(self_t) -> element_t<Seq>;
+
+    static constexpr auto iterate(self_t self, auto&& pred) -> bool
+    {
+        return flux::iterate(self.get(), FLUX_FWD(pred));
+    }
 
     static constexpr auto first(self_t self) -> cursor_t<Seq>
     {

--- a/include/flux/core/default_impls.hpp
+++ b/include/flux/core/default_impls.hpp
@@ -165,72 +165,104 @@ struct sequence_traits<std::reference_wrapper<Seq>> : default_sequence_traits {
     }
 };
 
-// Default implementation for contiguous, sized ranges
+namespace detail {
+
+template <typename R>
+concept contiguous_sized_range = std::ranges::contiguous_range<R> && std::ranges::sized_range<R>;
+
+}
+
+// Default implementation for ranges
 template <typename R>
     requires (!detail::derived_from_inline_sequence_base<R> &&
-             std::ranges::contiguous_range<R> &&
-             std::ranges::sized_range<R> &&
-             std::ranges::contiguous_range<R const> &&
-             std::ranges::sized_range<R const>)
+               std::ranges::input_range<R>)
 struct sequence_traits<R> : default_sequence_traits {
 
     using value_type = std::ranges::range_value_t<R>;
 
-    static constexpr auto first(auto&) -> index_t { return index_t{0}; }
+    template <std::ranges::input_range Self>
+    static consteval auto element_type(Self&) -> std::ranges::range_reference_t<Self>;
 
-    static constexpr auto is_last(auto& self, index_t idx)
+    template <std::ranges::input_range Self, typename Pred>
+    static constexpr auto iterate(Self& self, Pred&& pred) -> bool
+    {
+        for (auto&& elem : self) {
+            if (!std::invoke(pred, FLUX_FWD(elem))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto first(Self&) -> index_t { return index_t{0}; }
+
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto is_last(Self& self, index_t idx) -> bool
     {
         return idx >= size(self);
     }
 
-    static constexpr auto inc(auto& self, index_t& idx)
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto inc(Self& self, index_t& idx) -> void
     {
         FLUX_DEBUG_ASSERT(idx < size(self));
         idx = num::add(idx, distance_t{1});
     }
 
-    static constexpr auto read_at(auto& self, index_t idx) -> decltype(auto)
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto read_at(Self& self, index_t idx)
+        -> std::ranges::range_reference_t<Self>
     {
         indexed_bounds_check(idx, size(self));
         return data(self)[idx];
     }
 
-    static constexpr auto read_at_unchecked(auto& self, index_t idx) -> decltype(auto)
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto read_at_unchecked(Self& self, index_t idx)
+        -> std::ranges::range_reference_t<Self>
     {
         return data(self)[idx];
     }
 
-    static constexpr auto dec(auto&, index_t& idx)
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto dec(Self&, index_t& idx) -> void
     {
         FLUX_DEBUG_ASSERT(idx > 0);
         idx = num::sub(idx, distance_t{1});
     }
 
-    static constexpr auto last(auto& self) -> index_t { return size(self); }
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto last(Self& self) -> index_t { return size(self); }
 
-    static constexpr auto inc(auto& self, index_t& idx, distance_t offset)
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto inc(Self& self, index_t& idx, distance_t offset) -> void
     {
         FLUX_DEBUG_ASSERT(num::add(idx, offset) <= size(self));
         FLUX_DEBUG_ASSERT(num::add(idx, offset) >= 0);
         idx = num::add(idx, offset);
     }
 
-    static constexpr auto distance(auto&, index_t from, index_t to) -> distance_t
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto distance(Self&, index_t from, index_t to) -> distance_t
     {
         return num::sub(to, from);
     }
 
-    static constexpr auto size(auto& self) -> distance_t
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto size(Self& self) -> distance_t
     {
         return num::cast<distance_t>(std::ranges::ssize(self));
     }
 
-    static constexpr auto data(auto& self) -> auto*
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto data(Self& self) -> auto*
     {
         return std::ranges::data(self);
     }
 
-    static constexpr auto for_each_while(auto& self, auto&& pred) -> index_t
+    template <detail::contiguous_sized_range Self>
+    static constexpr auto for_each_while(Self& self, auto&& pred) -> index_t
     {
         auto iter = std::ranges::begin(self);
         auto const end = std::ranges::end(self);

--- a/include/flux/core/default_impls.hpp
+++ b/include/flux/core/default_impls.hpp
@@ -153,7 +153,7 @@ struct sequence_traits<std::reference_wrapper<Seq>> : default_sequence_traits {
     }
 
     static constexpr auto size(self_t self) -> distance_t
-        requires sized_sequence<Seq>
+        requires sized_iterable<Seq>
     {
         return flux::size(self.get());
     }

--- a/include/flux/core/inline_iter_base.hpp
+++ b/include/flux/core/inline_iter_base.hpp
@@ -40,35 +40,59 @@ public:
 
     /// Returns a cursor pointing to the first element of the sequence
     [[nodiscard]]
-    constexpr auto first() { return flux::first(derived()); }
+    constexpr auto first()
+        requires sequence<Derived>
+    {
+        return flux::first(derived());
+    }
 
     /// Returns true if `cur` points to the end of the sequence
     ///
     /// @param cur The cursor to test
     template <std::same_as<Derived> D = Derived>
+        requires sequence<Derived>
     [[nodiscard]]
-    constexpr bool is_last(cursor_t<D> const& cur) { return flux::is_last(derived(), cur); }
+    constexpr bool is_last(cursor_t<D> const& cur)
+    {
+        return flux::is_last(derived(), cur);
+    }
 
     /// Increments the given cursor
     ///
     /// @param cur the cursor to increment
     template <std::same_as<Derived> D = Derived>
-    constexpr auto& inc(cursor_t<D>& cur) { return flux::inc(derived(), cur); }
+        requires sequence<Derived>
+    constexpr auto& inc(cursor_t<D>& cur)
+    {
+        return flux::inc(derived(), cur);
+    }
 
     /// Returns the element at the given cursor
     template <std::same_as<Derived> D = Derived>
+        requires sequence<Derived>
     [[nodiscard]]
-    constexpr decltype(auto) read_at(cursor_t<D> const& cur) { return flux::read_at(derived(), cur); }
+    constexpr decltype(auto) read_at(cursor_t<D> const& cur)
+    {
+        return flux::read_at(derived(), cur);
+    }
 
     /// Returns an rvalue version of the element at the given cursor
     template <std::same_as<Derived> D = Derived>
+        requires sequence<Derived>
     [[nodiscard]]
-    constexpr decltype(auto) move_at(cursor_t<D> const& cur) { return flux::move_at(derived(), cur); }
+    constexpr decltype(auto) move_at(cursor_t<D> const& cur)
+    {
+        return flux::move_at(derived(), cur);
+    }
 
     /// Returns the element at the given cursor
     template <std::same_as<Derived> D = Derived>
+        requires sequence<Derived>
     [[nodiscard]]
-    constexpr decltype(auto) operator[](cursor_t<D> const& cur) { return flux::read_at(derived(), cur); }
+    constexpr decltype(auto) operator[](cursor_t<D> const& cur)
+    {
+        return flux::read_at(derived(), cur);
+    }
 
     /// Returns an cursor pointing to one past the last element of the sequence
     [[nodiscard]]
@@ -138,8 +162,12 @@ public:
     }
 
     template <std::same_as<Derived> D = Derived>
+        requires sequence<Derived>
     [[nodiscard]]
-    constexpr auto next(cursor_t<D> cur) { return flux::next(derived(), cur); }
+    constexpr auto next(cursor_t<D> cur)
+    {
+        return flux::next(derived(), cur);
+    }
 
     template <std::same_as<Derived> D = Derived>
         requires bidirectional_sequence<Derived>
@@ -209,11 +237,13 @@ public:
     /*
      * Iterator support
      */
-    constexpr auto begin() &;
+    constexpr auto begin() &
+        requires sequence<Derived>;
 
     constexpr auto begin() const& requires sequence<Derived const>;
 
-    constexpr auto end() &;
+    constexpr auto end() &
+        requires sequence<Derived>;
 
     constexpr auto end() const& requires sequence<Derived const>;
 
@@ -242,7 +272,8 @@ public:
                      (multipass_sequence<Derived> && not infinite_sequence<Derived>);
 
     [[nodiscard]]
-    constexpr auto chunk(num::integral auto chunk_sz) &&;
+    constexpr auto chunk(num::integral auto chunk_sz) &&
+        requires sequence<Derived>;
 
     template <typename Pred>
         requires multipass_sequence<Derived> &&
@@ -291,16 +322,14 @@ public:
     constexpr auto flatten() && requires iterable<element_t<Derived>>;
 
     template <adaptable_sequence Pattern>
-        requires sequence<element_t<Derived>> &&
-                 multipass_sequence<Pattern> &&
-                 detail::flatten_with_compatible<element_t<Derived>, Pattern>
+        requires iterable<element_t<Derived>> && multipass_sequence<Pattern>
+        && detail::flatten_with_compatible<element_t<Derived>, Pattern>
     [[nodiscard]]
     constexpr auto flatten_with(Pattern&& pattern) &&;
 
-
     template <typename Value>
-        requires sequence<element_t<Derived>> &&
-                 std::constructible_from<value_t<element_t<Derived>>, Value&&>
+        requires iterable<element_t<Derived>>
+        && std::constructible_from<value_t<element_t<Derived>>, Value&&>
     [[nodiscard]]
     constexpr auto flatten_with(Value value) &&;
 
@@ -368,7 +397,8 @@ public:
 
     template <typename Pattern>
     [[nodiscard]]
-    constexpr auto split_string(Pattern&& pattern) &&;
+    constexpr auto split_string(Pattern&& pattern) &&
+        requires multipass_sequence<Derived>;
 
     [[nodiscard]]
     constexpr auto stride(num::integral auto by) &&;
@@ -411,9 +441,9 @@ public:
     constexpr auto count_if(Pred pred);
 
     template <sequence Needle, typename Cmp = std::ranges::equal_to>
-        requires std::predicate<Cmp&, element_t<Derived>, element_t<Needle>> &&
-                 (multipass_sequence<Derived> || sized_iterable<Derived>) &&
-                 (multipass_sequence<Needle> || sized_iterable<Needle>)
+        requires sequence<Derived> && std::predicate<Cmp&, element_t<Derived>, element_t<Needle>>
+        && (multipass_sequence<Derived> || sized_iterable<Derived>)
+        && (multipass_sequence<Needle> || sized_iterable<Needle>)
     constexpr auto ends_with(Needle&& needle, Cmp cmp = {}) -> bool;
 
     template <typename Value>
@@ -422,32 +452,33 @@ public:
 
     /// Returns a cursor pointing to the first occurrence of `value` in the sequence
     template <typename Value>
-        requires std::equality_comparable_with<element_t<Derived>, Value const&>
+        requires sequence<Derived>
+        && std::equality_comparable_with<element_t<Derived>, Value const&>
     [[nodiscard]]
     constexpr auto find(Value const&);
 
     template <typename Pred>
-        requires std::predicate<Pred&, element_t<Derived>>
+        requires sequence<Derived> && std::predicate<Pred&, element_t<Derived>>
     [[nodiscard]]
     constexpr auto find_if(Pred pred);
 
     template <typename Pred>
-        requires std::predicate<Pred&, element_t<Derived>>
+        requires sequence<Derived> && std::predicate<Pred&, element_t<Derived>>
     [[nodiscard]]
     constexpr auto find_if_not(Pred pred);
 
     template <typename Cmp = std::compare_three_way>
-        requires weak_ordering_for<Cmp, Derived>
+        requires sequence<Derived> && weak_ordering_for<Cmp, Derived>
     [[nodiscard]]
     constexpr auto find_max(Cmp cmp = Cmp{});
 
     template <typename Cmp = std::compare_three_way>
-        requires weak_ordering_for<Cmp, Derived>
+        requires sequence<Derived> && weak_ordering_for<Cmp, Derived>
     [[nodiscard]]
     constexpr auto find_min(Cmp cmp = Cmp{});
 
     template <typename Cmp = std::compare_three_way>
-        requires weak_ordering_for<Cmp, Derived>
+        requires sequence<Derived> && weak_ordering_for<Cmp, Derived>
     [[nodiscard]]
     constexpr auto find_minmax(Cmp cmp = Cmp{});
 

--- a/include/flux/core/inline_iter_base.hpp
+++ b/include/flux/core/inline_iter_base.hpp
@@ -3,8 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef FLUX_CORE_INLINE_SEQUENCE_BASE_HPP_INCLUDED
-#define FLUX_CORE_INLINE_SEQUENCE_BASE_HPP_INCLUDED
+#ifndef FLUX_CORE_INLINE_ITER_BASE_HPP_INCLUDED
+#define FLUX_CORE_INLINE_ITER_BASE_HPP_INCLUDED
 
 #include <flux/core/sequence_access.hpp>
 #include <flux/core/operation_requirements.hpp>
@@ -28,7 +28,7 @@ template <sequence Seq>
 using bounds_t = bounds<cursor_t<Seq>>;
 
 template <typename Derived>
-struct inline_sequence_base {
+struct inline_iter_base {
 private:
     constexpr auto derived() -> Derived& { return static_cast<Derived&>(*this); }
     constexpr auto derived() const -> Derived const& { return static_cast<Derived const&>(*this); }
@@ -522,4 +522,4 @@ public:
 
 } // namespace flux
 
-#endif // FLUX_CORE_SEQUENCE_IFACE_HPP_INCLUDED
+#endif // FLUX_CORE_INLINE_ITER_BASE_HPP_INCLUDED

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -386,13 +386,11 @@ public:
      */
 
     /// Returns `true` if every element of the sequence satisfies the predicate
-    template <typename Pred>
-        requires std::predicate<Pred&, element_t<Derived>>
+    template <predicate_for<Derived> Pred>
     [[nodiscard]]
     constexpr auto all(Pred pred);
 
-    template <typename Pred>
-        requires std::predicate<Pred&, element_t<Derived>>
+    template <predicate_for<Derived> Pred>
     [[nodiscard]]
     constexpr auto any(Pred pred);
 
@@ -484,8 +482,7 @@ public:
         requires weak_ordering_for<Cmp, Derived>
     constexpr auto minmax(Cmp cmp = Cmp{});
 
-    template <typename Pred>
-        requires std::predicate<Pred&, element_t<Derived>>
+    template <predicate_for<Derived> Pred>
     [[nodiscard]]
     constexpr auto none(Pred pred);
 

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -109,17 +109,17 @@ public:
 
     /// Returns the number of elements in the sequence
     [[nodiscard]]
-    constexpr auto size() requires sized_sequence<Derived> { return flux::size(derived()); }
+    constexpr auto size() requires sized_iterable<Derived> { return flux::size(derived()); }
 
     [[nodiscard]]
-    constexpr auto size() const requires sized_sequence<Derived const> { return flux::size(derived()); }
+    constexpr auto size() const requires sized_iterable<Derived const> { return flux::size(derived()); }
 
     /// Returns the number of elements in the sequence as a size_t
     [[nodiscard]]
-    constexpr auto usize() requires sized_sequence<Derived> { return flux::usize(derived()); }
+    constexpr auto usize() requires sized_iterable<Derived> { return flux::usize(derived()); }
 
     [[nodiscard]]
-    constexpr auto usize() const requires sized_sequence<Derived const> { return flux::usize(derived()); }
+    constexpr auto usize() const requires sized_iterable<Derived const> { return flux::usize(derived()); }
 
     template <typename Pred>
         requires std::invocable<Pred&, element_t<Derived>> &&
@@ -132,7 +132,7 @@ public:
     /// Returns true if the sequence contains no elements
     [[nodiscard]]
     constexpr auto is_empty()
-        requires (multipass_sequence<Derived> || sized_sequence<Derived>)
+        requires (multipass_sequence<Derived> || sized_iterable<Derived>)
     {
         return flux::is_empty(derived());
     }
@@ -412,8 +412,8 @@ public:
 
     template <sequence Needle, typename Cmp = std::ranges::equal_to>
         requires std::predicate<Cmp&, element_t<Derived>, element_t<Needle>> &&
-                 (multipass_sequence<Derived> || sized_sequence<Derived>) &&
-                 (multipass_sequence<Needle> || sized_sequence<Needle>)
+                 (multipass_sequence<Derived> || sized_iterable<Derived>) &&
+                 (multipass_sequence<Needle> || sized_iterable<Needle>)
     constexpr auto ends_with(Needle&& needle, Cmp cmp = {}) -> bool;
 
     template <typename Value>

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -200,7 +200,7 @@ public:
         return std::invoke(FLUX_FWD(func), std::move(derived()), FLUX_FWD(args)...);
     }
 
-    constexpr auto ref() const& requires const_iterable_sequence<Derived>;
+    constexpr auto ref() const& requires const_iterable<Derived>;
 
     auto ref() const&& -> void = delete;
 

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -419,7 +419,7 @@ public:
     constexpr auto ends_with(Needle&& needle, Cmp cmp = {}) -> bool;
 
     template <typename Value>
-        requires writable_sequence_of<Derived, Value const&>
+        requires writable_iterable_of<Derived, Value const&>
     constexpr auto fill(Value const& value) -> void;
 
     /// Returns a cursor pointing to the first occurrence of `value` in the sequence

--- a/include/flux/core/inline_sequence_base.hpp
+++ b/include/flux/core/inline_sequence_base.hpp
@@ -288,7 +288,7 @@ public:
     constexpr auto filter_deref() && requires detail::optional_like<value_t<Derived>>;
 
     [[nodiscard]]
-    constexpr auto flatten() && requires sequence<element_t<Derived>>;
+    constexpr auto flatten() && requires iterable<element_t<Derived>>;
 
     template <adaptable_sequence Pattern>
         requires sequence<element_t<Derived>> &&

--- a/include/flux/core/operation_requirements.hpp
+++ b/include/flux/core/operation_requirements.hpp
@@ -84,6 +84,10 @@ FLUX_EXPORT
 template <typename Fn, typename Sig>
 concept func = detail::func_<Fn const&, Sig> && func_mut<Fn, Sig>;
 
+FLUX_EXPORT
+template <typename Fn, typename It>
+concept predicate_for = func<Fn, auto(element_t<It>) -> bool>;
+
 } // namespace flux
 
 #endif // FLUX_CORE_OPERATION_REQUIREMENTS_HPP_INCLUDED

--- a/include/flux/core/operation_requirements.hpp
+++ b/include/flux/core/operation_requirements.hpp
@@ -39,7 +39,6 @@ concept repeated_invocable = repeated_invocable_helper<Func, E, N>::value;
 template <typename InnerSeq, typename Pattern>
 concept flatten_with_compatible =
     std::common_reference_with<element_t<InnerSeq>, element_t<Pattern>> &&
-    std::common_reference_with<rvalue_element_t<InnerSeq>, rvalue_element_t<Pattern>> &&
     std::common_with<value_t<InnerSeq>, value_t<Pattern>>;
 
 template <typename, typename>

--- a/include/flux/core/operation_requirements.hpp
+++ b/include/flux/core/operation_requirements.hpp
@@ -11,17 +11,17 @@
 namespace flux {
 
 FLUX_EXPORT
-template <typename Seq, typename Func, typename Init>
-using fold_result_t = std::decay_t<std::invoke_result_t<Func&, Init, element_t<Seq>>>;
+template <typename It, typename Func, typename Init>
+using fold_result_t = std::decay_t<std::invoke_result_t<Func&, Init, element_t<It>>>;
 
 namespace detail {
 
-template <typename Seq, typename Func, typename Init,
-          typename R = fold_result_t<Seq, Func, Init>>
+template <typename It, typename Func, typename Init,
+          typename R = fold_result_t<It, Func, Init>>
 concept foldable_ =
-    std::invocable<Func&, R, element_t<Seq>> &&
+    std::invocable<Func&, R, element_t<It>> &&
     std::convertible_to<Init, R> &&
-    std::assignable_from<R&, std::invoke_result_t<Func&, R, element_t<Seq>>>;
+    std::assignable_from<R&, std::invoke_result_t<Func&, R, element_t<It>>>;
 
 template <typename Func, typename E, distance_t N>
 struct repeated_invocable_helper {
@@ -45,22 +45,22 @@ concept flatten_with_compatible =
 } // namespace detail
 
 FLUX_EXPORT
-template <typename Seq, typename Func, typename Init>
+template <typename It, typename Func, typename Init>
 concept foldable =
-    sequence<Seq> &&
-    std::invocable<Func&, Init, element_t<Seq>> &&
-    detail::foldable_<Seq, Func, Init>;
+    iterable<It> &&
+    std::invocable<Func&, Init, element_t<It>> &&
+    detail::foldable_<It, Func, Init>;
 
 FLUX_EXPORT
-template <typename Fn, typename Seq1, typename Seq2 = Seq1>
+template <typename Fn, typename It1, typename It2 = It1>
 concept weak_ordering_for =
-    sequence<Seq1> &&
-    sequence<Seq2> &&
-    ordering_invocable<Fn&, element_t<Seq1>, element_t<Seq2>, std::weak_ordering> &&
-    ordering_invocable<Fn&, value_t<Seq1>&, element_t<Seq2>, std::weak_ordering> &&
-    ordering_invocable<Fn&, element_t<Seq1>, value_t<Seq2>&, std::weak_ordering> &&
-    ordering_invocable<Fn&, value_t<Seq1>&, value_t<Seq2>&, std::weak_ordering> &&
-    ordering_invocable<Fn&, common_element_t<Seq1>, common_element_t<Seq2>, std::weak_ordering>;
+    iterable<It1> &&
+    iterable<It2> &&
+    ordering_invocable<Fn&, element_t<It1>, element_t<It2>, std::weak_ordering> &&
+    ordering_invocable<Fn&, value_t<It1>&, element_t<It2>, std::weak_ordering> &&
+    ordering_invocable<Fn&, element_t<It1>, value_t<It2>&, std::weak_ordering> &&
+    ordering_invocable<Fn&, value_t<It1>&, value_t<It2>&, std::weak_ordering> &&
+    ordering_invocable<Fn&, common_element_t<It1>, common_element_t<It2>, std::weak_ordering>;
 
 } // namespace flux
 

--- a/include/flux/core/operation_requirements.hpp
+++ b/include/flux/core/operation_requirements.hpp
@@ -42,6 +42,16 @@ concept flatten_with_compatible =
     std::common_reference_with<rvalue_element_t<InnerSeq>, rvalue_element_t<Pattern>> &&
     std::common_with<value_t<InnerSeq>, value_t<Pattern>>;
 
+template <typename, typename>
+inline constexpr bool invocable_helper_v = false;
+
+template <typename F, typename R, typename... Args>
+inline constexpr bool invocable_helper_v<F, R(Args...)>
+    = std::is_invocable_r_v<R, F, Args...>;
+
+template <typename F, typename Sig>
+concept func_ = invocable_helper_v<F, Sig>;
+
 } // namespace detail
 
 FLUX_EXPORT
@@ -61,6 +71,18 @@ concept weak_ordering_for =
     ordering_invocable<Fn&, element_t<It1>, value_t<It2>&, std::weak_ordering> &&
     ordering_invocable<Fn&, value_t<It1>&, value_t<It2>&, std::weak_ordering> &&
     ordering_invocable<Fn&, common_element_t<It1>, common_element_t<It2>, std::weak_ordering>;
+
+FLUX_EXPORT
+template <typename Fn, typename Sig>
+concept func_once = detail::func_<Fn&&, Sig>;
+
+FLUX_EXPORT
+template <typename Fn, typename Sig>
+concept func_mut = detail::func_<Fn&, Sig> && func_once<Fn, Sig>;
+
+FLUX_EXPORT
+template <typename Fn, typename Sig>
+concept func = detail::func_<Fn const&, Sig> && func_mut<Fn, Sig>;
 
 } // namespace flux
 

--- a/include/flux/core/ref.hpp
+++ b/include/flux/core/ref.hpp
@@ -7,7 +7,7 @@
 #define FLUX_CORE_REF_HPP_INCLUDED
 
 #include <flux/core/concepts.hpp>
-#include <flux/core/inline_sequence_base.hpp>
+#include <flux/core/inline_iter_base.hpp>
 #include <flux/core/sequence_access.hpp>
 
 namespace flux {
@@ -121,7 +121,7 @@ struct passthrough_traits_base : default_iter_traits {
 };
 
 template <iterable Base>
-struct ref_adaptor : inline_sequence_base<ref_adaptor<Base>> {
+struct ref_adaptor : inline_iter_base<ref_adaptor<Base>> {
 private:
     Base* base_;
 
@@ -199,7 +199,7 @@ struct ref_fn {
 
 template <iterable Base>
     requires std::movable<Base>
-struct owning_adaptor : inline_sequence_base<owning_adaptor<Base>> {
+struct owning_adaptor : inline_iter_base<owning_adaptor<Base>> {
 private:
     Base base_;
 
@@ -258,14 +258,14 @@ FLUX_EXPORT inline constexpr auto from = detail::from_fn{};
 FLUX_EXPORT inline constexpr auto from_fwd_ref = detail::from_fwd_ref_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::ref() const&
+constexpr auto inline_iter_base<D>::ref() const&
     requires const_iterable<D>
 {
     return flux::ref(derived());
 }
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::mut_ref() &
+constexpr auto inline_iter_base<D>::mut_ref() &
 {
     return flux::mut_ref(derived());
 }

--- a/include/flux/core/ref.hpp
+++ b/include/flux/core/ref.hpp
@@ -16,7 +16,8 @@ namespace detail {
 
 struct passthrough_traits_base : default_sequence_traits {
 
-    static consteval auto element_type(auto& self) -> element_t<decltype(self.base())>;
+    template <typename Self>
+    static consteval auto element_type(Self& self) -> element_t<decltype(self.base())>;
 
     static constexpr auto iterate(auto& self, auto&& pred)
         -> decltype(flux::iterate(self.base(), FLUX_FWD(pred)))

--- a/include/flux/core/ref.hpp
+++ b/include/flux/core/ref.hpp
@@ -111,7 +111,7 @@ struct passthrough_traits_base : default_sequence_traits {
     }
 };
 
-template <sequence Base>
+template <iterable Base>
 struct ref_adaptor : inline_sequence_base<ref_adaptor<Base>> {
 private:
     Base* base_;
@@ -155,7 +155,7 @@ template <typename T>
 inline constexpr bool is_ref_adaptor<ref_adaptor<T>> = true;
 
 struct mut_ref_fn {
-    template <sequence Seq>
+    template <iterable Seq>
         requires (!std::is_const_v<Seq>)
     [[nodiscard]]
     constexpr auto operator()(Seq& seq) const
@@ -169,7 +169,7 @@ struct mut_ref_fn {
 };
 
 struct ref_fn {
-    template <const_iterable_sequence Seq>
+    template <const_iterable Seq>
         requires (!is_ref_adaptor<Seq>)
     [[nodiscard]]
     constexpr auto operator()(Seq const& seq) const
@@ -177,7 +177,7 @@ struct ref_fn {
         return ref_adaptor<Seq const>(seq);
     }
 
-    template <const_iterable_sequence Seq>
+    template <const_iterable Seq>
     [[nodiscard]]
     constexpr auto operator()(ref_adaptor<Seq> ref) const
     {
@@ -250,7 +250,7 @@ FLUX_EXPORT inline constexpr auto from_fwd_ref = detail::from_fwd_ref_fn{};
 
 template <typename D>
 constexpr auto inline_sequence_base<D>::ref() const&
-    requires const_iterable_sequence<D>
+    requires const_iterable<D>
 {
     return flux::ref(derived());
 }

--- a/include/flux/core/ref.hpp
+++ b/include/flux/core/ref.hpp
@@ -14,7 +14,7 @@ namespace flux {
 
 namespace detail {
 
-struct passthrough_traits_base : default_sequence_traits {
+struct passthrough_traits_base : default_iter_traits {
 
     template <typename Self>
     static consteval auto element_type(Self& self) -> element_t<decltype(self.base())>;
@@ -152,7 +152,7 @@ public:
 
     constexpr Base& base() const noexcept { return *base_; }
 
-    struct flux_sequence_traits : passthrough_traits_base {
+    struct flux_iter_traits : passthrough_traits_base {
         using value_type = value_t<Base>;
     };
 };
@@ -213,7 +213,7 @@ public:
     constexpr Base&& base() && noexcept { return std::move(base_); }
     constexpr Base const&& base() const&& noexcept { return std::move(base_); }
 
-    struct flux_sequence_traits : passthrough_traits_base {
+    struct flux_iter_traits : passthrough_traits_base {
         using value_type = value_t<Base>;
     };
 };

--- a/include/flux/core/ref.hpp
+++ b/include/flux/core/ref.hpp
@@ -16,6 +16,14 @@ namespace detail {
 
 struct passthrough_traits_base : default_sequence_traits {
 
+    static consteval auto element_type(auto& self) -> element_t<decltype(self.base())>;
+
+    static constexpr auto iterate(auto& self, auto&& pred)
+        -> decltype(flux::iterate(self.base(), FLUX_FWD(pred)))
+    {
+        return flux::iterate(self.base(), FLUX_FWD(pred));
+    }
+
     static constexpr auto first(auto& self)
         -> decltype(flux::first(self.base()))
     {

--- a/include/flux/core/sequence_access.hpp
+++ b/include/flux/core/sequence_access.hpp
@@ -14,6 +14,16 @@ namespace flux {
 
 namespace detail {
 
+struct iterate_fn {
+    template <iterable It, typename Pred>
+        requires std::invocable<Pred&, element_t<It>> &&
+                 boolean_testable<std::invoke_result_t<Pred&, element_t<It>>>
+    constexpr auto operator()(It&& iter, Pred pred) const -> bool
+    {
+        return traits_t<It>::iterate(iter, pred);
+    }
+};
+
 struct first_fn {
     template <sequence Seq>
     [[nodiscard]]
@@ -173,6 +183,7 @@ struct for_each_while_fn {
 
 } // namespace detail
 
+FLUX_EXPORT inline constexpr auto iterate = detail::iterate_fn{};
 FLUX_EXPORT inline constexpr auto first = detail::first_fn{};
 FLUX_EXPORT inline constexpr auto is_last = detail::is_last_fn{};
 FLUX_EXPORT inline constexpr auto read_at = detail::read_at_fn{};

--- a/include/flux/core/sequence_access.hpp
+++ b/include/flux/core/sequence_access.hpp
@@ -124,20 +124,20 @@ struct last_fn {
 };
 
 struct size_fn {
-    template <sized_sequence Seq>
+    template <sized_iterable It>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq) const -> distance_t
+    constexpr auto operator()(It&& it) const -> distance_t
     {
-        return traits_t<Seq>::size(seq);
+        return traits_t<It>::size(it);
     }
 };
 
 struct usize_fn {
-    template <sized_sequence Seq>
+    template <sized_iterable It>
     [[nodiscard]]
-    constexpr auto operator()(Seq&& seq) const -> std::size_t
+    constexpr auto operator()(It&& it) const -> std::size_t
     {
-        return num::unchecked_cast<std::size_t>(size_fn{}(seq));
+        return num::unchecked_cast<std::size_t>(size_fn{}(it));
     }
 };
 
@@ -252,11 +252,11 @@ struct prev_fn {
 
 struct is_empty_fn {
     template <sequence Seq>
-        requires (multipass_sequence<Seq> || sized_sequence<Seq>)
+        requires (multipass_sequence<Seq> || sized_iterable<Seq>)
     [[nodiscard]]
     constexpr auto operator()(Seq&& seq) const -> bool
     {
-        if constexpr (sized_sequence<Seq>) {
+        if constexpr (sized_iterable<Seq>) {
             return flux::size(seq) == 0;
         } else {
             return is_last(seq, first(seq));

--- a/include/flux/core/sequence_access.hpp
+++ b/include/flux/core/sequence_access.hpp
@@ -267,8 +267,8 @@ struct is_empty_fn {
 template <typename Seq1, typename Seq2>
 concept element_swappable_with_ =
     std::constructible_from<value_t<Seq1>, rvalue_element_t<Seq1>> &&
-    writable_sequence_of<Seq1, rvalue_element_t<Seq2>> &&
-    writable_sequence_of<Seq2, value_t<Seq1>&&>;
+    writable_iterable_of<Seq1, rvalue_element_t<Seq2>> &&
+    writable_iterable_of<Seq2, value_t<Seq1>&&>;
 
 template <typename Seq1, typename Seq2>
 concept element_swappable_with =

--- a/include/flux/core/sequence_iterator.hpp
+++ b/include/flux/core/sequence_iterator.hpp
@@ -206,26 +206,26 @@ FLUX_EXPORT inline constexpr auto begin = detail::begin_fn{};
 FLUX_EXPORT inline constexpr auto end = detail::end_fn{};
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::begin() &
+constexpr auto inline_iter_base<D>::begin() &
 {
     return flux::begin(derived());
 }
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::begin() const&
+constexpr auto inline_iter_base<D>::begin() const&
     requires sequence<D const>
 {
     return flux::begin(derived());
 };
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::end() &
+constexpr auto inline_iter_base<D>::end() &
 {
     return flux::end(derived());
 }
 
 template <typename D>
-constexpr auto inline_sequence_base<D>::end() const&
+constexpr auto inline_iter_base<D>::end() const&
 requires sequence<D const>
 {
     return flux::end(derived());

--- a/include/flux/core/sequence_iterator.hpp
+++ b/include/flux/core/sequence_iterator.hpp
@@ -207,6 +207,7 @@ FLUX_EXPORT inline constexpr auto end = detail::end_fn{};
 
 template <typename D>
 constexpr auto inline_iter_base<D>::begin() &
+    requires sequence<D>
 {
     return flux::begin(derived());
 }
@@ -220,6 +221,7 @@ constexpr auto inline_iter_base<D>::begin() const&
 
 template <typename D>
 constexpr auto inline_iter_base<D>::end() &
+    requires sequence<D>
 {
     return flux::end(derived());
 }

--- a/include/flux/core/slice.hpp
+++ b/include/flux/core/slice.hpp
@@ -7,7 +7,7 @@
 #define FLUX_OP_SLICE_HPP_INCLUDED
 
 #include <flux/core/concepts.hpp>
-#include <flux/core/inline_sequence_base.hpp>
+#include <flux/core/inline_iter_base.hpp>
 
 namespace flux {
 
@@ -26,7 +26,7 @@ struct slice_data<Cur, false> {
 
 template <sequence Base, bool Bounded>
     requires (!Bounded || regular_cursor<cursor_t<Base>>)
-struct subsequence : inline_sequence_base<subsequence<Base, Bounded>>
+struct subsequence : inline_iter_base<subsequence<Base, Bounded>>
 {
 private:
     Base* base_;

--- a/include/flux/core/slice.hpp
+++ b/include/flux/core/slice.hpp
@@ -100,6 +100,9 @@ struct sequence_traits<subsequence<Base, Bounded>>
     using value_type = value_t<Base>;
     using self_t = subsequence<Base, Bounded>;
 
+    using default_sequence_traits::element_type;
+    using default_sequence_traits::iterate;
+
     static constexpr auto first(self_t& self) -> cursor_t<Base>
     {
         if constexpr (std::copy_constructible<decltype(self.data_.first)>) {

--- a/include/flux/core/slice.hpp
+++ b/include/flux/core/slice.hpp
@@ -100,8 +100,8 @@ struct iter_traits<subsequence<Base, Bounded>>
     using value_type = value_t<Base>;
     using self_t = subsequence<Base, Bounded>;
 
-    using default_sequence_traits::element_type;
-    using default_sequence_traits::iterate;
+    using default_iter_traits::element_type;
+    using default_iter_traits::iterate;
 
     static constexpr auto first(self_t& self) -> cursor_t<Base>
     {
@@ -137,8 +137,8 @@ struct iter_traits<subsequence<Base, Bounded>>
                flux::distance(*self.base_, flux::first(*self.base_), self.data_.first);
     }
 
-    using default_sequence_traits::size;
-    using default_sequence_traits::for_each_while;
+    using default_iter_traits::size;
+    using default_iter_traits::for_each_while;
 };
 
 FLUX_EXPORT inline constexpr auto slice = detail::slice_fn{};

--- a/include/flux/core/slice.hpp
+++ b/include/flux/core/slice.hpp
@@ -32,7 +32,7 @@ private:
     Base* base_;
     FLUX_NO_UNIQUE_ADDRESS slice_data<cursor_t<Base>, Bounded> data_;
 
-    friend struct sequence_traits<subsequence>;
+    friend struct iter_traits<subsequence>;
 
 public:
     constexpr subsequence(Base& base, cursor_t<Base>&& from,
@@ -94,7 +94,7 @@ struct slice_fn {
 using detail::subsequence;
 
 template <typename Base, bool Bounded>
-struct sequence_traits<subsequence<Base, Bounded>>
+struct iter_traits<subsequence<Base, Bounded>>
     : detail::passthrough_traits_base
 {
     using value_type = value_t<Base>;

--- a/include/flux/sequence/array_ptr.hpp
+++ b/include/flux/sequence/array_ptr.hpp
@@ -22,7 +22,7 @@ struct make_array_ptr_unchecked_fn;
 FLUX_EXPORT
 template <typename T>
     requires (std::is_object_v<T> && !std::is_abstract_v<T>)
-struct array_ptr : inline_sequence_base<array_ptr<T>> {
+struct array_ptr : inline_iter_base<array_ptr<T>> {
 private:
     T* data_ = nullptr;
     distance_t sz_ = 0;

--- a/include/flux/sequence/array_ptr.hpp
+++ b/include/flux/sequence/array_ptr.hpp
@@ -76,7 +76,7 @@ public:
         return std::ranges::equal_to{}(lhs.data_, rhs.data_) && lhs.sz_ == rhs.sz_;
     }
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
 
         static constexpr auto first(array_ptr const&) -> index_t { return 0; }
 

--- a/include/flux/sequence/array_ptr.hpp
+++ b/include/flux/sequence/array_ptr.hpp
@@ -48,7 +48,7 @@ public:
     template <typename Seq>
         requires (!decays_to<Seq, array_ptr> &&
                   contiguous_sequence<Seq> &&
-                  sized_sequence<Seq> &&
+                  sized_iterable<Seq> &&
                   detail::non_slicing_ptr_convertible<std::remove_reference_t<element_t<Seq>>, T>)
     constexpr explicit array_ptr(Seq& seq)
         : data_(flux::data(seq)),
@@ -57,7 +57,7 @@ public:
 
     template <typename Seq>
         requires (contiguous_sequence<Seq> &&
-                  sized_sequence<Seq> &&
+                  sized_iterable<Seq> &&
                   detail::non_slicing_ptr_convertible<std::remove_reference_t<element_t<Seq>>, T>)
     constexpr array_ptr(detail::ref_adaptor<Seq> ref)
         : data_(flux::data(ref)),

--- a/include/flux/sequence/bitset.hpp
+++ b/include/flux/sequence/bitset.hpp
@@ -13,7 +13,7 @@
 namespace flux {
 
 template <std::size_t N>
-struct iter_traits<std::bitset<N>> : default_sequence_traits {
+struct iter_traits<std::bitset<N>> : default_iter_traits {
 
     using value_type = bool;
 

--- a/include/flux/sequence/bitset.hpp
+++ b/include/flux/sequence/bitset.hpp
@@ -13,7 +13,7 @@
 namespace flux {
 
 template <std::size_t N>
-struct sequence_traits<std::bitset<N>> : default_sequence_traits {
+struct iter_traits<std::bitset<N>> : default_sequence_traits {
 
     using value_type = bool;
 

--- a/include/flux/sequence/empty.hpp
+++ b/include/flux/sequence/empty.hpp
@@ -14,7 +14,7 @@ namespace detail {
 
 template <typename T>
 struct empty_sequence : inline_sequence_base<empty_sequence<T>> {
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             friend auto operator==(cursor_type, cursor_type) -> bool = default;

--- a/include/flux/sequence/empty.hpp
+++ b/include/flux/sequence/empty.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <typename T>
-struct empty_sequence : inline_sequence_base<empty_sequence<T>> {
+struct empty_sequence : inline_iter_base<empty_sequence<T>> {
     struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {

--- a/include/flux/sequence/generator.hpp
+++ b/include/flux/sequence/generator.hpp
@@ -73,7 +73,7 @@ public:
 };
 
 template <typename T>
-struct iter_traits<generator<T>> : default_sequence_traits
+struct iter_traits<generator<T>> : default_iter_traits
 {
 private:
     struct cursor_type {

--- a/include/flux/sequence/generator.hpp
+++ b/include/flux/sequence/generator.hpp
@@ -53,7 +53,7 @@ private:
 
     explicit generator(handle_type&& handle) : coro_(std::move(handle)) {}
 
-    friend struct sequence_traits<generator>;
+    friend struct iter_traits<generator>;
 
 public:
     generator(generator&& other) noexcept
@@ -73,7 +73,7 @@ public:
 };
 
 template <typename T>
-struct sequence_traits<generator<T>> : default_sequence_traits
+struct iter_traits<generator<T>> : default_sequence_traits
 {
 private:
     struct cursor_type {
@@ -81,7 +81,7 @@ private:
         cursor_type& operator=(cursor_type&&) = default;
     private:
         cursor_type() = default;
-        friend struct sequence_traits;
+        friend struct iter_traits;
     };
 
     using self_t = generator<T>;

--- a/include/flux/sequence/generator.hpp
+++ b/include/flux/sequence/generator.hpp
@@ -15,7 +15,7 @@ namespace flux {
 
 FLUX_EXPORT
 template <typename ElemT>
-struct generator : inline_sequence_base<generator<ElemT>> {
+struct generator : inline_iter_base<generator<ElemT>> {
 
     using yielded_type = std::conditional_t<std::is_reference_v<ElemT>,
                                             ElemT,

--- a/include/flux/sequence/getlines.hpp
+++ b/include/flux/sequence/getlines.hpp
@@ -37,7 +37,7 @@ public:
     getlines_sequence(getlines_sequence&&) = default;
     getlines_sequence& operator=(getlines_sequence&&) = default;
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
             explicit cursor_type() = default;

--- a/include/flux/sequence/getlines.hpp
+++ b/include/flux/sequence/getlines.hpp
@@ -16,7 +16,7 @@ namespace flux {
 namespace detail {
 
 template <typename CharT, typename Traits>
-struct getlines_sequence : inline_sequence_base<getlines_sequence<CharT, Traits>> {
+struct getlines_sequence : inline_iter_base<getlines_sequence<CharT, Traits>> {
 private:
     using istream_type = std::basic_istream<CharT, Traits>;
     using string_type = std::basic_string<CharT, Traits>;

--- a/include/flux/sequence/iota.hpp
+++ b/include/flux/sequence/iota.hpp
@@ -115,13 +115,13 @@ struct iota_sequence_traits : default_iter_traits {
 };
 
 template <typename T>
-struct basic_iota_sequence : inline_sequence_base<basic_iota_sequence<T>> {
+struct basic_iota_sequence : inline_iter_base<basic_iota_sequence<T>> {
     using flux_iter_traits = iota_sequence_traits<T, iota_traits{}>;
     friend flux_iter_traits;
 };
 
 template <typename T>
-struct iota_sequence : inline_sequence_base<iota_sequence<T>> {
+struct iota_sequence : inline_iter_base<iota_sequence<T>> {
 private:
     T start_;
 
@@ -137,7 +137,7 @@ public:
 };
 
 template <typename T>
-struct bounded_iota_sequence : inline_sequence_base<bounded_iota_sequence<T>> {
+struct bounded_iota_sequence : inline_iter_base<bounded_iota_sequence<T>> {
     T start_;
     T end_;
 

--- a/include/flux/sequence/iota.hpp
+++ b/include/flux/sequence/iota.hpp
@@ -49,7 +49,7 @@ struct iota_traits {
 };
 
 template <incrementable T, iota_traits Traits>
-struct iota_sequence_traits : default_sequence_traits {
+struct iota_sequence_traits : default_iter_traits {
     using cursor_type = T;
 
     static constexpr bool is_infinite = !Traits.has_end;
@@ -116,8 +116,8 @@ struct iota_sequence_traits : default_sequence_traits {
 
 template <typename T>
 struct basic_iota_sequence : inline_sequence_base<basic_iota_sequence<T>> {
-    using flux_sequence_traits = iota_sequence_traits<T, iota_traits{}>;
-    friend flux_sequence_traits;
+    using flux_iter_traits = iota_sequence_traits<T, iota_traits{}>;
+    friend flux_iter_traits;
 };
 
 template <typename T>
@@ -132,8 +132,8 @@ public:
         : start_(std::move(from))
     {}
 
-    using flux_sequence_traits = iota_sequence_traits<T, traits>;
-    friend flux_sequence_traits;
+    using flux_iter_traits = iota_sequence_traits<T, traits>;
+    friend flux_iter_traits;
 };
 
 template <typename T>
@@ -149,8 +149,8 @@ public:
           end_(std::move(to))
     {}
 
-    using flux_sequence_traits = iota_sequence_traits<T, traits>;
-    friend flux_sequence_traits;
+    using flux_iter_traits = iota_sequence_traits<T, traits>;
+    friend flux_iter_traits;
 };
 
 struct iota_fn {

--- a/include/flux/sequence/istream.hpp
+++ b/include/flux/sequence/istream.hpp
@@ -21,7 +21,7 @@ class istream_adaptor : public inline_sequence_base<istream_adaptor<T, CharT, Tr
     istream_type* is_ = nullptr;
     T val_ = T();
 
-    friend struct sequence_traits<istream_adaptor>;
+    friend struct iter_traits<istream_adaptor>;
 
 public:
     explicit istream_adaptor(istream_type& is)
@@ -45,14 +45,14 @@ struct from_istream_fn {
 } // namespace detail
 
 template <typename T, typename CharT, typename Traits>
-struct sequence_traits<detail::istream_adaptor<T, CharT, Traits>> : default_sequence_traits
+struct iter_traits<detail::istream_adaptor<T, CharT, Traits>> : default_sequence_traits
 {
 private:
     struct cursor_type {
         cursor_type(cursor_type&&) = default;
         cursor_type& operator=(cursor_type&&) = default;
     private:
-        friend struct sequence_traits;
+        friend struct iter_traits;
         explicit cursor_type() = default;
     };
 

--- a/include/flux/sequence/istream.hpp
+++ b/include/flux/sequence/istream.hpp
@@ -45,7 +45,7 @@ struct from_istream_fn {
 } // namespace detail
 
 template <typename T, typename CharT, typename Traits>
-struct iter_traits<detail::istream_adaptor<T, CharT, Traits>> : default_sequence_traits
+struct iter_traits<detail::istream_adaptor<T, CharT, Traits>> : default_iter_traits
 {
 private:
     struct cursor_type {

--- a/include/flux/sequence/istream.hpp
+++ b/include/flux/sequence/istream.hpp
@@ -16,7 +16,7 @@ namespace detail {
 
 template <typename T, typename CharT, typename Traits>
     requires std::default_initializable<T>
-class istream_adaptor : public inline_sequence_base<istream_adaptor<T, CharT, Traits>> {
+class istream_adaptor : public inline_iter_base<istream_adaptor<T, CharT, Traits>> {
     using istream_type = std::basic_istream<CharT, Traits>;
     istream_type* is_ = nullptr;
     T val_ = T();

--- a/include/flux/sequence/istreambuf.hpp
+++ b/include/flux/sequence/istreambuf.hpp
@@ -40,7 +40,7 @@ struct from_istreambuf_fn {
 } // namespace detail
 
 template <detail::derives_from_streambuf Streambuf>
-struct iter_traits<Streambuf> : default_sequence_traits
+struct iter_traits<Streambuf> : default_iter_traits
 {
 private:
     struct cursor_type {

--- a/include/flux/sequence/istreambuf.hpp
+++ b/include/flux/sequence/istreambuf.hpp
@@ -40,14 +40,14 @@ struct from_istreambuf_fn {
 } // namespace detail
 
 template <detail::derives_from_streambuf Streambuf>
-struct sequence_traits<Streambuf> : default_sequence_traits
+struct iter_traits<Streambuf> : default_sequence_traits
 {
 private:
     struct cursor_type {
         cursor_type(cursor_type&&) = default;
         cursor_type& operator=(cursor_type&&) = default;
     private:
-        friend struct sequence_traits;
+        friend struct iter_traits;
         cursor_type() = default;
     };
 

--- a/include/flux/sequence/range.hpp
+++ b/include/flux/sequence/range.hpp
@@ -27,13 +27,13 @@ private:
     using V = std::conditional_t<IsConst, R const, R>;
 
 public:
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         class cursor_type {
 
             std::ranges::iterator_t<V> iter;
 
-            friend struct flux_sequence_traits;
+            friend struct flux_iter_traits;
 
             constexpr explicit cursor_type(std::ranges::iterator_t<V> iter) : iter(std::move(iter)) {}
         public:

--- a/include/flux/sequence/range.hpp
+++ b/include/flux/sequence/range.hpp
@@ -20,7 +20,7 @@ concept can_const_iterate =
     std::same_as<std::ranges::iterator_t<R>, std::ranges::iterator_t<R const>>;
 
 template <typename R, bool IsConst>
-struct range_sequence : inline_sequence_base<range_sequence<R, IsConst>> {
+struct range_sequence : inline_iter_base<range_sequence<R, IsConst>> {
 private:
     R rng_;
 

--- a/include/flux/sequence/repeat.hpp
+++ b/include/flux/sequence/repeat.hpp
@@ -37,7 +37,7 @@ public:
           data_{count}
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         using self_t = repeat_sequence;
 

--- a/include/flux/sequence/repeat.hpp
+++ b/include/flux/sequence/repeat.hpp
@@ -19,7 +19,7 @@ template <>
 struct repeat_data<false> { std::size_t count; };
 
 template <std::movable T, bool IsInfinite>
-struct repeat_sequence : inline_sequence_base<repeat_sequence<T, IsInfinite>>
+struct repeat_sequence : inline_iter_base<repeat_sequence<T, IsInfinite>>
 {
 private:
     T obj_;

--- a/include/flux/sequence/single.hpp
+++ b/include/flux/sequence/single.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <std::movable T>
-struct single_sequence : inline_sequence_base<single_sequence<T>> {
+struct single_sequence : inline_iter_base<single_sequence<T>> {
 private:
     T obj_;
 

--- a/include/flux/sequence/single.hpp
+++ b/include/flux/sequence/single.hpp
@@ -55,7 +55,7 @@ struct single_fn {
 } // namespace detail
 
 template <typename T>
-struct iter_traits<detail::single_sequence<T>> : default_sequence_traits
+struct iter_traits<detail::single_sequence<T>> : default_iter_traits
 {
 private:
     using self_t = detail::single_sequence<T>;

--- a/include/flux/sequence/single.hpp
+++ b/include/flux/sequence/single.hpp
@@ -17,7 +17,7 @@ struct single_sequence : inline_sequence_base<single_sequence<T>> {
 private:
     T obj_;
 
-    friend struct sequence_traits<single_sequence>;
+    friend struct iter_traits<single_sequence>;
 
 public:
     constexpr single_sequence()
@@ -55,7 +55,7 @@ struct single_fn {
 } // namespace detail
 
 template <typename T>
-struct sequence_traits<detail::single_sequence<T>> : default_sequence_traits
+struct iter_traits<detail::single_sequence<T>> : default_sequence_traits
 {
 private:
     using self_t = detail::single_sequence<T>;

--- a/include/flux/sequence/unfold.hpp
+++ b/include/flux/sequence/unfold.hpp
@@ -26,10 +26,10 @@ public:
           func_(std::move(func))
     {}
 
-    struct flux_sequence_traits : default_sequence_traits {
+    struct flux_iter_traits : default_iter_traits {
     private:
         struct cursor_type {
-            friend struct flux_sequence_traits;
+            friend struct flux_iter_traits;
             cursor_type(cursor_type&&) = default;
             cursor_type& operator=(cursor_type&&) = default;
         private:

--- a/include/flux/sequence/unfold.hpp
+++ b/include/flux/sequence/unfold.hpp
@@ -13,7 +13,7 @@ namespace flux {
 namespace detail {
 
 template <typename R, typename Func>
-struct unfold_sequence : inline_sequence_base<unfold_sequence<R, Func>> {
+struct unfold_sequence : inline_iter_base<unfold_sequence<R, Func>> {
 private:
     R state_;
     Func func_;

--- a/test/test_adjacent.cpp
+++ b/test/test_adjacent.cpp
@@ -40,7 +40,7 @@ constexpr bool test_pairwise()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         static_assert(std::same_as<flux::element_t<S>, std::pair<int&, int&>>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, std::pair<int&&, int&&>>);
@@ -70,7 +70,7 @@ constexpr bool test_pairwise()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(flux::size(seq) == 4);
 
@@ -111,7 +111,7 @@ constexpr bool test_pairwise()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(tuple_equal(seq[cur], std::pair{4, 5}));
@@ -141,7 +141,7 @@ constexpr bool test_adjacent()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(seq.size() == 3);
         STATIC_CHECK(seq.distance(seq.first(), seq.last()) == 3);
@@ -165,7 +165,7 @@ constexpr bool test_adjacent()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(flux::size(seq) == 3);
 
@@ -232,7 +232,7 @@ constexpr bool test_adjacent()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(tuple_equal(seq[cur], std::array{3, 4, 5}));

--- a/test/test_adjacent_filter.cpp
+++ b/test/test_adjacent_filter.cpp
@@ -23,7 +23,7 @@ constexpr bool test_adjacent_filter()
         static_assert(flux::bidirectional_sequence<F>);
         static_assert(not flux::random_access_sequence<F>);
         static_assert(flux::bounded_sequence<F>);
-        static_assert(not flux::sized_sequence<F>);
+        static_assert(not flux::sized_iterable<F>);
 
         static_assert(std::same_as<flux::element_t<F>, int&>);
 
@@ -44,7 +44,7 @@ constexpr bool test_adjacent_filter()
         static_assert(flux::bidirectional_sequence<F>);
         static_assert(not flux::random_access_sequence<F>);
         static_assert(flux::bounded_sequence<F>);
-        static_assert(not flux::sized_sequence<F>);
+        static_assert(not flux::sized_iterable<F>);
 
         static_assert(std::same_as<flux::element_t<F>, int const&>);
 
@@ -136,7 +136,7 @@ constexpr bool test_dedup()
         static_assert(flux::bidirectional_sequence<F>);
         static_assert(not flux::random_access_sequence<F>);
         static_assert(flux::bounded_sequence<F>);
-        static_assert(not flux::sized_sequence<F>);
+        static_assert(not flux::sized_iterable<F>);
 
         static_assert(std::same_as<flux::element_t<F>, int&>);
 
@@ -157,7 +157,7 @@ constexpr bool test_dedup()
         static_assert(flux::bidirectional_sequence<F>);
         static_assert(not flux::random_access_sequence<F>);
         static_assert(flux::bounded_sequence<F>);
-        static_assert(not flux::sized_sequence<F>);
+        static_assert(not flux::sized_iterable<F>);
 
         static_assert(std::same_as<flux::element_t<F>, int const&>);
 

--- a/test/test_adjacent_map.cpp
+++ b/test/test_adjacent_map.cpp
@@ -26,7 +26,7 @@ constexpr bool test_pairwise_map() {
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(seq.size() ==  4);
 
@@ -45,7 +45,7 @@ constexpr bool test_pairwise_map() {
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(flux::size(seq) ==  4);
 
@@ -109,7 +109,7 @@ constexpr bool test_adjacent_map()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(seq.size() ==  7);
 
@@ -128,7 +128,7 @@ constexpr bool test_adjacent_map()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(flux::size(seq) ==  7);
 

--- a/test/test_all_any_none.cpp
+++ b/test/test_all_any_none.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <initializer_list>
+#include <ranges>
 #include <vector>
 
 #ifdef USE_MODULES
@@ -28,13 +29,29 @@ static_assert(test_all<int>({}));
 static_assert(test_all({1, 2, 3, 4, 5}));
 static_assert(test_all({1.0, 2.0, -3.0, 4.0}));
 
+template <typename T>
+constexpr bool test_any(std::initializer_list<T> ilist)
+{
+    return flux::any(ilist, gt_zero) == std::any_of(ilist.begin(), ilist.end(), gt_zero);
+}
+static_assert(test_any<int>({}));
+static_assert(test_any({1, 2, 3, 4, 5}));
+static_assert(test_any({1.0, 2.0, -3.0, 4.0}));
+
+template <typename T>
+constexpr bool test_none(std::initializer_list<T> ilist)
+{
+    return flux::none(ilist, gt_zero) == std::none_of(ilist.begin(), ilist.end(), gt_zero);
+}
+static_assert(test_none<int>({}));
+static_assert(test_none({1, 2, 3, 4, 5}));
+static_assert(test_none({1.0, 2.0, -3.0, 4.0}));
+
 }
 
 TEST_CASE("all with vector")
 {
-    std::vector<int> vec{1, 2, 3, 4, 5};
-
-    static_assert(flux::contiguous_sequence<decltype(vec)>);
+    auto vec = std::vector<int>{1, 2, 3, 4, 5} | std::views::filter(flux::pred::even);
 
     bool req = flux::all(vec, gt_zero);
 

--- a/test/test_array_ptr.cpp
+++ b/test/test_array_ptr.cpp
@@ -324,7 +324,7 @@ constexpr bool test_array_ptr_sequence_impl()
     {
         using S = flux::array_ptr<int>;
         static_assert(flux::contiguous_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::infinite_sequence<S>);
         static_assert(std::same_as<flux::value_t<S>, int>);
@@ -332,7 +332,7 @@ constexpr bool test_array_ptr_sequence_impl()
         static_assert(std::same_as<flux::rvalue_element_t<S>, int&&>);
 
         static_assert(flux::contiguous_sequence<S const>);
-        static_assert(flux::sized_sequence<S const>);
+        static_assert(flux::sized_iterable<S const>);
         static_assert(flux::bounded_sequence<S const>);
         static_assert(not flux::infinite_sequence<S const>);
         static_assert(std::same_as<flux::value_t<S const>, int>);
@@ -341,7 +341,7 @@ constexpr bool test_array_ptr_sequence_impl()
 
         using C = flux::array_ptr<int const>;
         static_assert(flux::contiguous_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
         static_assert(flux::bounded_sequence<C>);
         static_assert(not flux::infinite_sequence<C>);
         static_assert(std::same_as<flux::value_t<C>, int>);
@@ -349,7 +349,7 @@ constexpr bool test_array_ptr_sequence_impl()
         static_assert(std::same_as<flux::rvalue_element_t<C>, int const&&>);
 
         static_assert(flux::contiguous_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
         static_assert(flux::bounded_sequence<C const>);
         static_assert(not flux::infinite_sequence<C const>);
         static_assert(std::same_as<flux::value_t<C const>, int>);

--- a/test/test_bitset.cpp
+++ b/test/test_bitset.cpp
@@ -22,7 +22,7 @@ constexpr bool test_bitset()
 
         static_assert(flux::random_access_sequence<B>);
         static_assert(flux::bounded_sequence<B>);
-        static_assert(flux::sized_sequence<B>);
+        static_assert(flux::sized_iterable<B>);
 
         static_assert(std::same_as<flux::element_t<B>, std::bitset<32>::reference>);
         static_assert(std::same_as<flux::element_t<B const>, bool>);

--- a/test/test_cartesian_power.cpp
+++ b/test/test_cartesian_power.cpp
@@ -34,7 +34,7 @@ constexpr bool test_cartesian_power()
         static_assert(flux::random_access_sequence<C>);
         static_assert(not flux::contiguous_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         static_assert(flux::sequence<C const>);
         static_assert(flux::multipass_sequence<C const>);
@@ -42,7 +42,7 @@ constexpr bool test_cartesian_power()
         static_assert(flux::random_access_sequence<C const>);
         static_assert(not flux::contiguous_sequence<C const>);
         static_assert(flux::bounded_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
 
         static_assert(std::same_as<flux::element_t<C>, std::tuple<int&>>);
         static_assert(std::same_as<flux::value_t<C>, std::tuple<int>>);
@@ -90,7 +90,7 @@ constexpr bool test_cartesian_power()
         static_assert(flux::random_access_sequence<C>);
         static_assert(not flux::contiguous_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         static_assert(flux::sequence<C const>);
         static_assert(flux::multipass_sequence<C const>);
@@ -98,7 +98,7 @@ constexpr bool test_cartesian_power()
         static_assert(flux::random_access_sequence<C const>);
         static_assert(not flux::contiguous_sequence<C const>);
         static_assert(flux::bounded_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
 
         static_assert(std::same_as<flux::element_t<C>, std::tuple<int&, int&>>);
         static_assert(std::same_as<flux::value_t<C>, std::tuple<int, int>>);
@@ -157,7 +157,7 @@ constexpr bool test_cartesian_power()
         static_assert(flux::random_access_sequence<C>);
         static_assert(not flux::contiguous_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         static_assert(flux::sequence<C const>);
         static_assert(flux::multipass_sequence<C const>);
@@ -165,7 +165,7 @@ constexpr bool test_cartesian_power()
         static_assert(flux::random_access_sequence<C const>);
         static_assert(not flux::contiguous_sequence<C const>);
         static_assert(flux::bounded_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
 
         static_assert(std::same_as<flux::element_t<C>, std::tuple<char&, char&, char&>>);
         static_assert(std::same_as<flux::value_t<C>, std::tuple<char, char, char>>);

--- a/test/test_cartesian_power_map.cpp
+++ b/test/test_cartesian_power_map.cpp
@@ -32,7 +32,7 @@ constexpr bool test_cartesian_power_map()
         static_assert(flux::bounded_sequence<C>);
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         STATIC_CHECK(flux::size(cart) == 2);
 
@@ -64,7 +64,7 @@ constexpr bool test_cartesian_power_map()
         static_assert(flux::bounded_sequence<C>);
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         STATIC_CHECK(flux::size(cart) == 2 * 2);
 
@@ -95,7 +95,7 @@ constexpr bool test_cartesian_power_map()
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         STATIC_CHECK(flux::size(cart) == 2 * 2 * 2);
 

--- a/test/test_cartesian_product.cpp
+++ b/test/test_cartesian_product.cpp
@@ -451,12 +451,12 @@ constexpr bool test_cartesian_product()
         STATIC_CHECK(count_j == 4);
     }
 
-    // `cartesian_product` `for_each_while` short circuits.
+    // `cartesian_product` `iterate` short circuits.
     {
         auto cart = flux::cartesian_product(std::array{100, 200}, std::array{300, 0});
 
         int count = 0;
-        cart.for_each_while(flux::unpack([&] (auto, auto j) {
+        flux::iterate(cart, flux::unpack([&] (auto, auto j) {
                 ++count;
                 return j != 0;
             }));

--- a/test/test_cartesian_product.cpp
+++ b/test/test_cartesian_product.cpp
@@ -28,7 +28,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C>);
         static_assert(not flux::contiguous_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         static_assert(flux::sequence<C const>);
         static_assert(flux::multipass_sequence<C const>);
@@ -36,7 +36,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C const>);
         static_assert(not flux::contiguous_sequence<C const>);
         static_assert(flux::bounded_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
 
         static_assert(std::same_as<flux::element_t<C>, std::tuple<int&>>);
         static_assert(std::same_as<flux::value_t<C>, std::tuple<int>>);
@@ -79,7 +79,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C>);
         static_assert(not flux::contiguous_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         static_assert(flux::sequence<C const>);
         static_assert(flux::multipass_sequence<C const>);
@@ -87,7 +87,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C const>);
         static_assert(not flux::contiguous_sequence<C const>);
         static_assert(flux::bounded_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
 
         static_assert(std::same_as<flux::element_t<C>, std::tuple<int&, bool&>>);
         static_assert(std::same_as<flux::value_t<C>, std::tuple<int, bool>>);
@@ -134,7 +134,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C>);
         static_assert(not flux::contiguous_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         static_assert(flux::sequence<C const>);
         static_assert(flux::multipass_sequence<C const>);
@@ -142,7 +142,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C const>);
         static_assert(not flux::contiguous_sequence<C const>);
         static_assert(flux::bounded_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
 
         static_assert(std::same_as<flux::element_t<C>, std::tuple<int&, bool&>>);
         static_assert(std::same_as<flux::value_t<C>, std::tuple<int, bool>>);
@@ -193,7 +193,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C>);
         static_assert(not flux::contiguous_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         static_assert(flux::sequence<C const>);
         static_assert(flux::multipass_sequence<C const>);
@@ -201,7 +201,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C const>);
         static_assert(not flux::contiguous_sequence<C const>);
         static_assert(flux::bounded_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
 
         static_assert(std::same_as<flux::element_t<C>, std::tuple<int&, bool&, unsigned long long&>>);
         static_assert(std::same_as<flux::value_t<C>, std::tuple<int, bool, unsigned long long>>);
@@ -283,7 +283,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C>);
         static_assert(not flux::contiguous_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         static_assert(flux::sequence<C const>);
         static_assert(flux::multipass_sequence<C const>);
@@ -291,7 +291,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C const>);
         static_assert(not flux::contiguous_sequence<C const>);
         static_assert(flux::bounded_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
 
         static_assert(std::same_as<flux::element_t<C>, std::tuple<int&, int&, int&, int&, int&, int&>>);
         static_assert(std::same_as<flux::value_t<C>, std::tuple<int, int, int, int, int, int>>);
@@ -346,7 +346,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C>);
         static_assert(not flux::contiguous_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         static_assert(flux::sequence<C const>);
         static_assert(flux::multipass_sequence<C const>);
@@ -354,7 +354,7 @@ constexpr bool test_cartesian_product()
         static_assert(flux::random_access_sequence<C const>);
         static_assert(not flux::contiguous_sequence<C const>);
         static_assert(flux::bounded_sequence<C const>);
-        static_assert(flux::sized_sequence<C const>);
+        static_assert(flux::sized_iterable<C const>);
 
         static_assert(std::same_as<flux::element_t<C>, std::tuple<flux::distance_t, flux::distance_t, flux::distance_t>>);
         static_assert(std::same_as<flux::value_t<C>, std::tuple<flux::distance_t, flux::distance_t, flux::distance_t>>);

--- a/test/test_cartesian_product_map.cpp
+++ b/test/test_cartesian_product_map.cpp
@@ -22,7 +22,7 @@ constexpr bool test_cartesian_product_map()
         static_assert(flux::bounded_sequence<C>);
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         STATIC_CHECK(flux::size(cart) == 2 * 5);
 
@@ -58,7 +58,7 @@ constexpr bool test_cartesian_product_map()
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
 
         STATIC_CHECK(flux::size(cart) == 2 * 3 * 4);
 

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <ranges>
 #include <utility>
 
 #include "test_utils.hpp"
@@ -73,6 +74,23 @@ constexpr bool test_chain()
         static_assert(std::same_as<flux::rvalue_element_t<S const>, int const&&>);
 
         STATIC_CHECK(check_equal(std::as_const(seq), {1, 2, 3, 4, 5, 6}));
+    }
+
+    // Chaining non-sequence iterables works as expected
+    {
+        int arr1[] = {0, 1, 2};
+        int arr2[] = {3, 4, 5};
+
+        auto seq = flux::chain(arr1 | std::views::filter(flux::pred::true_),
+                               arr2 | std::views::filter(flux::pred::true_));
+
+        using S = decltype(seq);
+
+        static_assert(flux::iterable<S>);
+        static_assert(not flux::iterable<S const>); // views::filter is not const-iterable
+        static_assert(not flux::sequence<S>);
+
+        STATIC_CHECK(check_equal(seq, {0, 1, 2, 3, 4, 5}));
     }
 
     // Chaining single-pass sequences works as expected

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -26,14 +26,14 @@ constexpr bool test_chain()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int&>);
         static_assert(std::same_as<flux::value_t<S>, int>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int&&>);
 
         static_assert(flux::random_access_sequence<S const>);
         static_assert(flux::bounded_sequence<S const>);
-        static_assert(flux::sized_sequence<S const>);
+        static_assert(flux::sized_iterable<S const>);
         static_assert(std::same_as<flux::element_t<S const>, int&>);
         static_assert(std::same_as<flux::value_t<S const>, int>);
         static_assert(std::same_as<flux::rvalue_element_t<S const>, int&&>);
@@ -60,14 +60,14 @@ constexpr bool test_chain()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int&>);
         static_assert(std::same_as<flux::value_t<S>, int>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int&&>);
 
         static_assert(flux::random_access_sequence<S const>);
         static_assert(flux::bounded_sequence<S const>);
-        static_assert(flux::sized_sequence<S const>);
+        static_assert(flux::sized_iterable<S const>);
         static_assert(std::same_as<flux::element_t<S const>, int const&>);
         static_assert(std::same_as<flux::value_t<S const>, int>);
         static_assert(std::same_as<flux::rvalue_element_t<S const>, int const&&>);

--- a/test/test_chunk.cpp
+++ b/test/test_chunk.cpp
@@ -29,7 +29,7 @@ struct NotBidir : flux::inline_sequence_base<NotBidir<Base>> {
     constexpr Base& base() & { return base_; }
     constexpr Base const& base() const& { return base_; }
 
-    struct flux_sequence_traits : flux::default_sequence_traits {
+    struct flux_iter_traits : flux::default_iter_traits {
         static constexpr auto first(auto& self) { return flux::first(self.base_); }
 
         static constexpr bool is_last(auto& self, auto const& cur) {

--- a/test/test_chunk.cpp
+++ b/test/test_chunk.cpp
@@ -62,7 +62,7 @@ constexpr bool test_chunk_single_pass()
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
         static_assert(not flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         auto cur = seq.first();
         STATIC_CHECK(check_equal(seq[cur], {1, 2}));
@@ -179,7 +179,7 @@ constexpr bool test_chunk_multipass()
         static_assert(flux::multipass_sequence<S>);
         static_assert(not flux::bidirectional_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         auto cur = seq.first();
         STATIC_CHECK(check_equal(seq[cur], {1, 2}));
@@ -201,7 +201,7 @@ constexpr bool test_chunk_multipass()
         static_assert(flux::multipass_sequence<S>);
         static_assert(not flux::bidirectional_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(check_equal(flux::read_at(seq, cur), {1, 2}));
@@ -306,7 +306,7 @@ constexpr bool test_chunk_bidir()
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(flux::random_access_sequence<S>);
 
         auto cur = seq.first();
@@ -329,7 +329,7 @@ constexpr bool test_chunk_bidir()
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(flux::random_access_sequence<S>);
 
         auto cur = flux::first(seq);

--- a/test/test_chunk.cpp
+++ b/test/test_chunk.cpp
@@ -21,7 +21,7 @@ namespace {
 constexpr bool compiler_is_msvc = COMPILER_IS_MSVC;
 
 template <flux::sequence Base>
-struct NotBidir : flux::inline_sequence_base<NotBidir<Base>> {
+struct NotBidir : flux::inline_iter_base<NotBidir<Base>> {
     Base base_;
 
     constexpr explicit NotBidir(Base base) : base_(std::move(base)) {}

--- a/test/test_chunk_by.cpp
+++ b/test/test_chunk_by.cpp
@@ -50,7 +50,7 @@ constexpr bool test_chunk_by() {
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::random_access_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
 
         STATIC_CHECK(seq.count() == 3);
 

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -260,8 +260,8 @@ namespace {
             static int const& read_at(const_iter const&, int);
         };
     };
-    static_assert(flux::const_iterable_sequence<const_iter>);
-    static_assert(flux::const_iterable_sequence<const_iter const>);
+    static_assert(flux::const_iterable<const_iter>);
+    static_assert(flux::const_iterable<const_iter const>);
 
     // read_at(S const&) is not defined
     struct not_const_iter1 {
@@ -272,7 +272,7 @@ namespace {
             static int read_at(not_const_iter1&, int);
         };
     };
-    static_assert(not flux::const_iterable_sequence<not_const_iter1>);
+    static_assert(not flux::const_iterable<not_const_iter1>);
 
     // read_at(S) and read_at(S const) yield different types
     struct not_const_iter2 {
@@ -284,8 +284,8 @@ namespace {
             static double read_at(not_const_iter2 const&, int);
         };
     };
-    static_assert(not flux::const_iterable_sequence<not_const_iter2>);
-    static_assert(flux::const_iterable_sequence<not_const_iter2 const>);
+    static_assert(not flux::const_iterable<not_const_iter2>);
+    static_assert(flux::const_iterable<not_const_iter2 const>);
 
     // read_at(S const) weakens const qualification
     struct not_const_iter3 {
@@ -297,8 +297,8 @@ namespace {
             static int& read_at(not_const_iter3 const&, int);
         };
     };
-    static_assert(not flux::const_iterable_sequence<not_const_iter3>);
-    static_assert(flux::const_iterable_sequence<not_const_iter3 const>);
+    static_assert(not flux::const_iterable<not_const_iter3>);
+    static_assert(flux::const_iterable<not_const_iter3 const>);
 
     // S is bounded but S const is not
     struct not_const_iter4 {
@@ -311,8 +311,8 @@ namespace {
             static int last(not_const_iter4&);
         };
     };
-    static_assert(not flux::const_iterable_sequence<not_const_iter4>);
-    static_assert(flux::const_iterable_sequence<not_const_iter4 const>);
+    static_assert(not flux::const_iterable<not_const_iter4>);
+    static_assert(flux::const_iterable<not_const_iter4 const>);
 
     // S const is sized but S is not
     struct not_const_iter5 {
@@ -326,8 +326,8 @@ namespace {
             static int size(not_const_iter5 const&);
         };
     };
-    static_assert(not flux::const_iterable_sequence<not_const_iter5>);
-    static_assert(flux::const_iterable_sequence<not_const_iter5 const>);
+    static_assert(not flux::const_iterable<not_const_iter5>);
+    static_assert(flux::const_iterable<not_const_iter5 const>);
 
 }
 

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -79,15 +79,15 @@ struct minimal_with_idx {
 } // end anon namespace
 
 template <>
-struct flux::sequence_traits<incomplete>
+struct flux::iter_traits<incomplete>
     : dummy_impl<incomplete> {};
 
 template <>
-struct flux::sequence_traits<indestructable>
+struct flux::iter_traits<indestructable>
     : dummy_impl<indestructable> {};
 
 template <>
-struct flux::sequence_traits<cant_instantiate<>>
+struct flux::iter_traits<cant_instantiate<>>
     : dummy_impl<cant_instantiate<>> {};
 
 static_assert(not flux::cursor<void>);
@@ -179,15 +179,15 @@ struct Derived2 : Base {};
 }
 
 template <>
-struct flux::sequence_traits<Base>
+struct flux::iter_traits<Base>
     : dummy_impl<Base> {};
 
 static_assert(flux::sequence<Base>);
 static_assert(not flux::sequence<Derived1>);
 
 template <>
-struct flux::sequence_traits<Derived2>
-    : flux::sequence_traits<Base> {};
+struct flux::iter_traits<Derived2>
+    : flux::iter_traits<Base> {};
 
 static_assert(flux::sequence<Derived2>);
 

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -49,7 +49,7 @@ struct cant_instantiate {
 };
 
 template <typename T>
-struct dummy_impl : flux::default_sequence_traits {
+struct dummy_impl : flux::default_iter_traits {
     static int first(T&);
     static bool is_last(T&, int);
     static int& inc(T&, int&);
@@ -58,7 +58,7 @@ struct dummy_impl : flux::default_sequence_traits {
 
 template <typename Elem>
 struct minimal_seq_of {
-    struct flux_sequence_traits : flux::default_sequence_traits {
+    struct flux_iter_traits : flux::default_iter_traits {
         static int first(minimal_seq_of);
         static bool is_last(minimal_seq_of, int);
         static int& inc(minimal_seq_of, int&);
@@ -68,7 +68,7 @@ struct minimal_seq_of {
 
 template <typename Idx>
 struct minimal_with_idx {
-    struct flux_sequence_traits : flux::default_sequence_traits {
+    struct flux_iter_traits : flux::default_iter_traits {
         static Idx first(minimal_with_idx);
         static bool is_last(minimal_with_idx, Idx const&);
         static Idx& inc(minimal_with_idx, Idx&);
@@ -194,7 +194,7 @@ static_assert(flux::sequence<Derived2>);
 // Adaptable sequence tests
 namespace {
     struct movable_seq {
-        struct flux_sequence_traits : flux::default_sequence_traits {
+        struct flux_iter_traits : flux::default_iter_traits {
             static int first(movable_seq);
             static bool is_last(movable_seq, int);
             static int& inc(movable_seq, int&);
@@ -207,7 +207,7 @@ namespace {
         move_only_seq(move_only_seq&&) = default;
         move_only_seq& operator=(move_only_seq&&) = default;
 
-        struct flux_sequence_traits : flux::default_sequence_traits {
+        struct flux_iter_traits : flux::default_iter_traits {
             static int first(move_only_seq const&);
             static bool is_last(move_only_seq const&, int);
             static int& inc(move_only_seq const&, int&);
@@ -220,7 +220,7 @@ namespace {
         unmovable_seq(unmovable_seq&&) = delete;
         unmovable_seq& operator=(unmovable_seq&&) = delete;
 
-        struct flux_sequence_traits : flux::default_sequence_traits {
+        struct flux_iter_traits : flux::default_iter_traits {
             static int first(unmovable_seq const&);
             static bool is_last(unmovable_seq const&, int);
             static int& inc(unmovable_seq const&, int&);
@@ -252,7 +252,7 @@ namespace {
 // const_iterable_sequence tests
 namespace {
     struct const_iter {
-        struct flux_sequence_traits : flux::default_sequence_traits {
+        struct flux_iter_traits : flux::default_iter_traits {
             static int first(const_iter const&);
             static bool is_last(const_iter const&, int);
             static void inc(const_iter const&, int&);
@@ -265,7 +265,7 @@ namespace {
 
     // read_at(S const&) is not defined
     struct not_const_iter1 {
-        struct flux_sequence_traits : flux::default_sequence_traits {
+        struct flux_iter_traits : flux::default_iter_traits {
             static int first(not_const_iter1 const&);
             static bool is_last(not_const_iter1 const&, int);
             static void inc(not_const_iter1 const&, int&);
@@ -276,7 +276,7 @@ namespace {
 
     // read_at(S) and read_at(S const) yield different types
     struct not_const_iter2 {
-        struct flux_sequence_traits : flux::default_sequence_traits {
+        struct flux_iter_traits : flux::default_iter_traits {
             static int first(not_const_iter2 const&);
             static bool is_last(not_const_iter2 const&, int);
             static void inc(not_const_iter2 const&, int&);
@@ -289,7 +289,7 @@ namespace {
 
     // read_at(S const) weakens const qualification
     struct not_const_iter3 {
-        struct flux_sequence_traits : flux::default_sequence_traits {
+        struct flux_iter_traits : flux::default_iter_traits {
             static int first(not_const_iter3 const&);
             static bool is_last(not_const_iter3 const&, int);
             static void inc(not_const_iter3 const&, int&);
@@ -302,7 +302,7 @@ namespace {
 
     // S is bounded but S const is not
     struct not_const_iter4 {
-        struct flux_sequence_traits : flux::default_sequence_traits {
+        struct flux_iter_traits : flux::default_iter_traits {
             static int first(not_const_iter4 const&);
             static bool is_last(not_const_iter4 const&, int);
             static void inc(not_const_iter4 const&, int&);
@@ -316,7 +316,7 @@ namespace {
 
     // S const is sized but S is not
     struct not_const_iter5 {
-        struct flux_sequence_traits : flux::default_sequence_traits {
+        struct flux_iter_traits : flux::default_iter_traits {
             static int first(not_const_iter5 const&);
             static bool is_last(not_const_iter5 const&, int);
             static void inc(not_const_iter5 const&, int&);

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -26,7 +26,7 @@ constexpr bool test_count()
         STATIC_CHECK(flux::count(arr) == 5);
 
         auto seq = flux::take_while(flux::ref(arr), [](int) { return true; });
-        static_assert(not flux::sized_sequence<decltype(seq)>);
+        static_assert(not flux::sized_iterable<decltype(seq)>);
 
         STATIC_CHECK(flux::count(seq) == 5);
     }
@@ -36,7 +36,7 @@ constexpr bool test_count()
         STATIC_CHECK(flux::ref(arr).count() == 5);
 
         auto seq = flux::take_while(flux::ref(arr), [](int) { return true; });
-        static_assert(not flux::sized_sequence<decltype(seq)>);
+        static_assert(not flux::sized_iterable<decltype(seq)>);
 
         STATIC_CHECK(seq.count() == 5);
     }

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -3,6 +3,9 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <array>
+#include <ranges>
+
 #include "test_utils.hpp"
 
 namespace {
@@ -46,6 +49,16 @@ constexpr bool test_count()
         auto seq = flux::ref(arr);
         STATIC_CHECK(seq.count_eq(2) == 3);
         STATIC_CHECK(seq.count_eq(99) == 0);
+    }
+
+    // Test with non-sequence iterable
+    {
+        auto view = std::array{1, 2, 2, 2, 3, 4, 5} | std::views::filter(flux::pred::even);
+
+        STATIC_CHECK(flux::count(view) == 4);
+
+        STATIC_CHECK(flux::count_eq(view, 2) == 3);
+
     }
 
     return true;

--- a/test/test_count_if.cpp
+++ b/test/test_count_if.cpp
@@ -3,6 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <ranges>
+
 #include "test_utils.hpp"
 
 
@@ -35,6 +37,15 @@ constexpr bool test_count_if()
         STATIC_CHECK(flux::count_if(arr, flux::proj(is_even, &S::i)));
 
         STATIC_CHECK(flux::ref(arr).count_if(flux::proj(is_even, &S::i)));
+    }
+
+    // Test with non-sequence iterable
+    {
+        int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        auto view = arr | std::views::filter(flux::pred::even);
+
+        STATIC_CHECK(flux::count_if(view, flux::pred::odd) == 0);
+        STATIC_CHECK(flux::count_if(view, flux::pred::even) == 5);
     }
 
     return true;

--- a/test/test_cursors.cpp
+++ b/test/test_cursors.cpp
@@ -22,7 +22,7 @@ constexpr bool test_cursors()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(not flux::infinite_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, flux::index_t>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, flux::index_t>);
@@ -51,7 +51,7 @@ constexpr bool test_cursors()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(not flux::bounded_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::infinite_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, std::size_t>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, std::size_t>);

--- a/test/test_cycle.cpp
+++ b/test/test_cycle.cpp
@@ -23,7 +23,7 @@ constexpr bool test_cycle() {
         static_assert(flux::multipass_sequence<C>);
         static_assert(flux::infinite_sequence<C>);
         static_assert(flux::read_only_iterable<C>);
-        static_assert(not flux::sized_sequence<C>); // infinite
+        static_assert(not flux::sized_iterable<C>); // infinite
         static_assert(not flux::bounded_sequence<C>); // infinite
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
@@ -68,7 +68,7 @@ constexpr bool test_cycle() {
         static_assert(flux::multipass_sequence<C>);
         static_assert(flux::read_only_iterable<C>);
         static_assert(not flux::infinite_sequence<C>);
-        static_assert(flux::sized_sequence<C>); // not infinite
+        static_assert(flux::sized_iterable<C>); // not infinite
         static_assert(flux::bounded_sequence<C>);
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
@@ -99,7 +99,7 @@ constexpr bool test_cycle() {
         static_assert(flux::multipass_sequence<C>);
         static_assert(flux::read_only_iterable<C>);
         static_assert(not flux::infinite_sequence<C>);
-        static_assert(flux::sized_sequence<C>); // not infinite
+        static_assert(flux::sized_iterable<C>); // not infinite
         static_assert(flux::bounded_sequence<C>);
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
@@ -131,7 +131,7 @@ constexpr bool test_cycle() {
         static_assert(flux::multipass_sequence<C>);
         static_assert(flux::infinite_sequence<C>);
         static_assert(flux::read_only_iterable<C>);
-        static_assert(not flux::sized_sequence<C>); // infinite
+        static_assert(not flux::sized_iterable<C>); // infinite
         static_assert(not flux::bounded_sequence<C>); // infinite
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
@@ -158,7 +158,7 @@ constexpr bool test_cycle() {
         static_assert(flux::multipass_sequence<C>);
         static_assert(flux::infinite_sequence<C>);
         static_assert(flux::read_only_iterable<C>);
-        static_assert(not flux::sized_sequence<C>); // infinite
+        static_assert(not flux::sized_iterable<C>); // infinite
         static_assert(not flux::bounded_sequence<C>); // infinite
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
@@ -229,7 +229,7 @@ constexpr bool test_bounded_cycle()
         static_assert(flux::multipass_sequence<C>);
         static_assert(not flux::infinite_sequence<C>);
         static_assert(flux::read_only_iterable<C>);
-        static_assert(flux::sized_sequence<C>);
+        static_assert(flux::sized_iterable<C>);
         static_assert(flux::bounded_sequence<C>);
         static_assert(flux::bidirectional_sequence<C>);
         static_assert(flux::random_access_sequence<C>);
@@ -299,7 +299,7 @@ constexpr bool test_bounded_cycle()
         static_assert(flux::multipass_sequence<C>);
         static_assert(not flux::bidirectional_sequence<C>); // take_while is not bounded
         static_assert(not flux::infinite_sequence<C>);
-        static_assert(not flux::sized_sequence<C>);
+        static_assert(not flux::sized_iterable<C>);
         static_assert(flux::bounded_sequence<C>); // because we can form last()
 
         STATIC_CHECK(seq.is_last(seq.last()));

--- a/test/test_cycle.cpp
+++ b/test/test_cycle.cpp
@@ -22,7 +22,7 @@ constexpr bool test_cycle() {
         static_assert(flux::sequence<C>);
         static_assert(flux::multipass_sequence<C>);
         static_assert(flux::infinite_sequence<C>);
-        static_assert(flux::read_only_sequence<C>);
+        static_assert(flux::read_only_iterable<C>);
         static_assert(not flux::sized_sequence<C>); // infinite
         static_assert(not flux::bounded_sequence<C>); // infinite
         static_assert(flux::bidirectional_sequence<C>);
@@ -66,7 +66,7 @@ constexpr bool test_cycle() {
 
         static_assert(flux::sequence<C>);
         static_assert(flux::multipass_sequence<C>);
-        static_assert(flux::read_only_sequence<C>);
+        static_assert(flux::read_only_iterable<C>);
         static_assert(not flux::infinite_sequence<C>);
         static_assert(flux::sized_sequence<C>); // not infinite
         static_assert(flux::bounded_sequence<C>);
@@ -97,7 +97,7 @@ constexpr bool test_cycle() {
 
         static_assert(flux::sequence<C>);
         static_assert(flux::multipass_sequence<C>);
-        static_assert(flux::read_only_sequence<C>);
+        static_assert(flux::read_only_iterable<C>);
         static_assert(not flux::infinite_sequence<C>);
         static_assert(flux::sized_sequence<C>); // not infinite
         static_assert(flux::bounded_sequence<C>);
@@ -130,7 +130,7 @@ constexpr bool test_cycle() {
         static_assert(flux::sequence<C>);
         static_assert(flux::multipass_sequence<C>);
         static_assert(flux::infinite_sequence<C>);
-        static_assert(flux::read_only_sequence<C>);
+        static_assert(flux::read_only_iterable<C>);
         static_assert(not flux::sized_sequence<C>); // infinite
         static_assert(not flux::bounded_sequence<C>); // infinite
         static_assert(flux::bidirectional_sequence<C>);
@@ -157,7 +157,7 @@ constexpr bool test_cycle() {
         static_assert(flux::sequence<C>);
         static_assert(flux::multipass_sequence<C>);
         static_assert(flux::infinite_sequence<C>);
-        static_assert(flux::read_only_sequence<C>);
+        static_assert(flux::read_only_iterable<C>);
         static_assert(not flux::sized_sequence<C>); // infinite
         static_assert(not flux::bounded_sequence<C>); // infinite
         static_assert(flux::bidirectional_sequence<C>);
@@ -228,7 +228,7 @@ constexpr bool test_bounded_cycle()
         static_assert(flux::sequence<C>);
         static_assert(flux::multipass_sequence<C>);
         static_assert(not flux::infinite_sequence<C>);
-        static_assert(flux::read_only_sequence<C>);
+        static_assert(flux::read_only_iterable<C>);
         static_assert(flux::sized_sequence<C>);
         static_assert(flux::bounded_sequence<C>);
         static_assert(flux::bidirectional_sequence<C>);

--- a/test/test_drop.cpp
+++ b/test/test_drop.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <list>
+#include <ranges>
 #include <span>
 #include <string>
 #include <string_view>
@@ -76,6 +77,21 @@ constexpr bool test_drop() {
 
         STATIC_CHECK(flux::size(dropped) == 5);
         STATIC_CHECK(check_equal(dropped, {5, 6, 7, 8, 9}));
+    }
+
+    // test dropping non-sequence iterable
+    {
+        std::array arr{1, 2, 3, 4, 5};
+        auto view = arr | std::views::transform(std::identity{});
+
+        auto iter = flux::mut_ref(view).drop(2);
+
+        using I = decltype(iter);
+        static_assert(flux::iterable<I>);
+        static_assert(flux::sized_iterable<I>);
+        static_assert(not flux::sequence<I>);
+
+        STATIC_CHECK(iter.sum() == 3 + 4 + 5);
     }
 
     // test dropping zero items

--- a/test/test_drop.cpp
+++ b/test/test_drop.cpp
@@ -24,11 +24,11 @@ constexpr bool test_drop() {
         using D = decltype(dropped);
 
         static_assert(flux::contiguous_sequence<D>);
-        static_assert(flux::sized_sequence<D>);
+        static_assert(flux::sized_iterable<D>);
         static_assert(flux::bounded_sequence<D>);
 
         static_assert(flux::contiguous_sequence<D const>);
-        static_assert(flux::sized_sequence<D const>);
+        static_assert(flux::sized_iterable<D const>);
         static_assert(flux::bounded_sequence<D const>);
 
         STATIC_CHECK(flux::size(dropped) == 5);
@@ -48,11 +48,11 @@ constexpr bool test_drop() {
         using D = decltype(dropped);
 
         static_assert(flux::contiguous_sequence<D>);
-        static_assert(flux::sized_sequence<D>);
+        static_assert(flux::sized_iterable<D>);
         static_assert(flux::bounded_sequence<D>);
 
         static_assert(flux::contiguous_sequence<D const>);
-        static_assert(flux::sized_sequence<D const>);
+        static_assert(flux::sized_iterable<D const>);
         static_assert(flux::bounded_sequence<D const>);
 
         STATIC_CHECK(flux::size(dropped) == 5);
@@ -71,7 +71,7 @@ constexpr bool test_drop() {
 
         static_assert(flux::sequence<D>);
         static_assert(not flux::multipass_sequence<D>);
-        static_assert(flux::sized_sequence<D>);
+        static_assert(flux::sized_iterable<D>);
         static_assert(flux::bounded_sequence<D>);
 
         STATIC_CHECK(flux::size(dropped) == 5);

--- a/test/test_drop_while.cpp
+++ b/test/test_drop_while.cpp
@@ -20,11 +20,11 @@ constexpr bool test_drop_while()
 
         static_assert(flux::contiguous_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>); // because bounded + RA
+        static_assert(flux::sized_iterable<S>); // because bounded + RA
 
         static_assert(flux::contiguous_sequence<S const>);
         static_assert(flux::bounded_sequence<S const>);
-        static_assert(flux::sized_sequence<S const>);
+        static_assert(flux::sized_iterable<S const>);
 
         STATIC_CHECK(seq.size() == 5);
         STATIC_CHECK(seq.data() == arr + 5);

--- a/test/test_drop_while.cpp
+++ b/test/test_drop_while.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>
+#include <ranges>
 
 #include "test_utils.hpp"
 

--- a/test/test_drop_while.cpp
+++ b/test/test_drop_while.cpp
@@ -36,6 +36,27 @@ constexpr bool test_drop_while()
         STATIC_CHECK(check_equal(seq, {5, 6, 7, 8, 9}));
     }
 
+    // Non-sequence iterables are okay
+    {
+        int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+        auto rng = arr | std::views::filter(flux::pred::true_);
+
+        auto iter = flux::mut_ref(rng).drop_while([](int i) {
+            return i < 5;
+        });
+
+        using S = decltype(iter);
+
+        static_assert(flux::iterable<S>);
+        static_assert(flux::const_iterable<S>);
+        static_assert(not flux::sequence<S>);
+        static_assert(std::same_as<flux::element_t<S>, int&>);
+
+        STATIC_CHECK(check_equal(iter, {5, 6, 7, 8, 9}));
+
+    }
+
     // Single-pass sequences are okay
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};

--- a/test/test_empty.cpp
+++ b/test/test_empty.cpp
@@ -20,7 +20,7 @@ consteval auto empty_test() {
     auto e = flux::empty<T>;
     auto f = flux::empty<T>;
 
-    static_assert(flux::sized_sequence<decltype(e)>);
+    static_assert(flux::sized_iterable<decltype(e)>);
     static_assert(flux::bounded_sequence<decltype(e)>);
     static_assert(std::same_as<flux::element_t<decltype(e)>, T&>);
 

--- a/test/test_equal.cpp
+++ b/test/test_equal.cpp
@@ -57,7 +57,7 @@ constexpr bool test_equal()
         auto seq1 = flux::take_while(std::array{1, 2, 3, 4, 5}, yes);
         auto seq2 = flux::take_while(std::array{1}, yes);
 
-        static_assert(not flux::sized_sequence<decltype(seq1)>);
+        static_assert(not flux::sized_iterable<decltype(seq1)>);
 
         STATIC_CHECK(not flux::equal(seq1, seq2));
         STATIC_CHECK(not flux::equal(seq2, seq1));

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>
+#include <ranges>
 
 #include "test_utils.hpp"
 
@@ -66,6 +67,13 @@ constexpr bool test_fill()
         std::array<std::uint8_t, 0> arr{};
         std::uint8_t c = 5;
         flux::fill(arr, c);
+    }
+
+    // fill with non-sequence iterable
+    {
+        std::array arr = {1, 2, 3, 4, 5};
+        flux::fill(arr | std::views::filter(flux::pred::even), 99);
+        STATIC_CHECK(check_equal(arr, {1, 99, 3, 99, 5}));
     }
 
     return true;

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -46,13 +46,13 @@ constexpr bool test_filter()
         static_assert(flux::bidirectional_sequence<F>);
         static_assert(flux::bounded_sequence<F>);
         static_assert(not flux::ordered_cursor<F>);
-        static_assert(not flux::sized_sequence<F>);
+        static_assert(not flux::sized_iterable<F>);
 
         static_assert(flux::sequence<F const>);
         static_assert(flux::bidirectional_sequence<F const>);
         static_assert(flux::bounded_sequence<F const>);
         static_assert(not flux::ordered_cursor<F const>);
-        static_assert(not flux::sized_sequence<F const>);
+        static_assert(not flux::sized_iterable<F const>);
 
         STATIC_CHECK(check_equal(filtered, {0, 2, 4, 6, 8}));
         STATIC_CHECK(check_equal(std::as_const(filtered), {0, 2, 4, 6, 8}));
@@ -79,7 +79,7 @@ constexpr bool test_filter()
         static_assert(flux::sequence<F>);
         static_assert(not flux::multipass_sequence<F>);
         static_assert(flux::bounded_sequence<F>);
-        static_assert(not flux::sized_sequence<F>);
+        static_assert(not flux::sized_iterable<F>);
 
         if (!check_equal(filtered, {0, 2, 4, 6, 8})) {
             return false;

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>
+#include <ranges>
 #include <utility>
 
 #include "test_utils.hpp"
@@ -55,6 +56,19 @@ constexpr bool test_filter()
 
         STATIC_CHECK(check_equal(filtered, {0, 2, 4, 6, 8}));
         STATIC_CHECK(check_equal(std::as_const(filtered), {0, 2, 4, 6, 8}));
+    }
+
+    // Filtering non-sequence iterables works okay
+    {
+        auto view = std::array{1, 2, 3, 4, 5} | std::views::filter(flux::pred::true_);
+
+        auto filtered = flux::filter(std::move(view), is_even);
+        using F = decltype(filtered);
+
+        static_assert(flux::iterable<F>);
+        static_assert(!flux::sequence<F>);
+
+        STATIC_CHECK(check_equal(filtered, {2, 4}));
     }
 
     // Filtering single-pass sequences works okay

--- a/test/test_filter_map.cpp
+++ b/test/test_filter_map.cpp
@@ -44,13 +44,13 @@ constexpr bool test_filter()
         static_assert(flux::bidirectional_sequence<F>);
         static_assert(flux::bounded_sequence<F>);
         static_assert(not flux::ordered_cursor<F>);
-        static_assert(not flux::sized_sequence<F>);
+        static_assert(not flux::sized_iterable<F>);
 
         static_assert(flux::sequence<F const>);
         static_assert(flux::bidirectional_sequence<F const>);
         static_assert(flux::bounded_sequence<F const>);
         static_assert(not flux::ordered_cursor<F const>);
-        static_assert(not flux::sized_sequence<F const>);
+        static_assert(not flux::sized_iterable<F const>);
 
         STATIC_CHECK(check_equal(filtered, {0, 2, 4, 6, 8}));
         STATIC_CHECK(check_equal(std::as_const(filtered), {0, 2, 4, 6, 8}));

--- a/test/test_filter_map.cpp
+++ b/test/test_filter_map.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <optional>
+#include <ranges>
 #include <utility>
 
 #include "test_utils.hpp"

--- a/test/test_filter_map.cpp
+++ b/test/test_filter_map.cpp
@@ -56,6 +56,20 @@ constexpr bool test_filter()
         STATIC_CHECK(check_equal(std::as_const(filtered), {0, 2, 4, 6, 8}));
     }
 
+    // Basic filtering of non-sequence iterables
+    {
+        int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        auto rng = arr | std::views::transform(std::identity{});
+        auto filtered = flux::filter_map(std::move(rng), is_even_opt);
+
+        using F = decltype(filtered);
+        static_assert(flux::iterable<F>);
+        static_assert(flux::const_iterable<F>);
+        static_assert(not flux::sequence<F>);
+
+        STATIC_CHECK(check_equal(filtered, {0, 2, 4, 6, 8}));
+    }
+
     // A predicate that always returns true returns what it was given
     {
         int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};

--- a/test/test_flatten.cpp
+++ b/test/test_flatten.cpp
@@ -46,7 +46,7 @@ constexpr bool test_flatten_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5, 6, 7, 8, 9}));
@@ -65,7 +65,7 @@ constexpr bool test_flatten_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5, 6, 7, 8, 9}));
@@ -84,7 +84,7 @@ constexpr bool test_flatten_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(check_equal(seq, {1, 2, 3}));
@@ -110,7 +110,7 @@ constexpr bool test_flatten_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(seq.count() == 0);
@@ -128,7 +128,7 @@ constexpr bool test_flatten_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5, 6, 7, 8, 9}));
@@ -203,7 +203,7 @@ constexpr bool test_flatten_multipass()
 
         using S = decltype(seq);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(seq.is_empty());
@@ -220,7 +220,7 @@ constexpr bool test_flatten_multipass()
 
         using S = decltype(seq);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(check_equal(seq, {1, 2, 3, 4, 5, 6, 7, 8, 9}));

--- a/test/test_flatten_with.cpp
+++ b/test/test_flatten_with.cpp
@@ -26,7 +26,7 @@ constexpr bool test_flatten_with_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, char const&>);
         static_assert(std::same_as<flux::value_t<S>, char>);
@@ -43,7 +43,7 @@ constexpr bool test_flatten_with_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(check_equal(seq, "111-222-333"sv));
@@ -65,7 +65,7 @@ constexpr bool test_flatten_with_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(check_equal(seq, "111222333"sv));
@@ -82,7 +82,7 @@ constexpr bool test_flatten_with_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(check_equal(seq, "123--456--7-89"sv));
@@ -97,7 +97,7 @@ constexpr bool test_flatten_with_single_pass()
         using S = decltype(seq);
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(seq.count() == 0);
@@ -116,7 +116,7 @@ constexpr bool test_flatten_with_multipass()
 
         using S = decltype(seq);
         static_assert(flux::bidirectional_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, char const&>);
         static_assert(std::same_as<flux::value_t<S>, char>);

--- a/test/test_flatten_with.cpp
+++ b/test/test_flatten_with.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/test/test_for_each.cpp
+++ b/test/test_for_each.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>
+#include <ranges>
 
 #include "test_utils.hpp"
 
@@ -57,6 +58,17 @@ constexpr bool test_for_each()
         auto result = flux::for_each(ilist, counter{});
 
         STATIC_CHECK(result.sum == 12);
+    }
+
+    // Test flux::for_each with non-RA std range
+    {
+        auto rng = std::array{0, 1, 2, 3, 4} | std::views::filter(flux::pred::even);
+
+        int sum = 0;
+        auto fun = [&](int i) { sum += i; };
+        flux::for_each(rng, fun);
+
+        STATIC_CHECK(sum == 6);
     }
 
     return true;

--- a/test/test_from_range.cpp
+++ b/test/test_from_range.cpp
@@ -36,7 +36,7 @@ constexpr bool test_from_range()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::contiguous_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(flux::read_at(seq, flux::first(seq)) == 10);
@@ -123,7 +123,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int&>);
@@ -143,7 +143,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int&>);
@@ -163,7 +163,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -183,7 +183,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -204,7 +204,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int&>);
@@ -227,7 +227,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -247,7 +247,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -267,7 +267,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -287,7 +287,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -308,7 +308,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -328,7 +328,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(flux::sized_sequence<S>);
+            static_assert(flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -353,7 +353,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int&>);
@@ -373,7 +373,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int&>);
@@ -393,7 +393,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -413,7 +413,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -434,7 +434,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int&>);
@@ -457,7 +457,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -477,7 +477,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -497,7 +497,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -517,7 +517,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -538,7 +538,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -558,7 +558,7 @@ TEST_CASE("from range")
             static_assert(not flux::random_access_sequence<S>);
             static_assert(not flux::contiguous_sequence<S>);
             static_assert(flux::bounded_sequence<S>);
-            static_assert(not flux::sized_sequence<S>);
+            static_assert(not flux::sized_iterable<S>);
 
             static_assert(std::same_as<flux::value_t<S>, int>);
             static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -580,7 +580,7 @@ TEST_CASE("from range")
 
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(not flux::bounded_sequence<S>);
 
         static_assert(not flux::sequence<S const>);

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -67,7 +67,7 @@ TEST_CASE("generator")
 
         static_assert(flux::sequence<I>);
         static_assert(not flux::multipass_sequence<I>);
-        static_assert(not flux::sized_sequence<I>);
+        static_assert(not flux::sized_iterable<I>);
         static_assert(not flux::bounded_sequence<I>);
 
         static_assert(std::same_as<flux::element_t<I>, int const&>);

--- a/test/test_iota.cpp
+++ b/test/test_iota.cpp
@@ -21,7 +21,7 @@ constexpr bool test_iota_basic()
     static_assert(flux::random_access_sequence<F>);
     static_assert(flux::infinite_sequence<F>);
     static_assert(not flux::bounded_sequence<F>);
-    static_assert(not flux::sized_sequence<F>);
+    static_assert(not flux::sized_iterable<F>);
 
     STATIC_CHECK(check_equal(flux::take(f, 5), {0, 1, 2, 3, 4}));
 
@@ -41,7 +41,7 @@ constexpr bool test_iota_from()
     static_assert(flux::random_access_sequence<F>);
     static_assert(flux::infinite_sequence<F>);
     static_assert(not flux::bounded_sequence<F>);
-    static_assert(not flux::sized_sequence<F>);
+    static_assert(not flux::sized_iterable<F>);
 
     STATIC_CHECK(check_equal(flux::take(f, 5), {1u, 2u, 3u, 4u, 5u}));
 
@@ -60,7 +60,7 @@ constexpr bool test_iota_bounded()
     static_assert(flux::random_access_sequence<F>);
     static_assert(not flux::infinite_sequence<F>);
     static_assert(flux::bounded_sequence<F>);
-    static_assert(flux::sized_sequence<F>);
+    static_assert(flux::sized_iterable<F>);
 
     STATIC_CHECK(f.size() == 5);
     STATIC_CHECK(check_equal(f, {1u, 2u, 3u, 4u, 5u}));
@@ -82,7 +82,7 @@ constexpr bool test_iota_custom_type()
     static_assert(not flux::random_access_sequence<F>); // no iter_difference_t
     static_assert(not flux::infinite_sequence<F>);
     static_assert(flux::bounded_sequence<F>);
-    static_assert(not flux::sized_sequence<F>); // !
+    static_assert(not flux::sized_iterable<F>); // !
 
     STATIC_CHECK(f.count() == 5);
     STATIC_CHECK(check_equal(f, {1s, 2s, 3s, 4s, 5s}));

--- a/test/test_istream.cpp
+++ b/test/test_istream.cpp
@@ -18,7 +18,7 @@ TEST_CASE("istream")
 
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(not flux::bounded_sequence<S>);
 
         static_assert(std::same_as<flux::element_t<S>, int const&>);

--- a/test/test_istreambuf.cpp
+++ b/test/test_istreambuf.cpp
@@ -19,7 +19,7 @@ TEST_CASE("istreambuf")
 
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(not flux::bounded_sequence<S>);
 
         static_assert(std::same_as<flux::element_t<S>, char>);

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -60,6 +60,25 @@ constexpr bool test_map()
         STATIC_CHECK(mapped.size() == 5);
     }
 
+    // We can map non-sequence iterables
+    {
+        auto view = std::array{1, 2, 3, 4, 5} | std::views::transform(std::identity{});
+
+        auto mapped = flux::map(std::move(view), [](int i) { return i * 2; });
+
+        using M = decltype(mapped);
+
+        static_assert(flux::iterable<M>);
+        static_assert(flux::sized_iterable<M>);
+        static_assert(!flux::sequence<M>);
+
+        static_assert(flux::iterable<M const>);
+        static_assert(flux::sized_iterable<M>);
+        static_assert(!flux::sequence<M>);
+
+        STATIC_CHECK(check_equal(mapped, {2, 4, 6, 8, 10}));
+    }
+
     {
         int arr[] = {0, 1, 2, 3, 4};
 

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -23,7 +23,7 @@ constexpr bool test_map()
         static_assert(flux::random_access_sequence<M>);
         static_assert(not flux::contiguous_sequence<M>);
         static_assert(flux::bounded_sequence<M>);
-        static_assert(flux::sized_sequence<M>);
+        static_assert(flux::sized_iterable<M>);
 
         static_assert(std::same_as<int, flux::element_t<M>>);
         static_assert(std::same_as<int, flux::rvalue_element_t<M>>);
@@ -31,7 +31,7 @@ constexpr bool test_map()
         static_assert(flux::random_access_sequence<M const>);
         static_assert(not flux::contiguous_sequence<M const>);
         static_assert(flux::bounded_sequence<M const>);
-        static_assert(flux::sized_sequence<M const>);
+        static_assert(flux::sized_iterable<M const>);
 
         STATIC_CHECK(check_equal(mapped, {0, 2, 4, 6, 8}));
         STATIC_CHECK(mapped.size() == 5);
@@ -45,7 +45,7 @@ constexpr bool test_map()
         static_assert(flux::random_access_sequence<M>);
         static_assert(not flux::contiguous_sequence<M>);
         static_assert(flux::bounded_sequence<M>);
-        static_assert(flux::sized_sequence<M>);
+        static_assert(flux::sized_iterable<M>);
 
         static_assert(std::same_as<int const&, flux::element_t<M>>);
         static_assert(std::same_as<int const&&, flux::rvalue_element_t<M>>);
@@ -54,7 +54,7 @@ constexpr bool test_map()
         static_assert(flux::random_access_sequence<M const>);
         static_assert(not flux::contiguous_sequence<M const>);
         static_assert(flux::bounded_sequence<M const>);
-        static_assert(flux::sized_sequence<M const>);
+        static_assert(flux::sized_iterable<M const>);
 
         STATIC_CHECK(check_equal(mapped, {0, 1, 2, 3, 4}));
         STATIC_CHECK(mapped.size() == 5);

--- a/test/test_mask.cpp
+++ b/test/test_mask.cpp
@@ -24,7 +24,7 @@ constexpr bool test_mask()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::infinite_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int&>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int&&>);
         static_assert(std::same_as<flux::const_element_t<S>, int const&>);
@@ -45,7 +45,7 @@ constexpr bool test_mask()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::infinite_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int const&&>);
         static_assert(std::same_as<flux::const_element_t<S>, int const&>);
@@ -67,7 +67,7 @@ constexpr bool test_mask()
         static_assert(not flux::bidirectional_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::infinite_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int const&&>);
         static_assert(std::same_as<flux::const_element_t<S>, int const&>);
@@ -88,7 +88,7 @@ constexpr bool test_mask()
         static_assert(not flux::bidirectional_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::infinite_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int&>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int&&>);
         static_assert(std::same_as<flux::const_element_t<S>, int const&>);

--- a/test/test_minmax.cpp
+++ b/test/test_minmax.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>
+#include <ranges>
 
 #include "test_utils.hpp"
 
@@ -42,6 +43,18 @@ constexpr bool test_min()
         STATIC_CHECK(flux::min(arr, flux::proj(flux::cmp::compare, &IntPair::a))->b == 2);
     }
 
+    // Can find the min of a non-sequence iterable...
+    {
+        int arr[] = {1, 2, 3, 0, 1};
+        STATIC_CHECK(flux::min(arr | std::views::filter(flux::pred::true_)).value() == 0);
+    }
+
+    // ...including an empty one
+    {
+        int arr[] = {1, 2, 3, 0, 1};
+        STATIC_CHECK(not flux::min(arr | std::views::filter(flux::pred::false_)).has_value());
+    }
+
     return true;
 }
 static_assert(test_min());
@@ -71,6 +84,18 @@ constexpr bool test_max()
     {
         IntPair arr[] = { {1, 2}, {1, 3}, {1, 4}};
         STATIC_CHECK(flux::max(arr, flux::proj(flux::cmp::compare, &IntPair::a))->b == 4);
+    }
+
+    // Can find the max of a non-sequence iterable...
+    {
+        int arr[] = {1, 2, 3, 0, 1};
+        STATIC_CHECK(flux::max(arr | std::views::filter(flux::pred::true_)).value() == 3);
+    }
+
+    // ...including an empty one
+    {
+        int arr[] = {1, 2, 3, 0, 1};
+        STATIC_CHECK(not flux::max(arr | std::views::filter(flux::pred::false_)).has_value());
     }
 
     return true;
@@ -110,6 +135,20 @@ constexpr bool test_minmax()
         auto result = flux::minmax(arr, flux::proj(flux::cmp::compare, &IntPair::a)).value();
         STATIC_CHECK(result.min == IntPair{1, 2});
         STATIC_CHECK(result.max == IntPair{1, 4});
+    }
+
+    // Can find the min and max of a non-sequence iterable...
+    {
+        int arr[] = {1, 2, 3, 0, 1};
+        auto [min, max] = flux::minmax(arr | std::views::filter(flux::pred::true_)).value();
+        STATIC_CHECK(min == 0);
+        STATIC_CHECK(max == 3);
+    }
+
+    // ...including an empty one
+    {
+        int arr[] = {1, 2, 3, 0, 1};
+        STATIC_CHECK(not flux::minmax(arr | std::views::filter(flux::pred::false_)).has_value());
     }
 
     return true;

--- a/test/test_output_to.cpp
+++ b/test/test_output_to.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <iterator>
 #include <list>
+#include <ranges>
 #include <sstream>
 #include <vector>
 
@@ -87,5 +88,15 @@ TEST_CASE("output to")
 
         REQUIRE(iter == out.begin());
         REQUIRE(out.empty());
+    }
+
+    SUBCASE("...with a non-sequence iterable")
+    {
+        std::vector<int> const in{1, 2, 3, 4, 5};
+        std::vector<int> out;
+
+        flux::output_to(in | std::views::filter(flux::pred::odd), std::back_inserter(out));
+
+        REQUIRE(check_equal(out, {1, 3, 5}));
     }
 }

--- a/test/test_read_only.cpp
+++ b/test/test_read_only.cpp
@@ -21,7 +21,7 @@ constexpr bool test_read_only() {
         static_assert(flux::contiguous_sequence<S>);
         static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int const&&>);
         static_assert(std::same_as<flux::value_t<S>, int>);
@@ -40,7 +40,7 @@ constexpr bool test_read_only() {
         static_assert(flux::contiguous_sequence<S>);
         static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int const&&>);
         static_assert(std::same_as<flux::value_t<S>, int>);
@@ -61,7 +61,7 @@ constexpr bool test_read_only() {
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&&>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int const&&>);
         static_assert(std::same_as<flux::value_t<S>, int>);
@@ -83,7 +83,7 @@ constexpr bool test_read_only() {
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(flux::read_only_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&&>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int const&&>);
@@ -104,7 +104,7 @@ constexpr bool test_read_only() {
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int>);
         static_assert(std::same_as<flux::value_t<S>, int>);

--- a/test/test_read_only.cpp
+++ b/test/test_read_only.cpp
@@ -19,7 +19,7 @@ constexpr bool test_read_only() {
         using S = decltype(seq);
 
         static_assert(flux::contiguous_sequence<S>);
-        static_assert(flux::read_only_sequence<S>);
+        static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(flux::sized_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -38,7 +38,7 @@ constexpr bool test_read_only() {
         using S = decltype(seq);
 
         static_assert(flux::contiguous_sequence<S>);
-        static_assert(flux::read_only_sequence<S>);
+        static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(flux::sized_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&>);
@@ -59,7 +59,7 @@ constexpr bool test_read_only() {
         using S = decltype(seq);
 
         static_assert(flux::random_access_sequence<S>);
-        static_assert(flux::read_only_sequence<S>);
+        static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(flux::sized_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&&>);
@@ -81,10 +81,10 @@ constexpr bool test_read_only() {
         using S = decltype(seq);
 
         static_assert(flux::random_access_sequence<S>);
-        static_assert(flux::read_only_sequence<S>);
+        static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(flux::sized_sequence<S>);
-        static_assert(flux::read_only_sequence<S>);
+        static_assert(flux::read_only_iterable<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&&>);
         static_assert(std::same_as<flux::rvalue_element_t<S>, int const&&>);
         static_assert(std::same_as<flux::value_t<S>, int>);
@@ -102,7 +102,7 @@ constexpr bool test_read_only() {
         using S = decltype(seq);
 
         static_assert(flux::random_access_sequence<S>);
-        static_assert(flux::read_only_sequence<S>);
+        static_assert(flux::read_only_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(flux::sized_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, int>);
@@ -120,7 +120,7 @@ constexpr bool test_read_only() {
         using S = decltype(seq);
 
         static_assert(flux::random_access_sequence<S>);
-        static_assert(flux::read_only_sequence<S>);
+        static_assert(flux::read_only_iterable<S>);
         // This needs the C++23 tuple/pair converting constructors and
         // basic_common_reference specialisations to work properly
 #ifdef FLUX_HAVE_CPP23_TUPLE_COMMON_REF

--- a/test/test_read_only.cpp
+++ b/test/test_read_only.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>
+#include <ranges>
 
 #include "test_utils.hpp"
 
@@ -128,6 +129,22 @@ constexpr bool test_read_only() {
         static_assert(std::same_as<flux::rvalue_element_t<S>, std::pair<int const&&, double const&&>>);
 #endif
         static_assert(std::same_as<flux::value_t<S>, std::pair<int, double>>);
+    }
+
+    // Test read_only on plain iterables
+    {
+        auto view = std::views::filter(std::array{1, 2, 3, 4, 5}, flux::pred::true_);
+        auto read_only = flux::read_only(std::move(view));
+
+        using R = decltype(read_only);
+
+        static_assert(flux::iterable<R>);
+        static_assert(flux::read_only_iterable<R>);
+        static_assert(not flux::sequence<R>);
+        static_assert(std::same_as<flux::element_t<R>, int const&>);
+        static_assert(std::same_as<flux::value_t<R>, int>);
+
+        STATIC_CHECK(check_equal(read_only, {1, 2, 3, 4, 5}));
     }
 
     return true;

--- a/test/test_repeat.cpp
+++ b/test/test_repeat.cpp
@@ -30,7 +30,7 @@ constexpr bool test_repeat()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::infinite_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(not flux::bounded_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&>);
         static_assert(std::same_as<flux::value_t<S>, int>);
@@ -63,7 +63,7 @@ constexpr bool test_repeat()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::infinite_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
         static_assert(not flux::bounded_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&>);
         static_assert(std::same_as<flux::value_t<S>, int>);
@@ -87,7 +87,7 @@ constexpr bool test_repeat()
         using S = decltype(seq);
 
         static_assert(flux::random_access_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         STATIC_CHECK(check_equal(seq, {3, 3, 3, 3, 3}));
@@ -148,7 +148,7 @@ constexpr bool test_repeat_bounded()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(not flux::infinite_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, int const &>);
         static_assert(std::same_as<flux::value_t<S>, int>);
@@ -185,7 +185,7 @@ constexpr bool test_repeat_bounded()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(not flux::infinite_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(std::same_as<flux::element_t<S>, int const&>);
         static_assert(std::same_as<flux::value_t<S>, int>);

--- a/test/test_reverse.cpp
+++ b/test/test_reverse.cpp
@@ -22,12 +22,12 @@ constexpr bool test_reverse()
         static_assert(flux::random_access_sequence<R>);
         static_assert(not flux::contiguous_sequence<R>);
         static_assert(flux::bounded_sequence<R>);
-        static_assert(flux::sized_sequence<R>);
+        static_assert(flux::sized_iterable<R>);
 
         static_assert(flux::random_access_sequence<R const>);
         static_assert(not flux::contiguous_sequence<R const>);
         static_assert(flux::bounded_sequence<R const>);
-        static_assert(flux::sized_sequence<R const>);
+        static_assert(flux::sized_iterable<R const>);
 
         STATIC_CHECK(flux::size(reversed) == 5);
         STATIC_CHECK(check_equal(reversed, {4, 3, 2, 1, 0}));
@@ -41,12 +41,12 @@ constexpr bool test_reverse()
         static_assert(flux::random_access_sequence<R>);
         static_assert(not flux::contiguous_sequence<R>);
         static_assert(flux::bounded_sequence<R>);
-        static_assert(flux::sized_sequence<R>);
+        static_assert(flux::sized_iterable<R>);
 
         static_assert(flux::random_access_sequence<R const>);
         static_assert(not flux::contiguous_sequence<R const>);
         static_assert(flux::bounded_sequence<R const>);
-        static_assert(flux::sized_sequence<R const>);
+        static_assert(flux::sized_iterable<R const>);
 
         STATIC_CHECK(flux::size(reversed) == 5);
         STATIC_CHECK(check_equal(reversed, {4, 3, 2, 1, 0}));
@@ -163,7 +163,7 @@ TEST_CASE("reverse")
         static_assert(flux::regular_cursor<flux::cursor_t<R>>);
         static_assert(flux::bidirectional_sequence<R>);
         static_assert(not flux::random_access_sequence<R>);
-        static_assert(flux::sized_sequence<R>);
+        static_assert(flux::sized_iterable<R>);
         static_assert(flux::bounded_sequence<R>);
 
         REQUIRE(check_equal(rlist, {4, 3, 2, 1, 0}));

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -74,7 +74,7 @@ constexpr bool test_inclusive_scan()
     {
         auto scanner = []{ return flux::scan(
             std::views::transform(std::array{1, 2, 3, 4, 5}, std::identity{}),
-            flux::num::add); };
+            std::plus{}); };
 
         using S = decltype(scanner());
 
@@ -163,7 +163,7 @@ constexpr bool test_prescan()
     {
         auto scanner = []{ return flux::prescan(
             std::views::transform(std::array{1, 2, 3, 4, 5}, std::identity{}),
-            flux::num::add, 0); };
+            std::plus{}, 0); };
 
         using S = decltype(scanner());
 
@@ -244,7 +244,7 @@ constexpr bool test_scan_first()
     {
         auto scanner = []{ return flux::scan_first(
             std::views::transform(std::array{1, 2, 3, 4, 5}, std::identity{}),
-            flux::num::add); };
+            std::plus{}); };
 
         using S = decltype(scanner());
 

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -239,6 +239,26 @@ constexpr bool test_scan_first()
         STATIC_CHECK(seq[seq.inc(cur)] == 15);
         STATIC_CHECK(seq.is_last(seq.inc(cur)));
     }
+
+    // scan_first works correctly on iterables
+    {
+        auto scanner = []{ return flux::scan_first(
+            std::views::transform(std::array{1, 2, 3, 4, 5}, std::identity{}),
+            flux::num::add); };
+
+        using S = decltype(scanner());
+
+        static_assert(flux::iterable<S>);
+        static_assert(flux::sized_iterable<S>);
+        static_assert(not flux::sequence<S>);
+        static_assert(std::same_as<flux::element_t<S>, int const&>);
+
+        STATIC_CHECK(flux::size(scanner()) == 5);
+        STATIC_CHECK(check_equal(scanner(), {1, 3, 6, 10, 15}));
+        STATIC_CHECK(flux::contains(scanner(), 10) == true);
+        STATIC_CHECK(flux::contains(scanner(), 99) == false);
+    }
+
     return true;
 }
 static_assert(test_scan_first());

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -23,7 +23,7 @@ constexpr bool test_inclusive_scan()
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(not flux::infinite_sequence<S>);
 
         std::array<int, 5> req{};
@@ -85,7 +85,7 @@ constexpr bool test_prescan()
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(not flux::infinite_sequence<S>);
 
         std::array<int, 5> req{};
@@ -155,7 +155,7 @@ constexpr bool test_scan_first()
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(not flux::infinite_sequence<S>);
 
         std::array<int, 5> req{};
@@ -222,7 +222,7 @@ TEST_CASE("scan")
 
         static_assert(flux::sequence<decltype(seq)>);
         static_assert(not flux::multipass_sequence<decltype(seq)>);
-        static_assert(not flux::sized_sequence<decltype(seq)>);
+        static_assert(not flux::sized_iterable<decltype(seq)>);
         static_assert(not flux::bounded_sequence<decltype(seq)>);
 
         REQUIRE(check_equal(seq, {101, 103, 106, 110, 115}));
@@ -237,7 +237,7 @@ TEST_CASE("scan")
 
         static_assert(flux::sequence<decltype(seq)>);
         static_assert(not flux::multipass_sequence<decltype(seq)>);
-        static_assert(not flux::sized_sequence<decltype(seq)>);
+        static_assert(not flux::sized_iterable<decltype(seq)>);
         static_assert(not flux::bounded_sequence<decltype(seq)>);
 
         REQUIRE(check_equal(seq, {100, 101, 103, 106, 110, 115}));
@@ -251,7 +251,7 @@ TEST_CASE("scan")
 
         static_assert(flux::sequence<decltype(seq)>);
         static_assert(not flux::multipass_sequence<decltype(seq)>);
-        static_assert(not flux::sized_sequence<decltype(seq)>);
+        static_assert(not flux::sized_iterable<decltype(seq)>);
         static_assert(not flux::bounded_sequence<decltype(seq)>);
 
         REQUIRE(check_equal(seq, {1, 3, 6, 10, 15}));

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <numeric>
+#include <ranges>
 #include <sstream>
 
 #include "test_utils.hpp"
@@ -67,6 +68,25 @@ constexpr bool test_inclusive_scan()
         STATIC_CHECK(seq[seq.inc(cur)] == 10);
         STATIC_CHECK(seq[seq.inc(cur)] == 15);
         STATIC_CHECK(seq.is_last(seq.inc(cur)));
+    }
+
+    // Scan works correctly on iterables
+    {
+        auto scanner = []{ return flux::scan(
+            std::views::transform(std::array{1, 2, 3, 4, 5}, std::identity{}),
+            flux::num::add); };
+
+        using S = decltype(scanner());
+
+        static_assert(flux::iterable<S>);
+        static_assert(flux::sized_iterable<S>);
+        static_assert(not flux::sequence<S>);
+        static_assert(std::same_as<flux::element_t<S>, int const&>);
+
+        STATIC_CHECK(flux::size(scanner()) == 5);
+        STATIC_CHECK(check_equal(scanner(), {1, 3, 6, 10, 15}));
+        STATIC_CHECK(flux::contains(scanner(), 10) == true);
+        STATIC_CHECK(flux::contains(scanner(), 99) == false);
     }
 
     return true;
@@ -137,6 +157,25 @@ constexpr bool test_prescan()
         STATIC_CHECK(seq[seq.inc(cur)] == 10);
         STATIC_CHECK(seq[seq.inc(cur)] == 15);
         STATIC_CHECK(seq.is_last(seq.inc(cur)));
+    }
+
+    // Prescan works correctly on iterables
+    {
+        auto scanner = []{ return flux::prescan(
+            std::views::transform(std::array{1, 2, 3, 4, 5}, std::identity{}),
+            flux::num::add, 0); };
+
+        using S = decltype(scanner());
+
+        static_assert(flux::iterable<S>);
+        static_assert(flux::sized_iterable<S>);
+        static_assert(not flux::sequence<S>);
+        static_assert(std::same_as<flux::element_t<S>, int const&>);
+
+        STATIC_CHECK(flux::size(scanner()) == 6);
+        STATIC_CHECK(check_equal(scanner(), {0, 1, 3, 6, 10, 15}));
+        STATIC_CHECK(flux::contains(scanner(), 10) == true);
+        STATIC_CHECK(flux::contains(scanner(), 99) == false);
     }
 
     return true;

--- a/test/test_set_adaptors.cpp
+++ b/test/test_set_adaptors.cpp
@@ -20,7 +20,7 @@ constexpr bool test_set_union()
         using T = decltype(union_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(union_seq, {0, 1, 2, 3, 4, 5, 6}));
     }
@@ -35,7 +35,7 @@ constexpr bool test_set_union()
 
         static_assert(flux::sequence<Seq>);
         static_assert(flux::multipass_sequence<Seq>);
-        static_assert(not flux::sized_sequence<Seq>);
+        static_assert(not flux::sized_iterable<Seq>);
 
         static_assert(std::same_as<flux::element_t<Seq>, int&>);
         static_assert(std::same_as<flux::value_t<Seq>, int>);
@@ -64,7 +64,7 @@ constexpr bool test_set_union()
         using T = decltype(union_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(union_seq, {0, 1, 2, 3, 4, 5}));
     }
@@ -76,7 +76,7 @@ constexpr bool test_set_union()
         using T = decltype(union_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(union_seq, {1, 3, 5}));
     }
@@ -88,7 +88,7 @@ constexpr bool test_set_union()
         using T = decltype(union_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(union_seq, {1, 3, 5}));
     }
@@ -100,7 +100,7 @@ constexpr bool test_set_union()
         using T = decltype(union_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(union_seq, {5, 4, 3, 2, 1, 0 }));
     }
@@ -116,7 +116,7 @@ constexpr bool test_set_union()
         using T = decltype(union_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(union_seq, std::array<std::pair<int, char>, 6>{
                         {{0, 'a'}, {1, 'x'}, {2, 'b'}, {3, 'y'}, {4, 'c'}, {5, 'z'}}}));
@@ -176,7 +176,7 @@ constexpr bool test_set_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, {0, 2, 4, 6}));
     }
@@ -191,7 +191,7 @@ constexpr bool test_set_difference()
 
         static_assert(flux::sequence<Seq>);
         static_assert(flux::multipass_sequence<Seq>);
-        static_assert(not flux::sized_sequence<Seq>);
+        static_assert(not flux::sized_iterable<Seq>);
 
         static_assert(std::same_as<flux::element_t<Seq>, int&>);
         static_assert(std::same_as<flux::value_t<Seq>, int>);
@@ -220,7 +220,7 @@ constexpr bool test_set_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, {0, 2, 4, 6}));
     }
@@ -232,7 +232,7 @@ constexpr bool test_set_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, flux::empty<int>));
     }
@@ -244,7 +244,7 @@ constexpr bool test_set_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, {1, 3, 5}));
     }
@@ -257,7 +257,7 @@ constexpr bool test_set_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, {5, 3, 1}));
     }
@@ -273,7 +273,7 @@ constexpr bool test_set_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, std::array<std::pair<int, char>, 2>{{{0, 'a'}, {3, 'd'}}}));
     }
@@ -299,7 +299,7 @@ constexpr bool test_set_difference()
 
         static_assert(flux::sequence<Seq>);
         static_assert(flux::multipass_sequence<Seq>);
-        static_assert(not flux::sized_sequence<Seq>);
+        static_assert(not flux::sized_iterable<Seq>);
 
         static_assert(std::same_as<flux::element_t<Seq>, int&>);
         static_assert(std::same_as<flux::value_t<Seq>, int>);
@@ -321,7 +321,7 @@ constexpr bool test_set_symmetric_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, {0, 2, 4, 6}));
     }
@@ -336,7 +336,7 @@ constexpr bool test_set_symmetric_difference()
 
         static_assert(flux::sequence<Seq>);
         static_assert(flux::multipass_sequence<Seq>);
-        static_assert(not flux::sized_sequence<Seq>);
+        static_assert(not flux::sized_iterable<Seq>);
 
         static_assert(std::same_as<flux::element_t<Seq>, int&>);
         static_assert(std::same_as<flux::value_t<Seq>, int>);
@@ -365,7 +365,7 @@ constexpr bool test_set_symmetric_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, {0, 3, 4, 5}));
     }
@@ -377,7 +377,7 @@ constexpr bool test_set_symmetric_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, {1, 3, 5}));
     }
@@ -389,7 +389,7 @@ constexpr bool test_set_symmetric_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, {1, 3, 5}));
     }
@@ -402,7 +402,7 @@ constexpr bool test_set_symmetric_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, {6, 5, 3, 1}));
     }
@@ -418,7 +418,7 @@ constexpr bool test_set_symmetric_difference()
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(diff_seq, std::array<std::pair<int, char>, 3>{{{0, 'a'}, {3, 'd'}, {5, 'z'}}}));
     }
@@ -444,7 +444,7 @@ constexpr bool test_set_symmetric_difference()
 
         static_assert(flux::sequence<Seq>);
         static_assert(flux::multipass_sequence<Seq>);
-        static_assert(not flux::sized_sequence<Seq>);
+        static_assert(not flux::sized_iterable<Seq>);
 
         static_assert(std::same_as<flux::element_t<Seq>, long>);
         static_assert(std::same_as<flux::value_t<Seq>, long>);
@@ -467,7 +467,7 @@ constexpr bool test_set_intersection()
         using T = decltype(inter_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(inter_seq, {1, 3}));
     }
@@ -482,7 +482,7 @@ constexpr bool test_set_intersection()
 
         static_assert(flux::sequence<Seq>);
         static_assert(flux::multipass_sequence<Seq>);
-        static_assert(not flux::sized_sequence<Seq>);
+        static_assert(not flux::sized_iterable<Seq>);
 
         static_assert(std::same_as<flux::element_t<Seq>, int&>);
         static_assert(std::same_as<flux::value_t<Seq>, int>);
@@ -511,7 +511,7 @@ constexpr bool test_set_intersection()
         using T = decltype(inter_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(inter_seq, {1, 3}));
     }
@@ -523,7 +523,7 @@ constexpr bool test_set_intersection()
         using T = decltype(inter_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(inter_seq, flux::empty<int>));
     }
@@ -535,7 +535,7 @@ constexpr bool test_set_intersection()
         using T = decltype(inter_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(inter_seq, flux::empty<int>));
     }
@@ -548,7 +548,7 @@ constexpr bool test_set_intersection()
         using T = decltype(inter_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(inter_seq, {3, 1}));
     }
@@ -564,7 +564,7 @@ constexpr bool test_set_intersection()
         using T = decltype(inter_seq);
         static_assert(flux::sequence<T>);
         static_assert(flux::multipass_sequence<T>);
-        static_assert(not flux::sized_sequence<T>);
+        static_assert(not flux::sized_iterable<T>);
 
         STATIC_CHECK(check_equal(inter_seq, std::array<std::pair<int, char>, 2>{{{1, 'b'}, {2, 'c'}}}));
     }
@@ -590,7 +590,7 @@ constexpr bool test_set_intersection()
 
         static_assert(flux::sequence<Seq>);
         static_assert(flux::multipass_sequence<Seq>);
-        static_assert(not flux::sized_sequence<Seq>);
+        static_assert(not flux::sized_iterable<Seq>);
 
         static_assert(std::same_as<flux::element_t<Seq>, int&>);
         static_assert(std::same_as<flux::value_t<Seq>, int>);

--- a/test/test_single.cpp
+++ b/test/test_single.cpp
@@ -18,11 +18,11 @@ constexpr bool test_single()
         using S = decltype(s);
 
         static_assert(flux::contiguous_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
         static_assert(flux::bounded_sequence<S>);
 
         static_assert(flux::contiguous_sequence<S const>);
-        static_assert(flux::sized_sequence<S const>);
+        static_assert(flux::sized_iterable<S const>);
         static_assert(flux::bounded_sequence<S const>);
 
         static_assert(std::same_as<flux::element_t<S>, float&>);

--- a/test/test_slide.cpp
+++ b/test/test_slide.cpp
@@ -22,7 +22,7 @@ constexpr bool test_slide()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(seq.size() == 4);
         STATIC_CHECK(seq.distance(seq.first(), seq.last()) == 4);
@@ -47,7 +47,7 @@ constexpr bool test_slide()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(flux::size(seq) == 4);
 
@@ -108,7 +108,7 @@ constexpr bool test_slide()
         static_assert(flux::bidirectional_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         auto cur = flux::first(seq);
         STATIC_CHECK(check_equal(seq[cur], {4, 5}));

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -19,7 +19,7 @@ struct span_seq {
     T* ptr_;
     std::size_t sz_;
 
-    struct flux_sequence_traits : flux::default_sequence_traits {
+    struct flux_iter_traits : flux::default_iter_traits {
         static constexpr std::size_t first(span_seq const&) { return 0; }
         static constexpr bool is_last(span_seq const& self, std::size_t i) { return i == self.sz_; }
         static constexpr std::size_t& inc(span_seq const&, std::size_t& i) { return ++i; }

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -120,21 +120,21 @@ constexpr bool test_split_with_predicate()
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::bidirectional_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
 
         static_assert(flux::sequence<S const>);
         static_assert(flux::multipass_sequence<S const>);
         static_assert(flux::bounded_sequence<S const>);
         static_assert(not flux::bidirectional_sequence<S const>);
-        static_assert(not flux::sized_sequence<S const>);
+        static_assert(not flux::sized_iterable<S const>);
 
         using E = flux::element_t<S>;
         static_assert(flux::contiguous_sequence<E>);
-        static_assert(flux::sized_sequence<E>);
+        static_assert(flux::sized_iterable<E>);
 
         using EC = flux::element_t<S const>;
         static_assert(flux::contiguous_sequence<EC>);
-        static_assert(flux::sized_sequence<EC>);
+        static_assert(flux::sized_iterable<EC>);
 
         auto cur = split.first();
         STATIC_CHECK(check_equal(split[cur], {1, 2}));

--- a/test/test_starts_with.cpp
+++ b/test/test_starts_with.cpp
@@ -101,7 +101,7 @@ constexpr bool test_starts_with()
 
     return true;
 }
-//static_assert(test_starts_with());
+static_assert(test_starts_with());
 
 }
 

--- a/test/test_starts_with.cpp
+++ b/test/test_starts_with.cpp
@@ -101,7 +101,7 @@ constexpr bool test_starts_with()
 
     return true;
 }
-static_assert(test_starts_with());
+//static_assert(test_starts_with());
 
 }
 

--- a/test/test_stride.cpp
+++ b/test/test_stride.cpp
@@ -13,7 +13,7 @@
 namespace {
 
 template <flux::sequence Base>
-struct NotBidir : flux::inline_sequence_base<NotBidir<Base>> {
+struct NotBidir : flux::inline_iter_base<NotBidir<Base>> {
     Base base_;
 
     constexpr explicit NotBidir(Base base) : base_(std::move(base)) {}

--- a/test/test_stride.cpp
+++ b/test/test_stride.cpp
@@ -21,7 +21,7 @@ struct NotBidir : flux::inline_sequence_base<NotBidir<Base>> {
     constexpr Base& base() & { return base_; }
     constexpr Base const& base() const& { return base_; }
 
-    struct flux_sequence_traits : flux::default_sequence_traits {
+    struct flux_iter_traits : flux::default_iter_traits {
         static constexpr auto first(auto& self) { return flux::first(self.base_); }
 
         static constexpr bool is_last(auto& self, auto const& cur) {

--- a/test/test_stride.cpp
+++ b/test/test_stride.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <limits>
 #include <list>
+#include <ranges>
 
 #include "test_utils.hpp"
 
@@ -136,6 +137,25 @@ constexpr bool test_stride_non_bidir()
         auto cur = seq.find(4);
 
         STATIC_CHECK(&seq[cur] == arr.data() + 4);
+    }
+
+    // Stride works on non-sequence iterables
+    {
+        auto view = std::views::transform(std::array{0, 1, 2, 3, 4, 5}, std::identity{});
+
+        auto strided = flux::stride(std::move(view), 2);
+
+        using S = decltype(strided);
+        static_assert(flux::iterable<S>);
+        static_assert(flux::const_iterable<S>);
+        static_assert(flux::iterable<S const>);
+        static_assert(flux::sized_iterable<S>);
+        static_assert(not flux::sequence<S>);
+        static_assert(std::same_as<flux::element_t<S>, int&>);
+        static_assert(std::same_as<flux::element_t<S const>, int const&>);
+
+        STATIC_CHECK(flux::size(strided) == 3);
+        STATIC_CHECK(check_equal(strided, {0, 2, 4}));
     }
 
     return true;

--- a/test/test_stride.cpp
+++ b/test/test_stride.cpp
@@ -54,7 +54,7 @@ constexpr bool test_stride_non_bidir()
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::bidirectional_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(check_equal(seq, {0, 2, 4}));
         STATIC_CHECK(seq.last() == flux::last(arr));
@@ -72,7 +72,7 @@ constexpr bool test_stride_non_bidir()
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(not flux::bidirectional_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(check_equal(seq, {0, 3, 6}));
         STATIC_CHECK(flux::last(seq) == flux::last(arr));
@@ -156,7 +156,7 @@ constexpr bool test_stride_bidir()
         static_assert(flux::bounded_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
         static_assert(not flux::contiguous_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(check_equal(seq, {0, 2, 4}));
         STATIC_CHECK(seq.last().cur == flux::last(arr));
@@ -176,7 +176,7 @@ constexpr bool test_stride_bidir()
         static_assert(flux::multipass_sequence<S>);
         static_assert(flux::bounded_sequence<S>);
         static_assert(flux::random_access_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(check_equal(seq, {0, 3, 6}));
         STATIC_CHECK(flux::last(seq).cur == flux::last(arr));

--- a/test/test_take.cpp
+++ b/test/test_take.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <list>
 #include <optional>
+#include <ranges>
 
 #include "test_utils.hpp"
 
@@ -45,6 +46,23 @@ constexpr bool test_take()
 
         STATIC_CHECK(taken.size() == 3);
         STATIC_CHECK(check_equal(taken, {0, 1, 2}));
+    }
+
+    // test take with non-sequence iterable
+    {
+        auto arr = std::array{1, 2, 3, 4, 5};
+        auto view = arr | std::views::transform(std::identity{});
+        auto iter = flux::take(view, 3);
+
+        using I = decltype(iter);
+        static_assert(flux::iterable<I>);
+        static_assert(flux::sized_iterable<I>);
+        static_assert(not flux::sequence<I>);
+        static_assert(flux::iterable<I const>);
+        static_assert(flux::sized_iterable<I const>);
+
+        STATIC_CHECK(iter.all(flux::pred::gt(0)));
+        STATIC_CHECK(iter.sum() == 1 + 2 + 3);
     }
 
     // test taking all the elements

--- a/test/test_take.cpp
+++ b/test/test_take.cpp
@@ -20,11 +20,11 @@ constexpr bool test_take()
         using T = decltype(taken);
         static_assert(flux::contiguous_sequence<T>);
         static_assert(flux::bounded_sequence<T>);
-        static_assert(flux::sized_sequence<T>);
+        static_assert(flux::sized_iterable<T>);
 
         static_assert(flux::contiguous_sequence<T const>);
         static_assert(flux::bounded_sequence<T const>);
-        static_assert(flux::sized_sequence<T const>);
+        static_assert(flux::sized_iterable<T const>);
 
         STATIC_CHECK(taken.size() == 3);
         STATIC_CHECK(taken.data() == arr);
@@ -37,11 +37,11 @@ constexpr bool test_take()
         using T = decltype(taken);
         static_assert(flux::contiguous_sequence<T>);
         static_assert(flux::bounded_sequence<T>);
-        static_assert(flux::sized_sequence<T>);
+        static_assert(flux::sized_iterable<T>);
 
         static_assert(flux::contiguous_sequence<T const>);
         static_assert(flux::bounded_sequence<T const>);
-        static_assert(flux::sized_sequence<T const>);
+        static_assert(flux::sized_iterable<T const>);
 
         STATIC_CHECK(taken.size() == 3);
         STATIC_CHECK(check_equal(taken, {0, 1, 2}));

--- a/test/test_take_while.cpp
+++ b/test/test_take_while.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>
+#include <ranges>
 
 #include "test_utils.hpp"
 
@@ -68,6 +69,23 @@ constexpr bool test_take_while()
                        .drop(1);
 
         STATIC_CHECK(check_equal(seq, {4, 16, 36, 64, 100}));
+    }
+
+    // Test with non-sequence iterables
+    {
+        auto view = std::views::filter(std::array{1, 2, 3, 4, 5}, flux::pred::true_);
+
+        auto taken = flux::take_while(std::move(view), flux::pred::lt(4));
+
+        using T = decltype(taken);
+
+        static_assert(flux::iterable<T>);
+        static_assert(not flux::sized_iterable<T>);
+        static_assert(not flux::sequence<T>);
+
+        STATIC_CHECK(flux::contains(taken, 2));
+        STATIC_CHECK(not flux::contains(taken, 4));
+        STATIC_CHECK(check_equal(taken, {1, 2, 3}));
     }
 
     return true;

--- a/test/test_take_while.cpp
+++ b/test/test_take_while.cpp
@@ -13,7 +13,7 @@ namespace {
 struct ints {
     int from = 0;
 
-    struct flux_sequence_traits : flux::default_sequence_traits {
+    struct flux_iter_traits : flux::default_iter_traits {
         static constexpr int first(ints) { return 0; }
         static constexpr bool is_last(ints, int) { return false; }
         static constexpr int read_at(ints self, int cur){ return self.from + cur; }

--- a/test/test_take_while.cpp
+++ b/test/test_take_while.cpp
@@ -31,7 +31,7 @@ constexpr bool test_take_while()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(not flux::bounded_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
 
         STATIC_CHECK(check_equal(
             seq, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
@@ -45,7 +45,7 @@ constexpr bool test_take_while()
 
         static_assert(flux::random_access_sequence<S>);
         static_assert(not flux::bounded_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
 
         STATIC_CHECK(check_equal(seq, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
     }

--- a/test/test_to.cpp
+++ b/test/test_to.cpp
@@ -66,7 +66,7 @@ test_vector(flux::from_iterable_t, Seq&&, A const&) -> test_vector<flux::value_t
 struct test_iterable {
     int arr[5] = {1, 2, 3, 4, 5};
 
-    struct flux_sequence_traits : flux::default_sequence_traits {
+    struct flux_iter_traits : flux::default_iter_traits {
 
         static consteval auto element_type(test_iterable const&) -> int const&;
 

--- a/test/test_unchecked.cpp
+++ b/test/test_unchecked.cpp
@@ -19,7 +19,7 @@ constexpr bool test_unchecked()
         using S = decltype(seq);
 
         static_assert(contiguous_sequence<S>);
-        static_assert(sized_sequence<S>);
+        static_assert(sized_iterable<S>);
         static_assert(bounded_sequence<S>);
 
         seq.sort();
@@ -37,7 +37,7 @@ constexpr bool test_unchecked()
 
         static_assert(random_access_sequence<S>);
         static_assert(bounded_sequence<S>);
-        static_assert(sized_sequence<S>);
+        static_assert(sized_iterable<S>);
         static_assert(std::same_as<value_t<S>, std::pair<int, double>>);
         static_assert(std::same_as<element_t<S>, std::pair<int&, double&>>);
         static_assert(std::same_as<rvalue_element_t<S>, std::pair<int&&, double&&>>);

--- a/test/test_unfold.cpp
+++ b/test/test_unfold.cpp
@@ -20,7 +20,7 @@ constexpr bool test_unfold()
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
         static_assert(flux::infinite_sequence<S>);
-        static_assert(not flux::sized_sequence<S>);
+        static_assert(not flux::sized_iterable<S>);
 
         STATIC_CHECK(check_equal(flux::take(seq, 10), flux::ints().take(10)));
     }
@@ -33,7 +33,7 @@ constexpr bool test_unfold()
         static_assert(flux::sequence<S>);
         static_assert(not flux::multipass_sequence<S>);
         static_assert(not flux::infinite_sequence<S>);
-        static_assert(flux::sized_sequence<S>);
+        static_assert(flux::sized_iterable<S>);
 
         STATIC_CHECK(flux::size(seq) == 10);
         STATIC_CHECK(check_equal(seq, flux::ints().take(10)));

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -132,7 +132,7 @@ struct flux::sequence_traits<single_pass_only<Base>> : flux::default_sequence_tr
     }
 
     static constexpr auto size(self_t& self)
-        requires sized_sequence<Base>
+        requires sized_iterable<Base>
     {
         return flux::size(self.base_);
     }

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -47,9 +47,10 @@ public:
                               std::initializer_list<T> ilist) const
     {
         auto iter = ilist.begin();
-        return flux::iterate(it, [&iter](auto&& elem) {
+        bool r =  flux::iterate(it, [&iter](auto&& elem) {
             return *iter++ == elem;
         });
+        return r ? iter == ilist.end() : r;
     }
 
     template <typename T>
@@ -63,11 +64,12 @@ public:
                               flux::sequence auto&& seq) const
     {
         auto cur = flux::first(seq);
-        return flux::iterate(it, [&](auto&& elem) {
+        bool k = flux::iterate(it, [&](auto&& elem) {
             bool r = (elem == flux::read_at(seq, cur));
             flux::inc(seq, cur);
             return r;
         });
+        return k ? flux::is_last(seq, cur) : k;
     }
 
     constexpr bool operator()(flux::sequence auto&& seq1,

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -43,6 +43,16 @@ private:
 
 public:
     template <typename T>
+    constexpr bool operator()(flux::iterable auto&& it,
+                              std::initializer_list<T> ilist) const
+    {
+        auto iter = ilist.begin();
+        return flux::iterate(it, [&iter](auto&& elem) {
+            return *iter++ == elem;
+        });
+    }
+
+    template <typename T>
     constexpr bool operator()(flux::sequence auto&& seq,
                               std::initializer_list<T> ilist) const
     {

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -59,6 +59,17 @@ public:
         return impl(FLUX_FWD(seq), ilist);
     }
 
+    constexpr bool operator()(flux::iterable auto&& it,
+                              flux::sequence auto&& seq) const
+    {
+        auto cur = flux::first(seq);
+        return flux::iterate(it, [&](auto&& elem) {
+            bool r = (elem == flux::read_at(seq, cur));
+            flux::inc(seq, cur);
+            return r;
+        });
+    }
+
     constexpr bool operator()(flux::sequence auto&& seq1,
                               flux::sequence auto&& seq2) const
     {

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -111,7 +111,7 @@ public:
 }
 
 template <typename Base>
-struct flux::iter_traits<single_pass_only<Base>> : flux::default_sequence_traits
+struct flux::iter_traits<single_pass_only<Base>> : flux::default_iter_traits
 {
     using self_t = single_pass_only<Base>;
     using cursor_t = typename single_pass_only<Base>::cursor_type;

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -81,7 +81,7 @@ public:
 } check_equal;
 
 template <flux::sequence Base>
-struct single_pass_only : flux::inline_sequence_base<single_pass_only<Base>> {
+struct single_pass_only : flux::inline_iter_base<single_pass_only<Base>> {
 private:
     Base base_;
 

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -97,7 +97,7 @@ private:
         cursor_type& operator=(cursor_type&&) = default;
     };
 
-    friend struct flux::sequence_traits<single_pass_only>;
+    friend struct flux::iter_traits<single_pass_only>;
 
 public:
     constexpr explicit single_pass_only(Base&& base)
@@ -111,7 +111,7 @@ public:
 }
 
 template <typename Base>
-struct flux::sequence_traits<single_pass_only<Base>> : flux::default_sequence_traits
+struct flux::iter_traits<single_pass_only<Base>> : flux::default_sequence_traits
 {
     using self_t = single_pass_only<Base>;
     using cursor_t = typename single_pass_only<Base>::cursor_type;

--- a/test/test_zip.cpp
+++ b/test/test_zip.cpp
@@ -24,13 +24,13 @@ constexpr bool test_zip()
         static_assert(flux::sequence<Z>);
         static_assert(flux::bidirectional_sequence<Z>);
         static_assert(flux::random_access_sequence<Z>);
-        static_assert(flux::sized_sequence<Z>);
+        static_assert(flux::sized_iterable<Z>);
         static_assert(flux::bounded_sequence<Z>);
 
         static_assert(flux::sequence<Z const>);
         static_assert(flux::bidirectional_sequence<Z const>);
         static_assert(flux::random_access_sequence<Z const>);
-        static_assert(flux::sized_sequence<Z const>);
+        static_assert(flux::sized_iterable<Z const>);
         static_assert(flux::bounded_sequence<Z const>);
 
         static_assert(std::same_as<flux::element_t<Z>, std::pair<int&, double&>>);
@@ -66,13 +66,13 @@ constexpr bool test_zip()
         static_assert(flux::sequence<Z>);
         static_assert(flux::bidirectional_sequence<Z>);
         static_assert(flux::random_access_sequence<Z>);
-        static_assert(flux::sized_sequence<Z>);
+        static_assert(flux::sized_iterable<Z>);
         static_assert(flux::bounded_sequence<Z>);
 
         static_assert(flux::sequence<Z const>);
         static_assert(flux::bidirectional_sequence<Z const>);
         static_assert(flux::random_access_sequence<Z const>);
-        static_assert(flux::sized_sequence<Z const>);
+        static_assert(flux::sized_iterable<Z const>);
         static_assert(flux::bounded_sequence<Z const>);
 
         static_assert(std::same_as<flux::element_t<Z>, std::pair<int&, double&>>);
@@ -112,7 +112,7 @@ constexpr bool test_zip()
 
         using Z = decltype(zipped);
         static_assert(flux::random_access_sequence<Z>);
-        static_assert(flux::sized_sequence<Z>);
+        static_assert(flux::sized_iterable<Z>);
 
         auto cur1 = flux::next(zipped, flux::first(zipped), 2);
         auto cur2 = flux::next(zipped, flux::first(zipped), 3);

--- a/test/test_zip_map.cpp
+++ b/test/test_zip_map.cpp
@@ -29,13 +29,13 @@ constexpr bool test_zip_map()
         static_assert(flux::sequence<Z>);
         static_assert(flux::bidirectional_sequence<Z>);
         static_assert(flux::random_access_sequence<Z>);
-        static_assert(flux::sized_sequence<Z>);
+        static_assert(flux::sized_iterable<Z>);
         static_assert(flux::bounded_sequence<Z>);
 
         static_assert(flux::sequence<Z const>);
         static_assert(flux::bidirectional_sequence<Z const>);
         static_assert(flux::random_access_sequence<Z const>);
-        static_assert(flux::sized_sequence<Z const>);
+        static_assert(flux::sized_iterable<Z const>);
         static_assert(flux::bounded_sequence<Z const>);
 
         static_assert(std::same_as<flux::element_t<Z>, int>);
@@ -81,13 +81,13 @@ constexpr bool test_zip_map()
         static_assert(flux::sequence<Z>);
         static_assert(flux::bidirectional_sequence<Z>);
         static_assert(flux::random_access_sequence<Z>);
-        static_assert(flux::sized_sequence<Z>);
+        static_assert(flux::sized_iterable<Z>);
         static_assert(flux::bounded_sequence<Z>);
 
         static_assert(flux::sequence<Z const>);
         static_assert(flux::bidirectional_sequence<Z const>);
         static_assert(flux::random_access_sequence<Z const>);
-        static_assert(flux::sized_sequence<Z const>);
+        static_assert(flux::sized_iterable<Z const>);
         static_assert(flux::bounded_sequence<Z const>);
 
         static_assert(std::same_as<flux::element_t<Z>, int>);
@@ -126,13 +126,13 @@ constexpr bool test_zip_map()
         static_assert(flux::sequence<Z>);
         static_assert(flux::bidirectional_sequence<Z>);
         static_assert(flux::random_access_sequence<Z>);
-        static_assert(flux::sized_sequence<Z>);
+        static_assert(flux::sized_iterable<Z>);
         static_assert(flux::bounded_sequence<Z>);
 
         static_assert(flux::sequence<Z const>);
         static_assert(flux::bidirectional_sequence<Z const>);
         static_assert(flux::random_access_sequence<Z const>);
-        static_assert(flux::sized_sequence<Z const>);
+        static_assert(flux::sized_iterable<Z const>);
         static_assert(flux::bounded_sequence<Z const>);
 
         static_assert(std::same_as<flux::element_t<Z>, int>);
@@ -162,13 +162,13 @@ constexpr bool test_zip_map()
         static_assert(flux::sequence<Z>);
         static_assert(flux::bidirectional_sequence<Z>);
         static_assert(flux::random_access_sequence<Z>);
-        static_assert(flux::sized_sequence<Z>);
+        static_assert(flux::sized_iterable<Z>);
         static_assert(flux::bounded_sequence<Z>);
 
         static_assert(flux::sequence<Z const>);
         static_assert(flux::bidirectional_sequence<Z const>);
         static_assert(flux::random_access_sequence<Z const>);
-        static_assert(flux::sized_sequence<Z const>);
+        static_assert(flux::sized_iterable<Z const>);
         static_assert(flux::bounded_sequence<Z const>);
 
         static_assert(std::same_as<flux::element_t<Z>, int const&>);
@@ -198,13 +198,13 @@ constexpr bool test_zip_map()
         static_assert(flux::sequence<Z>);
         static_assert(flux::bidirectional_sequence<Z>);
         static_assert(flux::random_access_sequence<Z>);
-        static_assert(flux::sized_sequence<Z>);
+        static_assert(flux::sized_iterable<Z>);
         static_assert(flux::bounded_sequence<Z>);
 
         static_assert(flux::sequence<Z const>);
         static_assert(flux::bidirectional_sequence<Z const>);
         static_assert(flux::random_access_sequence<Z const>);
-        static_assert(flux::sized_sequence<Z const>);
+        static_assert(flux::sized_iterable<Z const>);
         static_assert(flux::bounded_sequence<Z const>);
 
         static_assert(std::same_as<flux::element_t<Z>, int>);
@@ -232,13 +232,13 @@ constexpr bool test_zip_map()
         static_assert(flux::sequence<Z>);
         static_assert(flux::bidirectional_sequence<Z>);
         static_assert(flux::random_access_sequence<Z>);
-        static_assert(flux::sized_sequence<Z>);
+        static_assert(flux::sized_iterable<Z>);
         static_assert(flux::bounded_sequence<Z>);
 
         static_assert(flux::sequence<Z const>);
         static_assert(flux::bidirectional_sequence<Z const>);
         static_assert(flux::random_access_sequence<Z const>);
-        static_assert(flux::sized_sequence<Z const>);
+        static_assert(flux::sized_iterable<Z const>);
         static_assert(flux::bounded_sequence<Z const>);
 
         static_assert(std::same_as<flux::element_t<Z>, int&>);


### PR DESCRIPTION
This PR adds a new `iterable` concept and updates various algorithms and adaptors to use it.

An `iterable` is, as the name suggests, something we can iterate over -- specifically, by using internal iteration. The required interface is:

```cpp
struct sequence_traits<T> {
    auto element_type(T& iterable) -> E;

    template <typename T, typename Pred>
        requires std::predicate<Pred&, E>
    auto iterate(T& iterable, Pred&& pred) -> bool;
};
```

This is basically the existing `for_each_while` abstracted out into its own concept, returning a `bool` to indicate whether iteration was completed successfully rather than a cursor.

Once `iterate()` has returned, it is unspecified whether a second call to `iterate()` will start again from the beginning, carry on where it left off, do nothing, or do something else. Iterables are strictly weaker than sequences: that is, every sequence is an iterable, but not vice versa.  Nonetheless, a large number of algorithms work on iterables (just about anything that can be written as a short-circuiting fold), and most of the existing sequence adaptors can work on iterables as well.

Since iterables only use internal iteration, there is no external state (i.e. a cursor) which could be invalidated. Not only does this make the iterable interface easier to implement for some types, but most importantly it means that we can provide a safe default implementation of the `iterable` protocol for **all** C++20 ranges.

This dramatically improves our interoperability with ranges, while the use of internal iteration means that converting ranges pipelines to the equivalent Flux code may yield some nice performance benefits.

