### PR TITLE
Update to Doctest v2.4.12

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,8 @@
 include(FetchContent)
 
 FetchContent_Declare(doctest
-    GIT_REPOSITORY https://github.com/tcbrindle/doctest.git
-    GIT_TAG cmake4-fix
+    GIT_REPOSITORY https://github.com/doctest/doctest.git
+    GIT_TAG 1da23a3e8119ec5cce4f9388e91b065e20bf06f5 # v2.4.12
     FIND_PACKAGE_ARGS
 )
 


### PR DESCRIPTION
https://github.com/doctest/doctest/issues/854 has now been fixed (at least until the next CMake minimum version bump), so switch back to using the latest upstream Doctest rather than our temporary fork