### PR TITLE
Fix issue #228

### DIFF
--- a/include/flux/adaptor/set_adaptors.hpp
+++ b/include/flux/adaptor/set_adaptors.hpp
@@ -74,7 +74,7 @@ public:
     public:
         using value_type = std::common_type_t<value_t<Base1>, value_t<Base2>>;
 
-        inline static constexpr bool is_infinite = flux::infinite_sequence<Base1> || 
+        inline static constexpr bool is_infinite = flux::infinite_sequence<Base1> ||
                                                    flux::infinite_sequence<Base2>;
 
         template <typename Self>
@@ -91,7 +91,7 @@ public:
             requires maybe_const_iterable<Self>
         static constexpr auto is_last(Self& self, cursor_type const& cur) -> bool
         {
-            return flux::is_last(self.base1_, cur.base1_cursor) && 
+            return flux::is_last(self.base1_, cur.base1_cursor) &&
                    flux::is_last(self.base2_, cur.base2_cursor);
         }
 
@@ -111,7 +111,7 @@ public:
         template <typename Self>
             requires maybe_const_iterable<Self>
         static constexpr auto read_at(Self& self, cursor_type const& cur)
-            -> std::common_reference_t<decltype(flux::read_at(self.base1_, cur.base1_cursor)), 
+            -> std::common_reference_t<decltype(flux::read_at(self.base1_, cur.base1_cursor)),
                                        decltype(flux::read_at(self.base2_, cur.base2_cursor))>
         {
             if (cur.active_ == cursor_type::first) {
@@ -122,7 +122,7 @@ public:
         }
 
         template <typename Self>
-            requires maybe_const_iterable<Self> && 
+            requires maybe_const_iterable<Self> &&
                      bounded_sequence<Base1> && bounded_sequence<Base2>
         static constexpr auto last(Self& self) -> cursor_type
         {
@@ -132,7 +132,7 @@ public:
         template <typename Self>
             requires maybe_const_iterable<Self>
         static constexpr auto move_at(Self& self, cursor_type const& cur)
-            -> std::common_reference_t<decltype(flux::move_at(self.base1_, cur.base1_cursor)), 
+            -> std::common_reference_t<decltype(flux::move_at(self.base1_, cur.base1_cursor)),
                                        decltype(flux::move_at(self.base2_, cur.base2_cursor))>
         {
             if (cur.active_ == cursor_type::first) {
@@ -141,7 +141,7 @@ public:
                 return flux::move_at(self.base2_, cur.base2_cursor);
             }
         }
-        
+
     };
 };
 
@@ -244,7 +244,7 @@ public:
         {
             return flux::move_at(self.base1_, cur.base1_cursor);
         }
-        
+
     };
 };
 
@@ -272,10 +272,13 @@ public:
             cursor_t<Base2> base2_cursor;
             enum : char {first, second, first_done, second_done} state_ = first;
 
-            friend auto operator==(cursor_type const&, cursor_type const&) -> bool
+            friend constexpr auto operator==(cursor_type const& lhs, cursor_type const& rhs) -> bool
                 requires std::equality_comparable<cursor_t<Base1>> &&
                          std::equality_comparable<cursor_t<Base2>>
-                = default;
+                {
+                    return lhs.base1_cursor == rhs.base1_cursor &&
+                           lhs.base2_cursor == rhs.base2_cursor;
+                }
         };
 
         template <typename Self>
@@ -311,7 +314,7 @@ public:
     public:
         using value_type = std::common_type_t<value_t<Base1>, value_t<Base2>>;
 
-        inline static constexpr bool is_infinite = flux::infinite_sequence<Base1> || 
+        inline static constexpr bool is_infinite = flux::infinite_sequence<Base1> ||
                                                    flux::infinite_sequence<Base2>;
 
         template <typename Self>
@@ -328,7 +331,7 @@ public:
             requires maybe_const_iterable<Self>
         static constexpr auto is_last(Self& self, cursor_type const& cur) -> bool
         {
-            return flux::is_last(self.base1_, cur.base1_cursor) && 
+            return flux::is_last(self.base1_, cur.base1_cursor) &&
                    flux::is_last(self.base2_, cur.base2_cursor);
         }
 
@@ -370,7 +373,9 @@ public:
         }
 
         template <typename Self>
-            requires maybe_const_iterable<Self> && bounded_sequence<Base1>
+            requires maybe_const_iterable<Self> &&
+                     bounded_sequence<Base1> &&
+                     bounded_sequence<Base2>
         static constexpr auto last(Self& self) -> cursor_type
         {
             return cursor_type{flux::last(self.base1_), flux::last(self.base2_)};
@@ -428,7 +433,7 @@ public:
 
         template <typename Self>
         static constexpr void update(Self& self, cursor_type& cur) {
-            while(not flux::is_last(self.base1_, cur.base1_cursor) && 
+            while(not flux::is_last(self.base1_, cur.base1_cursor) &&
                   not flux::is_last(self.base2_, cur.base2_cursor))
             {
                 auto r = std::invoke(self.cmp_, flux::read_at(self.base1_, cur.base1_cursor),
@@ -463,7 +468,7 @@ public:
             requires maybe_const_iterable<Self>
         static constexpr auto is_last(Self& self, cursor_type const& cur) -> bool
         {
-            return flux::is_last(self.base1_, cur.base1_cursor) || 
+            return flux::is_last(self.base1_, cur.base1_cursor) ||
                    flux::is_last(self.base2_, cur.base2_cursor);
         }
 
@@ -491,7 +496,7 @@ public:
         {
             return flux::move_at(self.base1_, cur.base1_cursor);
         }
-        
+
     };
 };
 
@@ -503,7 +508,7 @@ concept set_op_compatible =
 
 struct set_union_fn {
     template <adaptable_sequence Seq1, adaptable_sequence Seq2, typename Cmp = std::compare_three_way>
-        requires set_op_compatible<Seq1, Seq2> && 
+        requires set_op_compatible<Seq1, Seq2> &&
                  weak_ordering_for<Cmp, Seq1> &&
                  weak_ordering_for<Cmp, Seq2>
     [[nodiscard]]

--- a/test/test_set_adaptors.cpp
+++ b/test/test_set_adaptors.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <utility>
+#include <vector>
 
 #include "test_utils.hpp"
 

--- a/test/test_set_adaptors.cpp
+++ b/test/test_set_adaptors.cpp
@@ -110,8 +110,9 @@ constexpr bool test_set_union()
         std::array<std::pair<int, char>, 3> arr1{{{0, 'a'}, {2, 'b'}, {4, 'c'}}};
         std::array<std::pair<int, char>, 3> arr2{{{1, 'x'}, {3, 'y'}, {5, 'z'}}};
 
-        auto union_seq = flux::set_union(flux::ref(arr1), flux::ref(arr2), 
-                                         flux::proj(flux::cmp::compare, [] (auto v) { return v.first; }));
+        auto union_seq
+            = flux::set_union(flux::ref(arr1), flux::ref(arr2),
+                              flux::proj(flux::cmp::compare, [](auto v) { return v.first; }));
 
         using T = decltype(union_seq);
         static_assert(flux::sequence<T>);
@@ -267,8 +268,9 @@ constexpr bool test_set_difference()
         std::array<std::pair<int, char>, 4> arr1{{{0, 'a'}, {1, 'b'}, {2, 'c'}, {3, 'd'}}};
         std::array<std::pair<int, char>, 3> arr2{{{1, 'x'}, {2, 'y'}, {5, 'z'}}};
 
-        auto diff_seq = flux::set_difference(flux::ref(arr1), flux::ref(arr2), 
-                                             flux::proj(flux::cmp::compare, [] (auto v) { return v.first; }));
+        auto diff_seq
+            = flux::set_difference(flux::ref(arr1), flux::ref(arr2),
+                                   flux::proj(flux::cmp::compare, [](auto v) { return v.first; }));
 
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
@@ -412,8 +414,9 @@ constexpr bool test_set_symmetric_difference()
         std::array<std::pair<int, char>, 4> arr1{{{0, 'a'}, {1, 'b'}, {2, 'c'}, {3, 'd'}}};
         std::array<std::pair<int, char>, 3> arr2{{{1, 'x'}, {2, 'y'}, {5, 'z'}}};
 
-        auto diff_seq = flux::set_symmetric_difference(flux::ref(arr1), flux::ref(arr2), 
-                                                       flux::proj(flux::cmp::compare, [] (auto v) { return v.first; }));
+        auto diff_seq = flux::set_symmetric_difference(
+            flux::ref(arr1), flux::ref(arr2),
+            flux::proj(flux::cmp::compare, [](auto v) { return v.first; }));
 
         using T = decltype(diff_seq);
         static_assert(flux::sequence<T>);
@@ -558,8 +561,9 @@ constexpr bool test_set_intersection()
         std::array<std::pair<int, char>, 4> arr1{{{0, 'a'}, {1, 'b'}, {2, 'c'}, {3, 'd'}}};
         std::array<std::pair<int, char>, 3> arr2{{{1, 'x'}, {2, 'y'}, {5, 'z'}}};
 
-        auto inter_seq = flux::set_intersection(flux::ref(arr1), flux::ref(arr2), 
-                                             flux::proj(flux::cmp::compare, [] (auto v) { return v.first; }));
+        auto inter_seq = flux::set_intersection(
+            flux::ref(arr1), flux::ref(arr2),
+            flux::proj(flux::cmp::compare, [](auto v) { return v.first; }));
 
         using T = decltype(inter_seq);
         static_assert(flux::sequence<T>);
@@ -607,6 +611,27 @@ static_assert(test_set_difference());
 static_assert(test_set_symmetric_difference());
 static_assert(test_set_intersection());
 
+// https://github.com/tcbrindle/flux/issues/228
+constexpr bool issue_228()
+{
+    std::array arr1 {0, 1, 2, 3, 4, 5};
+    std::array arr2 {1, 3, 5, 6, 7};
+    auto merged = flux::set_symmetric_difference(flux::ref(arr1), flux::ref(arr2));
+
+    STATIC_CHECK(flux::equal(merged, std::array {0, 2, 4, 6, 7}));
+
+    std::vector<int> out;
+
+    for (auto i : merged) {
+        // crashes here
+        out.push_back(i);
+    }
+
+    STATIC_CHECK(check_equal(out, merged));
+
+    return true;
+}
+static_assert(issue_228());
 }
 
 TEST_CASE("set_union")
@@ -624,6 +649,8 @@ TEST_CASE("set_difference")
 TEST_CASE("set_symmetric_difference")
 {
     bool result = test_set_symmetric_difference();
+    REQUIRE(result);
+    result = issue_228();
     REQUIRE(result);
 }
 


### PR DESCRIPTION
Manually implement `set_symmetric_difference_adaptor::cursor_type`'s `operator==` so that it doesn't compare the `state_` field

Fixes #228