### PR TITLE
Fix header scanning regex

### DIFF
--- a/tools/make_single_header.cpp
+++ b/tools/make_single_header.cpp
@@ -16,7 +16,7 @@ namespace fs = std::filesystem;
 
 namespace {
 
-constexpr auto& include_regex = R"(#include <(flux(?:/\w*)+.hpp)>)";
+constexpr auto& include_regex = R"(#include <(flux(?:/\w*)+.h(?:pp)?)>)";
 
 template <typename Rng, typename Value>
 bool contains(const Rng& range, const Value& val)


### PR DESCRIPTION
...to allow us to pick up headers with extension `.h` as well as `.hpp` when building the single header

Fixes #221