### PR TITLE
from_range:Fix incorrect RA inc() bounds check

### DIFF
--- a/include/flux/sequence/range.hpp
+++ b/include/flux/sequence/range.hpp
@@ -119,7 +119,7 @@ public:
             if (offset < 0) {
                 bounds_check(num::add(offset, distance(self, first(self), cur)) >= 0);
             } else if (offset > 0) {
-                bounds_check(offset < distance(self, cur, last(self)));
+                bounds_check(offset <= distance(self, cur, last(self)));
             }
 
             cur.iter += num::cast<std::ranges::range_difference_t<V>>(offset);

--- a/test/test_from_range.cpp
+++ b/test/test_from_range.cpp
@@ -49,11 +49,26 @@ constexpr bool test_from_range()
 }
 static_assert(test_from_range());
 
+// https://github.com/tcbrindle/flux/issues/244
+constexpr bool issue_244()
+{
+    std::string_view str("abcdefghijklmnopqrstuvwxyz");
+
+    auto chunks = flux::from_range(str).chunk(3);
+
+    std::string out;
+
+    flux::for_each(chunks, [&out](auto c) { flux::for_each(c, [&out](char n) { out += n; }); });
+
+    return out == str;
+}
+static_assert(issue_244());
 }
 
 TEST_CASE("from range")
 {
     REQUIRE(test_from_range());
+    REQUIRE(issue_244());
 
     SUBCASE("bounds checking") {
         std::vector<int> vec{0, 1, 2, 3, 4};


### PR DESCRIPTION
It's okay for a random-access jump to take us to the last() position, so the bounds check should be `<=` rather than `<`

Fixes #244