### PR TITLE
Temporarily use Doctest fork to fix CMake4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
           docs-folder: 'docs/'
       - name: Upload pages artifact
         if: github.ref_name == 'main'
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/html/
 
@@ -39,4 +39,4 @@ jobs:
     steps:
       - name: Deploy to Github Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       matrix:
         compiler: [GCC-12, GCC-13, GCC-14, Clang-17, Clang-18, Clang-19]
-        test_with: [Headers, Module]
+        # test_with: [Headers, Module]
+        test_with: [Headers]
         build_type: [Debug, Release]
 
         exclude:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,8 @@
 include(FetchContent)
 
 FetchContent_Declare(doctest
-    GIT_REPOSITORY https://github.com/doctest/doctest.git
-    GIT_TAG ae7a13539fb71f270b87eb2e874fbac80bc8dda2 # v2.4.11
+    GIT_REPOSITORY https://github.com/tcbrindle/doctest.git
+    GIT_TAG cmake4-fix
     FIND_PACKAGE_ARGS
 )
 


### PR DESCRIPTION
CMake has been issuing deprecation warnings for Doctest for quite a while now (https://github.com/doctest/doctest/issues/854), and unfortunately CMake 4.0 turns this into a hard error.

Hopefully there will be a new Doctest release soon that fixes this, but until then we'll use a temporary fork as a workaround